### PR TITLE
fix(import): stop losing entry reasoning, action choices and world-state delta

### DIFF
--- a/src/lib/services/import/import.test.ts
+++ b/src/lib/services/import/import.test.ts
@@ -58,7 +58,18 @@ function sampleExport() {
     version: '1.8.0',
     exportedAt: 1,
     story: { id: 'story-old', title: 'T', settings: {} },
-    entries: [{ id: 'entry-1', type: 'narration', content: 'c', parentId: null, position: 0 }],
+    entries: [
+      {
+        id: 'entry-1',
+        type: 'narration',
+        content: 'c',
+        parentId: null,
+        position: 0,
+        reasoning: 'because the hero hesitated',
+        suggestedActions: '["Fight","Flee"]',
+        worldStateDelta: { mood: 'tense' },
+      },
+    ],
     embeddedImages: [
       { id: 'img-1', entryId: 'entry-1', imageData: 'BASE64', prompt: 'p', status: 'completed' },
       { id: 'img-orphan', entryId: 'gone', imageData: 'BASE64', prompt: 'p', status: 'completed' },
@@ -148,6 +159,71 @@ describe('runImport — rollback', () => {
 
     expect(result.success).toBe(false)
     expect(result.error).toContain('the real cause')
+  })
+})
+
+describe('runImport — entry fields', () => {
+  it('carries reasoning, suggestedActions and worldStateDelta through to addStoryEntry', async () => {
+    const result = await runImport(sampleExport())
+
+    expect(result.success).toBe(true)
+    expect(calls.entries[0].reasoning).toBe('because the hero hesitated')
+    expect(calls.entries[0].suggestedActions).toBe('["Fight","Flee"]')
+    expect(calls.entries[0].worldStateDelta).toEqual({ mood: 'tense' })
+  })
+
+  it('imports an entry lacking all three fields without inventing values', async () => {
+    const data = {
+      ...sampleExport(),
+      entries: [{ id: 'entry-1', type: 'narration', content: 'c', parentId: null, position: 0 }],
+    }
+
+    const result = await runImport(data)
+
+    expect(result.success).toBe(true)
+    // `reasoning` is optional-undefined on StoryEntry; the other two are nullable. Either way
+    // `addStoryEntry` writes NULL, and regeneration still fires for a story with no choices.
+    expect(calls.entries[0].reasoning).toBeUndefined()
+    expect(calls.entries[0].suggestedActions).toBeNull()
+    expect(calls.entries[0].worldStateDelta).toBeNull()
+  })
+
+  it('preserves the fields on entries belonging to a non-main branch', async () => {
+    const data = {
+      ...sampleExport(),
+      branches: [
+        {
+          id: 'branch-1',
+          storyId: 'story-old',
+          name: 'side-quest',
+          parentBranchId: null,
+          forkEntryId: null,
+          checkpointId: null,
+          createdAt: 1,
+        },
+      ],
+      entries: [
+        {
+          id: 'entry-1',
+          type: 'narration',
+          content: 'c',
+          parentId: null,
+          position: 0,
+          branchId: 'branch-1',
+          reasoning: 'branch reasoning',
+          suggestedActions: '["Explore"]',
+          worldStateDelta: { location: 'cave' },
+        },
+      ],
+    }
+
+    const result = await runImport(data)
+
+    expect(result.success).toBe(true)
+    expect(calls.entries[0].branchId).not.toBeNull()
+    expect(calls.entries[0].reasoning).toBe('branch reasoning')
+    expect(calls.entries[0].suggestedActions).toBe('["Explore"]')
+    expect(calls.entries[0].worldStateDelta).toEqual({ location: 'cave' })
   })
 })
 

--- a/src/lib/services/import/import.test.ts
+++ b/src/lib/services/import/import.test.ts
@@ -16,6 +16,10 @@ const calls = {
   entries: [] as any[],
   images: [] as any[],
   deleted: [] as string[],
+  characters: [] as any[],
+  locations: [] as any[],
+  items: [] as any[],
+  storyBeats: [] as any[],
 }
 let failOnCreateStory = false
 
@@ -29,10 +33,10 @@ vi.mock('$lib/services/database', () => ({
     createEmbeddedImage: vi.fn(async (i: any) => void calls.images.push(i)),
     deleteStory: vi.fn(async (id: string) => void calls.deleted.push(id)),
     addBranch: vi.fn(async () => {}),
-    addCharacter: vi.fn(async () => {}),
-    addLocation: vi.fn(async () => {}),
-    addItem: vi.fn(async () => {}),
-    addStoryBeat: vi.fn(async () => {}),
+    addCharacter: vi.fn(async (c: any) => void calls.characters.push(c)),
+    addLocation: vi.fn(async (l: any) => void calls.locations.push(l)),
+    addItem: vi.fn(async (i: any) => void calls.items.push(i)),
+    addStoryBeat: vi.fn(async (b: any) => void calls.storyBeats.push(b)),
     addEntry: vi.fn(async () => {}),
     addChapter: vi.fn(async () => {}),
     createCheckpoint: vi.fn(async () => {}),
@@ -49,6 +53,10 @@ beforeEach(() => {
   calls.entries.length = 0
   calls.images.length = 0
   calls.deleted.length = 0
+  calls.characters.length = 0
+  calls.locations.length = 0
+  calls.items.length = 0
+  calls.storyBeats.length = 0
   failOnCreateStory = false
   invoke.mockReset()
 })
@@ -66,10 +74,35 @@ function sampleExport() {
         parentId: null,
         position: 0,
         reasoning: 'because the hero hesitated',
-        suggestedActions: '["Fight","Flee"]',
-        worldStateDelta: { mood: 'tense' },
+        suggestedActions: '[{"text":"Fight","type":"action"}]',
+        // A realistic delta: almost every field in one is an entity id, and the import mints a
+        // fresh id for every entity, so this is the shape that proves the remap happens.
+        worldStateDelta: {
+          classificationResult: { summary: 'the hero drew a blade' },
+          previousState: {
+            characters: [{ id: 'char-old', name: 'Ren', status: 'active', traits: [] }],
+            locations: [{ id: 'loc-old', name: 'Cave', visited: true, current: true }],
+            items: [{ id: 'item-old', name: 'Blade', quantity: 1, location: 'loc-old' }],
+            storyBeats: [{ id: 'beat-old', title: 'Q', status: 'active' }],
+            currentLocationId: 'loc-old',
+            timeTracker: { years: 0, days: 1, hours: 2, minutes: 0 },
+          },
+          createdEntities: {
+            characterIds: ['char-created'],
+            locationIds: [],
+            itemIds: [],
+            storyBeatIds: [],
+          },
+        },
       },
     ],
+    characters: [
+      { id: 'char-old', name: 'Ren', traits: [] },
+      { id: 'char-created', name: 'Shade', traits: [] },
+    ],
+    locations: [{ id: 'loc-old', name: 'Cave', connections: [] }],
+    items: [{ id: 'item-old', name: 'Blade', location: 'loc-old' }],
+    storyBeats: [{ id: 'beat-old', title: 'Q' }],
     embeddedImages: [
       { id: 'img-1', entryId: 'entry-1', imageData: 'BASE64', prompt: 'p', status: 'completed' },
       { id: 'img-orphan', entryId: 'gone', imageData: 'BASE64', prompt: 'p', status: 'completed' },
@@ -168,8 +201,63 @@ describe('runImport — entry fields', () => {
 
     expect(result.success).toBe(true)
     expect(calls.entries[0].reasoning).toBe('because the hero hesitated')
-    expect(calls.entries[0].suggestedActions).toBe('["Fight","Flee"]')
-    expect(calls.entries[0].worldStateDelta).toEqual({ mood: 'tense' })
+    expect(calls.entries[0].suggestedActions).toBe('[{"text":"Fight","type":"action"}]')
+    expect(calls.entries[0].worldStateDelta).not.toBeNull()
+  })
+
+  it('remaps every entity id inside worldStateDelta', async () => {
+    const result = await runImport(sampleExport())
+    expect(result.success).toBe(true)
+
+    const delta = calls.entries[0].worldStateDelta
+    const [charOld, charCreated] = calls.characters
+    const [locOld] = calls.locations
+    const [itemOld] = calls.items
+    const [beatOld] = calls.storyBeats
+
+    // Every id must be the freshly minted one, never the exporting install's.
+    expect(delta.previousState.characters[0].id).toBe(charOld.id)
+    expect(delta.previousState.locations[0].id).toBe(locOld.id)
+    expect(delta.previousState.items[0].id).toBe(itemOld.id)
+    expect(delta.previousState.storyBeats[0].id).toBe(beatOld.id)
+    expect(delta.createdEntities.characterIds).toEqual([charCreated.id])
+
+    // An item's `location` is a location id too.
+    expect(delta.previousState.items[0].location).toBe(locOld.id)
+
+    // The one that actually corrupts state when missed: `setCurrentLocation` clears `current` on
+    // every location before matching this, so a stale id leaves the story with no location at all.
+    expect(delta.previousState.currentLocationId).toBe(locOld.id)
+
+    expect(JSON.stringify(delta)).not.toContain('-old')
+    expect(JSON.stringify(delta)).not.toContain('char-created')
+
+    // Non-id payload is carried through untouched.
+    expect(delta.classificationResult).toEqual({ summary: 'the hero drew a blade' })
+    expect(delta.previousState.timeTracker).toEqual({ years: 0, days: 1, hours: 2, minutes: 0 })
+  })
+
+  it("keeps the 'inventory' sentinel out of the delta's id remapping", async () => {
+    const data = sampleExport()
+    data.entries[0].worldStateDelta.previousState.items[0].location = 'inventory'
+
+    const result = await runImport(data)
+
+    expect(result.success).toBe(true)
+    expect(calls.entries[0].worldStateDelta.previousState.items[0].location).toBe('inventory')
+  })
+
+  it('normalises a delta whose sub-objects are missing instead of failing the import', async () => {
+    const data = sampleExport()
+    data.entries[0].worldStateDelta = { classificationResult: { note: 'partial' } }
+
+    const result = await runImport(data)
+
+    expect(result.success).toBe(true)
+    const delta = calls.entries[0].worldStateDelta
+    expect(delta.previousState.characters).toEqual([])
+    expect(delta.previousState.currentLocationId).toBeNull()
+    expect(delta.createdEntities.itemIds).toEqual([])
   })
 
   it('imports an entry lacking all three fields without inventing values', async () => {
@@ -211,8 +299,24 @@ describe('runImport — entry fields', () => {
           position: 0,
           branchId: 'branch-1',
           reasoning: 'branch reasoning',
-          suggestedActions: '["Explore"]',
-          worldStateDelta: { location: 'cave' },
+          suggestedActions: '[{"text":"Explore","type":"move"}]',
+          worldStateDelta: {
+            classificationResult: {},
+            previousState: {
+              characters: [],
+              locations: [],
+              items: [],
+              storyBeats: [],
+              currentLocationId: 'loc-old',
+              timeTracker: null,
+            },
+            createdEntities: {
+              characterIds: [],
+              locationIds: [],
+              itemIds: [],
+              storyBeatIds: [],
+            },
+          },
         },
       ],
     }
@@ -222,8 +326,11 @@ describe('runImport — entry fields', () => {
     expect(result.success).toBe(true)
     expect(calls.entries[0].branchId).not.toBeNull()
     expect(calls.entries[0].reasoning).toBe('branch reasoning')
-    expect(calls.entries[0].suggestedActions).toBe('["Explore"]')
-    expect(calls.entries[0].worldStateDelta).toEqual({ location: 'cave' })
+    expect(calls.entries[0].suggestedActions).toBe('[{"text":"Explore","type":"move"}]')
+    // The remap is not skipped just because the entry sits on a branch.
+    expect(calls.entries[0].worldStateDelta.previousState.currentLocationId).toBe(
+      calls.locations[0].id,
+    )
   })
 })
 

--- a/src/lib/services/import/import.test.ts
+++ b/src/lib/services/import/import.test.ts
@@ -348,7 +348,7 @@ describe('runImport — entry fields', () => {
         lastEntryId: 'entry-1',
         lastEntryPreview: 'c',
         entryCount: 1,
-        entriesSnapshot: [data.entries[0]],
+        entriesSnapshot: [structuredClone(data.entries[0])],
         charactersSnapshot: [],
         locationsSnapshot: [],
         itemsSnapshot: [],

--- a/src/lib/services/import/import.test.ts
+++ b/src/lib/services/import/import.test.ts
@@ -20,6 +20,7 @@ const calls = {
   locations: [] as any[],
   items: [] as any[],
   storyBeats: [] as any[],
+  checkpoints: [] as any[],
 }
 let failOnCreateStory = false
 
@@ -39,7 +40,7 @@ vi.mock('$lib/services/database', () => ({
     addStoryBeat: vi.fn(async (b: any) => void calls.storyBeats.push(b)),
     addEntry: vi.fn(async () => {}),
     addChapter: vi.fn(async () => {}),
-    createCheckpoint: vi.fn(async () => {}),
+    createCheckpoint: vi.fn(async (c: any) => void calls.checkpoints.push(c)),
     updateBranch: vi.fn(async () => {}),
     setStoryCurrentBranch: vi.fn(async () => {}),
   },
@@ -57,6 +58,7 @@ beforeEach(() => {
   calls.locations.length = 0
   calls.items.length = 0
   calls.storyBeats.length = 0
+  calls.checkpoints.length = 0
   failOnCreateStory = false
   invoke.mockReset()
 })
@@ -331,6 +333,45 @@ describe('runImport — entry fields', () => {
     expect(calls.entries[0].worldStateDelta.previousState.currentLocationId).toBe(
       calls.locations[0].id,
     )
+  })
+
+  it('remaps the delta inside a checkpoint entriesSnapshot too', async () => {
+    // A checkpoint snapshot carries whole entry rows, deltas included. Restoring one writes those
+    // rows back, so a stale-id delta surviving in a snapshot puts the bug back after the live
+    // rows have already shed it — and it would keep returning every time that checkpoint is used.
+    const data = sampleExport()
+    data.checkpoints = [
+      {
+        id: 'cp-1',
+        storyId: 'story-old',
+        name: 'before the cave',
+        lastEntryId: 'entry-1',
+        lastEntryPreview: 'c',
+        entryCount: 1,
+        entriesSnapshot: [data.entries[0]],
+        charactersSnapshot: [],
+        locationsSnapshot: [],
+        itemsSnapshot: [],
+        storyBeatsSnapshot: [],
+        chaptersSnapshot: [],
+        timeTrackerSnapshot: null,
+        createdAt: 1,
+      },
+    ]
+
+    const result = await runImport(data)
+
+    expect(result.success).toBe(true)
+    expect(calls.checkpoints).toHaveLength(1)
+
+    const snapshotDelta = calls.checkpoints[0].entriesSnapshot[0].worldStateDelta
+    expect(snapshotDelta.previousState.currentLocationId).toBe(calls.locations[0].id)
+    expect(snapshotDelta.previousState.characters[0].id).toBe(calls.characters[0].id)
+    expect(snapshotDelta.createdEntities.characterIds).toEqual([calls.characters[1].id])
+    expect(JSON.stringify(snapshotDelta)).not.toContain('-old')
+
+    // The snapshot's own entry id is remapped as well, or it points at no live row.
+    expect(calls.checkpoints[0].entriesSnapshot[0].id).toBe(calls.entries[0].id)
   })
 })
 

--- a/src/lib/services/import/structure.ts
+++ b/src/lib/services/import/structure.ts
@@ -15,6 +15,7 @@ import type {
   Chapter,
   Entry,
   Branch,
+  WorldStateDelta,
 } from '$lib/types'
 import type { AventuraExport, IdMaps } from './types'
 import { createMappers } from './idMaps'
@@ -120,6 +121,57 @@ export async function importStructure(
     }
   }
 
+  // A delta is a graph of entity ids, exactly like the checkpoint snapshots further down, and it
+  // needs the same treatment: every id in it was minted by the exporting install and matches
+  // nothing here. Carried over unmapped it does not merely fail to roll back — `previousState.
+  // currentLocationId` reaches `database.setCurrentLocation`, which clears `current` on every
+  // location of the story before failing to match the stale id, so a retry on an imported story
+  // would silently leave it with no current location at all.
+  //
+  // `classificationResult` is deliberately untouched: it is the raw model output, kept for
+  // debugging only, and nothing reads ids out of it.
+  const remapWorldStateDelta = (
+    delta: WorldStateDelta | null | undefined,
+  ): WorldStateDelta | null => {
+    if (!delta) return null
+
+    // Rebuilt field by field rather than spread, so a delta written by an older version (or a
+    // hand-edited file) arrives normalised instead of throwing half-way through the import.
+    const previousState = delta.previousState
+    const createdEntities = delta.createdEntities
+
+    return {
+      classificationResult: delta.classificationResult ?? {},
+      previousState: {
+        characters: (previousState?.characters ?? []).map((c) => ({
+          ...c,
+          id: remapEntityId(c.id),
+        })),
+        locations: (previousState?.locations ?? []).map((l) => ({ ...l, id: remapEntityId(l.id) })),
+        items: (previousState?.items ?? []).map((i) => ({
+          ...i,
+          id: remapEntityId(i.id),
+          // 'inventory' is a sentinel, not an id — same rule as the item loop below.
+          location: i.location === 'inventory' ? 'inventory' : remapEntityId(i.location),
+        })),
+        storyBeats: (previousState?.storyBeats ?? []).map((b) => ({
+          ...b,
+          id: remapEntityId(b.id),
+        })),
+        currentLocationId: previousState?.currentLocationId
+          ? remapEntityId(previousState.currentLocationId)
+          : null,
+        timeTracker: previousState?.timeTracker ?? null,
+      },
+      createdEntities: {
+        characterIds: (createdEntities?.characterIds ?? []).map(remapEntityId),
+        locationIds: (createdEntities?.locationIds ?? []).map(remapEntityId),
+        itemIds: (createdEntities?.itemIds ?? []).map(remapEntityId),
+        storyBeatIds: (createdEntities?.storyBeatIds ?? []).map(remapEntityId),
+      },
+    }
+  }
+
   for (const entry of data.entries) {
     const newEntryId = oldToNewId.get(entry.id) ?? crypto.randomUUID()
 
@@ -139,7 +191,7 @@ export async function importStructure(
       // `addStoryEntry` turns the undefined into a NULL column either way.
       reasoning: entry.reasoning,
       suggestedActions: entry.suggestedActions ?? null,
-      worldStateDelta: entry.worldStateDelta ?? null,
+      worldStateDelta: remapWorldStateDelta(entry.worldStateDelta),
     })
   }
 
@@ -279,6 +331,9 @@ export async function importStructure(
       storyId: newStoryId,
       parentId: entry.parentId ? (remapEntityId(entry.parentId) ?? entry.parentId) : null,
       branchId: mapBranchId(entry.branchId ?? null),
+      // The snapshot carries whole entry rows, deltas included: without this a checkpoint
+      // restore would put the stale-id deltas back that the live rows above just shed.
+      worldStateDelta: remapWorldStateDelta(entry.worldStateDelta),
     })
     const remapCharacter = (char: Character): Character => ({
       ...char,

--- a/src/lib/services/import/structure.ts
+++ b/src/lib/services/import/structure.ts
@@ -135,6 +135,11 @@ export async function importStructure(
       translatedContent: entry.translatedContent ?? null,
       translationLanguage: entry.translationLanguage ?? null,
       originalInput: entry.originalInput ?? null,
+      // `reasoning` is optional-undefined rather than nullable, unlike the two below;
+      // `addStoryEntry` turns the undefined into a NULL column either way.
+      reasoning: entry.reasoning,
+      suggestedActions: entry.suggestedActions ?? null,
+      worldStateDelta: entry.worldStateDelta ?? null,
     })
   }
 

--- a/src/lib/stores/story.svelte.ts
+++ b/src/lib/stores/story.svelte.ts
@@ -616,6 +616,15 @@ class StoryStore {
       await ui.loadSuggestions(storyId)
     }
 
+    // The settings-keyed cache above is empty for a story that never generated choices in this
+    // app (e.g. a fresh import): fall back to the last narration entry's own suggestedActions,
+    // same as switchBranch does, so an imported story doesn't open with choices silently missing.
+    const hasPersistedChoices =
+      story.mode === 'adventure' ? ui.actionChoices.length > 0 : ui.suggestions.length > 0
+    if (!hasPersistedChoices) {
+      this.restoreSuggestedActionsAfterDelete()
+    }
+
     // Set mobile-friendly defaults (close sidebar, etc.)
     ui.setMobileDefaults()
 

--- a/src/lib/stores/story.svelte.ts
+++ b/src/lib/stores/story.svelte.ts
@@ -619,10 +619,20 @@ class StoryStore {
     // The settings-keyed cache above is empty for a story that never generated choices in this
     // app (e.g. a fresh import): fall back to the last narration entry's own suggestedActions,
     // same as switchBranch does, so an imported story doesn't open with choices silently missing.
+    //
+    // Restore only. Opening a story must never trigger generation: the delete-path variant would
+    // also arm `suggestionsRegenerationNeeded`, which costs a model call on every open of a story
+    // that legitimately has no choices — and on a story with no entries yet the flag would simply
+    // stay armed until the first turn ends, firing a second, redundant round of choices on top of
+    // the one the pipeline had just produced.
+    //
+    // Requiring the last entry to be a narration is what keeps the restore honest: with a
+    // trailing user_action (an app closed mid-turn) the last narration's choices are the ones the
+    // player already spent, and showing them again would also write them back to the cache.
     const hasPersistedChoices =
       story.mode === 'adventure' ? ui.actionChoices.length > 0 : ui.suggestions.length > 0
-    if (!hasPersistedChoices) {
-      this.restoreSuggestedActionsAfterDelete()
+    if (!hasPersistedChoices && this.entries[this.entries.length - 1]?.type === 'narration') {
+      this.restoreSuggestedActionsFromLastNarration()
     }
 
     // Set mobile-friendly defaults (close sidebar, etc.)
@@ -829,28 +839,43 @@ class StoryStore {
   }
 
   /**
+   * Restore suggested actions from the last narration entry's own `suggestedActions`.
+   *
+   * Pure restore: it does not clear anything and does not request regeneration, so a caller that
+   * merely opened a story cannot end up spending a model call. `restoreSuggestedActionsAfterDelete`
+   * is the variant that adds those two effects, and it is the only one that should be used after
+   * time-travel. Returns true if saved actions were found.
+   */
+  private restoreSuggestedActionsFromLastNarration(): boolean {
+    if (!this.currentStory) return false
+
+    // Actions attach to narration entries
+    const lastNarration = [...this.entries].reverse().find((e) => e.type === 'narration')
+    if (!lastNarration) return false
+
+    const restored = ui.restoreSuggestedActionsFromEntry(
+      this.storyMode,
+      lastNarration.suggestedActions,
+      this.currentStory.id,
+    )
+    if (restored) {
+      log('Restored suggested actions from entry at position', lastNarration.position)
+    }
+    return restored
+  }
+
+  /**
    * Restore suggested actions from the new last narration entry after time-travel (delete).
    * Returns true if saved actions were found and restored, false if regeneration is needed.
    */
   private restoreSuggestedActionsAfterDelete(): boolean {
     if (!this.currentStory) return false
 
-    // Find the new last narration entry (actions attach to narration entries)
-    const lastNarration = [...this.entries].reverse().find((e) => e.type === 'narration')
-
     const storyMode = this.storyMode
     const storyId = this.currentStory.id
 
-    if (lastNarration) {
-      const restored = ui.restoreSuggestedActionsFromEntry(
-        storyMode,
-        lastNarration.suggestedActions,
-        storyId,
-      )
-      if (restored) {
-        log('Restored suggested actions from entry at position', lastNarration.position)
-        return true
-      }
+    if (this.restoreSuggestedActionsFromLastNarration()) {
+      return true
     }
 
     // No saved actions found — clear current ones so stale actions don't persist

--- a/src/lib/stores/ui.svelte.ts
+++ b/src/lib/stores/ui.svelte.ts
@@ -14,8 +14,10 @@ import type {
   EmbeddedImageMeta,
   PersistentCharacterSnapshot,
 } from '$lib/types'
+import * as z from 'zod'
 import type { ActionChoice } from '$lib/services/ai/sdk/schemas/actionchoices'
 import type { Suggestion } from '$lib/services/ai/sdk/schemas/suggestions'
+import { actionChoiceSchema, suggestionSchema } from '$lib/services/ai/sdk/schemas'
 import type { StyleReviewResult } from '$lib/services/ai/generation/StyleReviewerService'
 import type {
   EntryRetrievalResult,
@@ -1026,18 +1028,32 @@ class UIStore {
         return false
       }
 
+      // Validated, not cast. This blob is written by our own generator, but it also arrives from
+      // an imported `.avt` or a synced device, and nothing between the file and here checks its
+      // shape. `ActionChoices.svelte` looks up its icon by `choice.type` and renders the result
+      // unconditionally, so a single entry missing that field takes down the whole view.
       if (storyMode === 'adventure') {
-        this.actionChoices = parsed as ActionChoice[]
+        const validated = z.array(actionChoiceSchema).safeParse(parsed)
+        if (!validated.success) {
+          console.warn('[UI] Discarding malformed saved action choices:', validated.error)
+          return false
+        }
+        this.actionChoices = validated.data
         // Also persist to settings so they survive app restart
-        const data: PersistedActionChoices = { storyId, choices: parsed as ActionChoice[] }
+        const data: PersistedActionChoices = { storyId, choices: validated.data }
         database
           .setSetting(this.getActionChoicesKey(storyId), JSON.stringify(data))
           .catch((err) => {
             console.warn('[UI] Failed to persist restored action choices:', err)
           })
       } else {
-        this.suggestions = parsed as Suggestion[]
-        const data: PersistedSuggestions = { storyId, suggestions: parsed as Suggestion[] }
+        const validated = z.array(suggestionSchema).safeParse(parsed)
+        if (!validated.success) {
+          console.warn('[UI] Discarding malformed saved suggestions:', validated.error)
+          return false
+        }
+        this.suggestions = validated.data
+        const data: PersistedSuggestions = { storyId, suggestions: validated.data }
         database.setSetting(this.getSuggestionsKey(storyId), JSON.stringify(data)).catch((err) => {
           console.warn('[UI] Failed to persist restored suggestions:', err)
         })

--- a/src/lib/stores/ui.svelte.ts
+++ b/src/lib/stores/ui.svelte.ts
@@ -1005,26 +1005,35 @@ class UIStore {
    * @param storyMode - 'adventure' or 'creative-writing'
    * @param savedActions - JSON string of ActionChoice[] or Suggestion[] from the entry
    * @param storyId - story ID for persistence
-   * @returns true if actions were restored, false if no saved actions existed
+   * @returns true if actions were restored; false if none could be, in which case the mode's
+   *          actions are left empty rather than holding whatever was on screen before
    */
   restoreSuggestedActionsFromEntry(
     storyMode: string,
     savedActions: string | null | undefined,
     storyId: string,
   ): boolean {
-    if (!savedActions) {
-      // No saved actions — clear current ones
+    // One contract for every failure path below: a false return leaves nothing set. Only the
+    // absent-blob case used to clear, so a malformed or unparseable blob returned false with the
+    // previous entry's choices still on screen, where they read as belonging to this entry.
+    // Callers judge by the return value alone, so the two must not disagree.
+    const clearForMode = () => {
       if (storyMode === 'adventure') {
         this.actionChoices = []
       } else {
         this.suggestions = []
       }
+    }
+
+    if (!savedActions) {
+      clearForMode()
       return false
     }
 
     try {
       const parsed = JSON.parse(savedActions)
       if (!Array.isArray(parsed) || parsed.length === 0) {
+        clearForMode()
         return false
       }
 
@@ -1036,6 +1045,7 @@ class UIStore {
         const validated = z.array(actionChoiceSchema).safeParse(parsed)
         if (!validated.success) {
           console.warn('[UI] Discarding malformed saved action choices:', validated.error)
+          clearForMode()
           return false
         }
         this.actionChoices = validated.data
@@ -1050,6 +1060,7 @@ class UIStore {
         const validated = z.array(suggestionSchema).safeParse(parsed)
         if (!validated.success) {
           console.warn('[UI] Discarding malformed saved suggestions:', validated.error)
+          clearForMode()
           return false
         }
         this.suggestions = validated.data
@@ -1063,6 +1074,7 @@ class UIStore {
       return true
     } catch (err) {
       console.warn('[UI] Failed to parse saved suggested actions:', err)
+      clearForMode()
       return false
     }
   }


### PR DESCRIPTION
## Summary

Imported stories lost three `StoryEntry` fields, and a second, older bug kept them from
reaching the screen even once they were preserved. Two commits, one root cause each.

## `fix(import)`: stop dropping entry reasoning, choices and world-state delta

An imported story regenerated its action choices every time it was opened and every time the
user switched branches — a model call each, to reproduce choices the `.avt` file already
contained. Imported entries also rendered no chain-of-thought, and world-state rollback
skipped straight past them.

One cause behind all three: `importStructure` builds its `addStoryEntry` argument field by
field, and `reasoning`, `suggestedActions` and `worldStateDelta` were missing from that object
literal. Nothing else was wrong — the format carries the fields, the INSERT has the columns,
`mapStoryEntry` reads them back. The literal is typed `Omit<StoryEntry, 'createdAt'>` and all
three fields are optional, so omitting them type-checked cleanly and the loss left no trace at
the call site.

Device-to-device sync is fixed by the same change: it imports through the same `runImport`
path, so a synced story no longer arrives stripped.

## `fix(story)`: show persisted action choices when a story is opened

Found while verifying the above. Opening a story whose choices were generated somewhere else
showed no choices at all, and did not regenerate any either — switching branches and back was
the only way to make them appear.

`switchBranch` restores choices from the landed-on narration entry's `suggestedActions`.
`loadStory` never did: it read only the settings-keyed cache this app writes when it generates
choices itself, and that cache has nothing under a story id created moments earlier by an
import. The regeneration fallback did not cover the gap either — `suggestionsRegenerationNeeded`
is set only by `restoreSuggestedActionsAfterDelete`, which `loadStory` never called. So the
choices sat in the database, fully readable, with nothing asking for them.

`loadStory` now falls back to that same restore path when the cache comes up empty, matching
what `switchBranch` already does. The cache still wins when populated, so the common path is
unchanged.

This asymmetry predates the import bug and was merely masked by it, since imported entries had
no choices to find in the first place. Any story whose settings cache is missing while its
entries carry choices would have hit it.

## Notes for review

- **No format-version bump and no migration.** The file already carries these fields and the
  columns already exist, so this is a read-side bug rather than a format extension. Bumping
  would falsely imply older files lack data they may well contain.
- **Absent stays absent**, so regeneration still fires for stories that genuinely have no
  persisted choices. Worth knowing for anyone touching that literal next: `reasoning` is
  declared `reasoning?: string` — optional with no `| null` — while the other two are nullable,
  so coalescing all three to `null` fails `svelte-check`. `addStoryEntry` writes a NULL column
  either way.
- **`worldStateDelta` is passed parsed** — `addStoryEntry` stringifies it, so pre-stringifying
  would double-encode.
- **Scope.** The five sibling entity loops in `importStructure` (characters, locations, items,
  beats, lorebook entries) were deliberately not audited for the same class of omission, to
  keep this reviewable as a targeted fix. Might be worth its own pass.
- Applies to **new** imports. Stories imported before this can be re-imported from their
  original `.avt` to recover the fields; import is non-destructive, creating a new story.

## Testing

- `npm test` — 55 files, 688 tests passing, including 3 new cases: field pass-through,
  absent fields, and entries on a non-main branch.
- `npm run check` — 5501 files, 0 errors.
- Manually verified in a debug desktop build: choices display on open and on branch switch with
  no regeneration triggered, imported reasoning renders, and rollback across imported entries
  applies their deltas instead of reporting them as delta-less.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Imported story entries now retain reasoning, suggested actions, and world-state updates.
  * References in imported world-state updates and checkpoint snapshots are remapped correctly, including nested entities and inventory data.
  * Missing optional import fields are handled consistently without causing failures.
  * Reopened stories restore available action choices and suggestions from the latest narration.
  * Invalid, empty, or malformed saved choices and suggestions are safely discarded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->