### PR TITLE
Prompt packs: stories carry their pack across export, import and sync

### DIFF
--- a/src/lib/components/layout/Header.svelte
+++ b/src/lib/components/layout/Header.svelte
@@ -87,6 +87,8 @@
         data.checkpoints,
         data.branches,
         data.chapters,
+        null, // currentBgImage: unchanged from before; the importer reads it off story instead
+        data.packBinding,
       )
     }, 'Aventuras (.avt)')
   }

--- a/src/lib/components/settings/ExperimentalSettings.svelte
+++ b/src/lib/components/settings/ExperimentalSettings.svelte
@@ -27,6 +27,7 @@
     Smartphone,
     Bell,
     Eye,
+    Package,
   } from '@lucide/svelte'
   import { Switch } from '$lib/components/ui/switch'
   import { Label } from '$lib/components/ui/label'
@@ -271,6 +272,10 @@
     await settings.updateExperimentalFeatures({ notificationPreview: checked })
   }
 
+  async function handleLegacyImportPackMappingToggle(checked: boolean) {
+    await settings.updateExperimentalFeatures({ legacyImportPackMapping: checked })
+  }
+
   async function handleResetAll() {
     await settings.resetExperimentalFeatures()
     stateTrackingChecked = settings.experimentalFeatures.stateTracking
@@ -467,6 +472,34 @@
       <span class="text-muted-foreground w-12 text-right font-mono text-sm">
         {settings.experimentalFeatures.autoSnapshotInterval}
       </span>
+    </div>
+  </div>
+
+  <Separator />
+
+  <!-- Pack mapping for older story files -->
+  <div class="space-y-5">
+    <div class="flex items-center gap-2">
+      <Package class="text-muted-foreground h-4 w-4" />
+      <Label class="text-sm font-medium">Story Import</Label>
+    </div>
+
+    <div class="flex flex-row items-center justify-between">
+      <div class="space-y-0.5">
+        <Label>Choose a prompt pack for older story files</Label>
+        <p class="text-muted-foreground text-xs">
+          Story files saved before Aventuras recorded prompt packs carry no pack of their own, and
+          import using the built-in one. Turn this on to be asked which of your packs such a file
+          should use. Files that do record a pack always ask, whatever this is set to.
+        </p>
+        <p class="text-muted-foreground pt-1 text-xs italic">
+          No effect if you only have one pack installed — there would be nothing to choose.
+        </p>
+      </div>
+      <Switch
+        checked={settings.experimentalFeatures.legacyImportPackMapping}
+        onCheckedChange={handleLegacyImportPackMappingToggle}
+      />
     </div>
   </div>
 

--- a/src/lib/components/settings/ExperimentalSettings.svelte
+++ b/src/lib/components/settings/ExperimentalSettings.svelte
@@ -490,7 +490,8 @@
         <p class="text-muted-foreground text-xs">
           Story files saved before Aventuras recorded prompt packs carry no pack of their own, and
           import using the built-in one. Turn this on to be asked which of your packs such a file
-          should use. Files that do record a pack always ask, whatever this is set to.
+          should use. Files that do record a pack bind to a matching installed pack, and ask only
+          when the match is uncertain or a required value is missing, whatever this is set to.
         </p>
         <p class="text-muted-foreground pt-1 text-xs italic">
           No effect if you only have one pack installed — there would be nothing to choose.

--- a/src/lib/components/settings/tabs/story-settings.svelte
+++ b/src/lib/components/settings/tabs/story-settings.svelte
@@ -124,11 +124,14 @@
 
   /** The story's bound pack, for display. `null` until loaded. */
   let boundPack = $state<PresetPack | null>(null)
+  let boundPackLoaded = $state(false)
 
   $effect(() => {
     const storyId = story.currentStory?.id
     if (!storyId) return
 
+    boundPack = null
+    boundPackLoaded = false
     let cancelled = false
     void (async () => {
       // Mirrors ContextBuilder.forStory: a NULL column means the built-in pack narrates.
@@ -136,6 +139,7 @@
       const pack = await database.getPack(packId)
       if (cancelled) return
       boundPack = pack
+      boundPackLoaded = true
     })()
 
     return () => {
@@ -159,7 +163,7 @@
     let cancelled = false
     const resolve = async () => {
       if (override) return templateUsesLengthInstruction(override)
-      const packId = (await database.getStoryPackId(storyId)) || 'default-pack'
+      const packId = (await database.getStoryPackId(storyId)) || DEFAULT_PACK_ID
       const template = await new ContextBuilder(packId).resolveTemplate(templateId)
       return templateUsesLengthInstruction(template?.content)
     }
@@ -308,6 +312,8 @@
         {#if isActive}
           <span>— overridden for this story by the custom prompt below.</span>
         {/if}
+      {:else if boundPackLoaded}
+        <span class="opacity-70">not found</span>
       {:else}
         <span class="opacity-70">loading…</span>
       {/if}

--- a/src/lib/components/settings/tabs/story-settings.svelte
+++ b/src/lib/components/settings/tabs/story-settings.svelte
@@ -10,6 +10,8 @@
   } from '$lib/services/prompts/templates'
   import { ContextBuilder } from '$lib/services/context'
   import { database } from '$lib/services/database'
+  import { DEFAULT_PACK_ID } from '$lib/services/packs/binding'
+  import type { PresetPack } from '$lib/services/packs/types'
   import WritingStyleFields from '$lib/components/shared/WritingStyleFields.svelte'
   import { Textarea } from '$lib/components/ui/textarea'
   import { Button } from '$lib/components/ui/button'
@@ -119,6 +121,27 @@
   // ── Derived flags ─────────────────────────────────────────────────────────────
 
   const isActive = $derived(!!savedCustomPrompt)
+
+  /** The story's bound pack, for display. `null` until loaded. */
+  let boundPack = $state<PresetPack | null>(null)
+
+  $effect(() => {
+    const storyId = story.currentStory?.id
+    if (!storyId) return
+
+    let cancelled = false
+    void (async () => {
+      // Mirrors ContextBuilder.forStory: a NULL column means the built-in pack narrates.
+      const packId = (await database.getStoryPackId(storyId)) || DEFAULT_PACK_ID
+      const pack = await database.getPack(packId)
+      if (cancelled) return
+      boundPack = pack
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  })
 
   /**
    * Response Length only does anything if the prompt that will actually run renders
@@ -270,6 +293,24 @@
     <p class="text-muted-foreground mb-3 text-xs">
       Replaces the default pack template for this story only. Supports Liquid template variables.
       Changes take effect on the next generation — no restart needed.
+    </p>
+
+    <!--
+      Which pack this story actually narrates through. Nothing else in the app shows it, and
+      "the default pack template" above is only true when the story is on the built-in pack —
+      for any other pack the sentence names something the reader cannot otherwise identify.
+    -->
+    <p class="text-muted-foreground mb-3 text-xs">
+      Prompt pack:
+      {#if boundPack}
+        <span class="text-foreground font-medium">{boundPack.name}</span>
+        {#if boundPack.author}<span>by {boundPack.author}</span>{/if}
+        {#if isActive}
+          <span>— overridden for this story by the custom prompt below.</span>
+        {/if}
+      {:else}
+        <span class="opacity-70">loading…</span>
+      {/if}
     </p>
 
     <Textarea

--- a/src/lib/components/story/LibraryView.svelte
+++ b/src/lib/components/story/LibraryView.svelte
@@ -7,12 +7,24 @@
   import { BookOpen, Upload, RefreshCw, Archive, Plus, MessageSquareShare } from '@lucide/svelte'
   import SetupWizard from '../wizard/SetupWizard.svelte'
   import STImportWizard from '../wizard/STImportWizard.svelte'
+  import PackMappingDialog from './PackMappingDialog.svelte'
+  import { settings } from '$lib/stores/settings.svelte'
+  import type { PresetPack } from '$lib/services/packs/types'
+  import { planPackBinding } from '$lib/services/import'
+  import type { PackBindingContext, PackBindingResolution } from '$lib/services/import'
 
   import { Button } from '$lib/components/ui/button'
   import EmptyState from '$lib/components/ui/empty-state/empty-state.svelte'
   import StoryCard from '$lib/components/story/StoryCard.svelte'
 
   let isImporting = $state(false)
+  /** Non-null only while the import is waiting on the user's pack choice. */
+  let packMapping = $state<{
+    context: PackBindingContext
+    lockedPack?: PresetPack | null
+    onlyVariables?: string[]
+    resolve: (resolution: PackBindingResolution | null) => void
+  } | null>(null)
   let showSetupWizard = $state(false)
   let setupWizardKey = $state(0)
   let showSTImportWizard = $state(false)
@@ -61,6 +73,34 @@
     }
   }
 
+  /**
+   * Which local pack the story being imported binds to.
+   *
+   * Called by the import pipeline once the file is parsed and before anything is written, so the
+   * dialog this may open costs nothing to dismiss.
+   */
+  async function resolvePackBinding(
+    context: PackBindingContext,
+  ): Promise<PackBindingResolution | null> {
+    const plan = await planPackBinding(
+      context,
+      settings.experimentalFeatures.legacyImportPackMapping,
+    )
+    if (!plan.ask) return plan.resolution
+
+    return new Promise((resolve) => {
+      packMapping = {
+        context,
+        lockedPack: plan.lockedPack,
+        onlyVariables: plan.onlyVariables,
+        resolve: (resolution) => {
+          packMapping = null
+          resolve(resolution)
+        },
+      }
+    })
+  }
+
   // Imports through the native picker, NOT an <input type="file">. Reading the file in JS means
   // materialising it as a string, and a .avt larger than V8's max string length (2^29-24 bytes,
   // ~512 MiB) cannot be one — a 546 MB export failed with a bogus "not valid JSON" error, because
@@ -69,7 +109,7 @@
     if (isImporting) return
     isImporting = true
     try {
-      const result = await exportService.importFromAventura()
+      const result = await exportService.importFromAventura({ resolvePackBinding })
 
       if (result.success && result.storyId) {
         await story.loadAllStories()
@@ -82,6 +122,9 @@
       ui.showToast(errMessage(error), 'error')
     } finally {
       isImporting = false
+      // A throw while the dialog is open would otherwise leave it on screen with nothing behind
+      // it to answer to.
+      packMapping = null
     }
   }
 </script>
@@ -185,4 +228,14 @@
   {#key stImportWizardKey}
     <STImportWizard onClose={() => (showSTImportWizard = false)} />
   {/key}
+{/if}
+
+<!-- Pack mapping step of an in-flight import -->
+{#if packMapping}
+  <PackMappingDialog
+    context={packMapping.context}
+    lockedPack={packMapping.lockedPack}
+    onlyVariables={packMapping.onlyVariables}
+    onResolve={packMapping.resolve}
+  />
 {/if}

--- a/src/lib/components/story/LibraryView.svelte
+++ b/src/lib/components/story/LibraryView.svelte
@@ -9,7 +9,7 @@
   import STImportWizard from '../wizard/STImportWizard.svelte'
   import PackMappingDialog from './PackMappingDialog.svelte'
   import { settings } from '$lib/stores/settings.svelte'
-  import type { PresetPack } from '$lib/services/packs/types'
+  import type { PresetPack } from '$lib/services/packs'
   import { planPackBinding } from '$lib/services/import'
   import type { PackBindingContext, PackBindingResolution } from '$lib/services/import'
 
@@ -122,9 +122,9 @@
       ui.showToast(errMessage(error), 'error')
     } finally {
       isImporting = false
-      // A throw while the dialog is open would otherwise leave it on screen with nothing behind
-      // it to answer to.
-      packMapping = null
+      // A throw while the dialog is open would otherwise leave it on screen, and leave
+      // resolvePackBinding suspended forever.
+      packMapping?.resolve(null)
     }
   }
 </script>

--- a/src/lib/components/story/PackMappingDialog.svelte
+++ b/src/lib/components/story/PackMappingDialog.svelte
@@ -1,0 +1,163 @@
+<!--
+  The pack step of a story import — an exception, not a routine. A confident match never gets
+  here; see `decidePackPrompt`. What reaches this component is a question worth asking: which
+  pack, because the match is uncertain or the named pack is absent, or one missing required
+  value on a pack that is otherwise settled.
+
+  It runs after the file is read and before the first row is written, so cancelling costs
+  nothing. `StepPackSelection` is reused unchanged — it is already presentational, and the state
+  it renders is owned here.
+-->
+<script lang="ts">
+  import * as Dialog from '$lib/components/ui/dialog'
+  import { Button } from '$lib/components/ui/button'
+  import StepPackSelection from '../wizard/steps/StepPackSelection.svelte'
+  import { database } from '$lib/services/database'
+  import { DEFAULT_PACK_ID } from '$lib/services/packs/binding'
+  import type { PresetPack, CustomVariable } from '$lib/services/packs/types'
+  import type { PackBindingContext, PackBindingResolution } from '$lib/services/import'
+
+  interface Props {
+    context: PackBindingContext
+    /**
+     * The pack is already settled and is not up for discussion — set when a confident match only
+     * needs a value the story does not carry. Suppresses the chooser by leaving it the sole
+     * option, which `StepPackSelection` already renders as no dropdown at all.
+     */
+    lockedPack?: PresetPack | null
+    /**
+     * Ask about these variables only. Set alongside `lockedPack`, so a story stopped for one
+     * missing answer is not made to re-review every value it already had.
+     */
+    onlyVariables?: string[]
+    /** Resolves once, with the user's choice or `null` if they backed out. */
+    onResolve: (resolution: PackBindingResolution | null) => void
+  }
+
+  let { context, lockedPack, onlyVariables, onResolve }: Props = $props()
+
+  let open = $state(true)
+  let availablePacks = $state<PresetPack[]>([])
+  let selectedPackId = $state(DEFAULT_PACK_ID)
+  let packVariables = $state<CustomVariable[]>([])
+  let variableValues = $state<Record<string, string>>({})
+  let loading = $state(true)
+
+  /** The file's own answers, kept so switching packs can re-apply them to matching names. */
+  const fileValues = $derived(context.binding?.customVariableValues ?? {})
+
+  /** Named a pack we found, but under a different author. Worth showing, not worth hiding behind. */
+  const authorMismatch = $derived(
+    context.match.confidence === 'name-only' ? context.match.pack : null,
+  )
+
+  $effect(() => {
+    void load()
+  })
+
+  async function load() {
+    availablePacks = lockedPack ? [lockedPack] : await database.getAllPacks()
+    // Pre-select the match when there is one; otherwise the built-in pack, which is where the
+    // story would have landed anyway.
+    selectedPackId = lockedPack?.id ?? context.match.pack?.id ?? DEFAULT_PACK_ID
+    await loadVariables(selectedPackId)
+    loading = false
+  }
+
+  /**
+   * Load the chosen pack's variables and seed each one.
+   *
+   * The story's own answer wins over the pack's default wherever the name matches — the value the
+   * author chose is more likely right than a default they never saw — and stays editable here.
+   */
+  async function loadVariables(packId: string) {
+    const all = await database.getPackVariables(packId)
+    packVariables = onlyVariables ? all.filter((v) => onlyVariables.includes(v.variableName)) : all
+    const seeded: Record<string, string> = {}
+    for (const variable of packVariables) {
+      seeded[variable.variableName] =
+        fileValues[variable.variableName] ?? variable.defaultValue ?? ''
+    }
+    variableValues = seeded
+  }
+
+  async function selectPack(packId: string) {
+    selectedPackId = packId
+    await loadVariables(packId)
+  }
+
+  function setVariable(variableName: string, value: string) {
+    variableValues = { ...variableValues, [variableName]: value }
+  }
+
+  function confirm() {
+    open = false
+    onResolve({
+      packId: selectedPackId,
+      // Keep every answer the file carried, not just the ones this pack defines: a value with no
+      // counterpart here is retained so re-binding to a pack that does define it brings it back.
+      customVariableValues: { ...fileValues, ...variableValues },
+    })
+  }
+
+  function cancel() {
+    open = false
+    onResolve(null)
+  }
+</script>
+
+<Dialog.Root {open} onOpenChange={(next) => !next && cancel()}>
+  <Dialog.Content class="sm:max-w-lg">
+    <Dialog.Header>
+      <Dialog.Title>
+        {lockedPack ? 'One more thing for this story' : 'Prompt Pack for this story'}
+      </Dialog.Title>
+      <Dialog.Description>
+        {#if lockedPack}
+          This story uses your "{lockedPack.name}" pack, which needs a value the story does not
+          carry.
+        {:else if context.binding && context.match.confidence === 'none'}
+          <!-- Leads with the absence: the useful response may well be to cancel and go install
+               the pack, which a neutral "choose one" would not suggest. -->
+          The prompt pack this story was written with — "{context.binding.pack.name}"{context
+            .binding.pack.author
+            ? ` by ${context.binding.pack.author}`
+            : ''} — is not installed on this device. Choose one of your packs to use instead, or cancel
+          and install that pack first.
+        {:else if context.binding}
+          This story was written with a pack called "{context.binding.pack.name}"{context.binding
+            .pack.author
+            ? ` by ${context.binding.pack.author}`
+            : ''}. Choose which of your packs it should use.
+        {:else}
+          This story file records no prompt pack. Choose which of your packs it should use.
+        {/if}
+      </Dialog.Description>
+    </Dialog.Header>
+
+    {#if authorMismatch}
+      <p class="rounded-md border border-amber-500/30 bg-amber-500/10 p-3 text-xs text-amber-500">
+        Your pack "{authorMismatch.name}" has the same name but a different author ({authorMismatch.author ??
+          'no author'}). It may not be the same pack.
+      </p>
+    {/if}
+
+    {#if !loading}
+      <div class="max-h-[60vh] overflow-y-auto py-2">
+        <StepPackSelection
+          {availablePacks}
+          {selectedPackId}
+          {packVariables}
+          {variableValues}
+          onSelectPack={selectPack}
+          onVariableChange={setVariable}
+        />
+      </div>
+    {/if}
+
+    <Dialog.Footer>
+      <Button variant="outline" onclick={cancel}>Cancel import</Button>
+      <Button onclick={confirm} disabled={loading}>Import story</Button>
+    </Dialog.Footer>
+  </Dialog.Content>
+</Dialog.Root>

--- a/src/lib/components/story/PackMappingDialog.svelte
+++ b/src/lib/components/story/PackMappingDialog.svelte
@@ -13,8 +13,8 @@
   import { Button } from '$lib/components/ui/button'
   import StepPackSelection from '../wizard/steps/StepPackSelection.svelte'
   import { database } from '$lib/services/database'
-  import { DEFAULT_PACK_ID } from '$lib/services/packs/binding'
-  import type { PresetPack, CustomVariable } from '$lib/services/packs/types'
+  import { DEFAULT_PACK_ID } from '$lib/services/packs'
+  import type { PresetPack, CustomVariable } from '$lib/services/packs'
   import { customVariableValue, mergeCustomVariableValues } from '$lib/services/import'
   import type { PackBindingContext, PackBindingResolution } from '$lib/services/import'
 
@@ -45,6 +45,7 @@
   let variableValues = $state<Record<string, string>>({})
   let editedValues = $state<Record<string, string>>({})
   let loading = $state(true)
+  let loadToken = 0
 
   /** The file's own answers, kept so switching packs can re-apply them to matching names. */
   const fileValues = $derived(context.binding?.customVariableValues ?? {})
@@ -74,7 +75,9 @@
    * author chose is more likely right than a default they never saw — and stays editable here.
    */
   async function loadVariables(packId: string) {
+    const token = ++loadToken
     const all = await database.getPackVariables(packId)
+    if (token !== loadToken) return
     targetPackVariables = all
     packVariables = onlyVariables ? all.filter((v) => onlyVariables.includes(v.variableName)) : all
     const seeded: Record<string, string> = {}

--- a/src/lib/components/story/PackMappingDialog.svelte
+++ b/src/lib/components/story/PackMappingDialog.svelte
@@ -15,6 +15,7 @@
   import { database } from '$lib/services/database'
   import { DEFAULT_PACK_ID } from '$lib/services/packs/binding'
   import type { PresetPack, CustomVariable } from '$lib/services/packs/types'
+  import { customVariableValue, mergeCustomVariableValues } from '$lib/services/import'
   import type { PackBindingContext, PackBindingResolution } from '$lib/services/import'
 
   interface Props {
@@ -39,8 +40,10 @@
   let open = $state(true)
   let availablePacks = $state<PresetPack[]>([])
   let selectedPackId = $state(DEFAULT_PACK_ID)
+  let targetPackVariables = $state<CustomVariable[]>([])
   let packVariables = $state<CustomVariable[]>([])
   let variableValues = $state<Record<string, string>>({})
+  let editedValues = $state<Record<string, string>>({})
   let loading = $state(true)
 
   /** The file's own answers, kept so switching packs can re-apply them to matching names. */
@@ -72,31 +75,39 @@
    */
   async function loadVariables(packId: string) {
     const all = await database.getPackVariables(packId)
+    targetPackVariables = all
     packVariables = onlyVariables ? all.filter((v) => onlyVariables.includes(v.variableName)) : all
     const seeded: Record<string, string> = {}
     for (const variable of packVariables) {
       seeded[variable.variableName] =
-        fileValues[variable.variableName] ?? variable.defaultValue ?? ''
+        customVariableValue(fileValues, variable.variableName) ?? variable.defaultValue ?? ''
     }
     variableValues = seeded
   }
 
   async function selectPack(packId: string) {
     selectedPackId = packId
+    editedValues = {}
     await loadVariables(packId)
   }
 
   function setVariable(variableName: string, value: string) {
     variableValues = { ...variableValues, [variableName]: value }
+    editedValues = { ...editedValues, [variableName]: value }
   }
 
   function confirm() {
+    const customVariableValues = mergeCustomVariableValues(
+      fileValues,
+      targetPackVariables,
+      editedValues,
+    )
     open = false
     onResolve({
       packId: selectedPackId,
       // Keep every answer the file carried, not just the ones this pack defines: a value with no
       // counterpart here is retained so re-binding to a pack that does define it brings it back.
-      customVariableValues: { ...fileValues, ...variableValues },
+      ...(Object.keys(customVariableValues).length > 0 ? { customVariableValues } : {}),
     })
   }
 

--- a/src/lib/components/sync/SyncModal.svelte
+++ b/src/lib/components/sync/SyncModal.svelte
@@ -92,6 +92,7 @@
   // State for receiving pushed stories (when in generate mode)
   let receivedStoryJson = $state<string | null>(null)
   let receivedStoryPreview = $state<SyncStoryPreview | null>(null)
+  let receivedStoryQueue = $state<string[]>([])
   let showReceivedConflict = $state(false)
   let pollingInterval: ReturnType<typeof setInterval> | null = null
   let receivingStory = false
@@ -133,6 +134,7 @@
     syncMessage = null
     receivedStoryJson = null
     receivedStoryPreview = null
+    receivedStoryQueue = []
     showReceivedConflict = false
     receivingStory = false
     remoteVersion = null
@@ -163,32 +165,44 @@
       const received = await syncService.getReceivedStories()
       if (received.length > 0) {
         if (receivedStoryJson || receivingStory) return
-        // Take the first received story
-        const storyJson = received[0]
-        const preview = syncService.getStoryPreview(storyJson)
-
-        if (preview) {
-          receivedStoryJson = storyJson
-          receivedStoryPreview = preview
-          // Claim this payload before awaiting any database work or a pack choice. Otherwise a
-          // later poll can replace the resolver while the first import is suspended.
-          stopPolling()
-          await syncService.clearReceivedStories()
-
-          // Check for conflict
-          const exists = await syncService.checkStoryExists(preview.title)
-          if (exists) {
-            showReceivedConflict = true
-          } else {
-            // No conflict, import directly
-            await importReceivedStory()
-          }
-        }
-
-        if (!preview) await syncService.clearReceivedStories()
+        // The native API clears its whole queue at once. Keep every payload after the claimed
+        // one locally, then process them in order after the active transfer finishes.
+        const [storyJson, ...queuedStories] = received
+        receivedStoryQueue = queuedStories
+        stopPolling()
+        await syncService.clearReceivedStories()
+        await claimReceivedStory(storyJson)
       }
     } catch {
       // Ignore polling errors
+    }
+  }
+
+  async function claimReceivedStory(storyJson: string) {
+    const preview = syncService.getStoryPreview(storyJson)
+    if (!preview) {
+      error = 'Received an invalid story payload'
+      resumeReceivedStories()
+      return
+    }
+
+    receivedStoryJson = storyJson
+    receivedStoryPreview = preview
+    const exists = await syncService.checkStoryExists(preview.title)
+    if (exists) {
+      showReceivedConflict = true
+    } else {
+      await importReceivedStory()
+    }
+  }
+
+  function resumeReceivedStories() {
+    const [next, ...remaining] = receivedStoryQueue
+    if (next) {
+      receivedStoryQueue = remaining
+      void claimReceivedStory(next)
+    } else {
+      startPolling()
     }
   }
 
@@ -241,6 +255,7 @@
       receivingStory = false
       receivedStoryJson = null
       receivedStoryPreview = null
+      resumeReceivedStories()
     }
   }
 
@@ -249,8 +264,7 @@
     receivingStory = false
     receivedStoryJson = null
     receivedStoryPreview = null
-    // Resume polling for more stories
-    startPolling()
+    resumeReceivedStories()
   }
 
   // Cleanup on destroy

--- a/src/lib/components/sync/SyncModal.svelte
+++ b/src/lib/components/sync/SyncModal.svelte
@@ -17,11 +17,62 @@
   import { Html5Qrcode } from 'html5-qrcode'
   import type { SyncServerInfo, SyncStoryPreview, SyncConnectionData } from '$lib/types/sync'
   import { onDestroy } from 'svelte'
+  import PackMappingDialog from '$lib/components/story/PackMappingDialog.svelte'
+  import { settings } from '$lib/stores/settings.svelte'
+  import { DEFAULT_PACK_ID } from '$lib/services/packs/binding'
+  import type { PresetPack } from '$lib/services/packs/types'
+  import { planPackBinding } from '$lib/services/import'
+  import type { PackBindingContext, PackBindingResolution } from '$lib/services/import'
   import * as ResponsiveModal from '$lib/components/ui/responsive-modal'
   import { Button } from '$lib/components/ui/button'
   import { Card, CardHeader, CardTitle, CardDescription } from '$lib/components/ui/card'
   import { ScrollArea } from '$lib/components/ui/scroll-area'
   import { Badge } from '$lib/components/ui/badge'
+
+  /** Non-null only while a transfer is waiting on the user's pack choice. */
+  let packMapping = $state<{
+    context: PackBindingContext
+    lockedPack?: PresetPack | null
+    onlyVariables?: string[]
+    resolve: (resolution: PackBindingResolution | null) => void
+  } | null>(null)
+
+  /**
+   * Settle which pack the incoming story binds to, before the transfer writes or deletes anything.
+   *
+   * This runs ahead of `createPreSyncBackup`/`deleteStory` on purpose. Both receive paths remove
+   * the story they are replacing *before* importing, so a question asked any later would let a
+   * cancel destroy the copy being replaced and put nothing in its place.
+   *
+   * Sync can ask at all because it is user-driven: the payload is already downloaded and no
+   * remote party is waiting. A background sync would need a different answer here.
+   *
+   * Returns the resolution, or `null` if the user backed out — in which case the caller must
+   * return without touching anything.
+   */
+  async function resolveIncomingPack(storyJson: string): Promise<PackBindingResolution | null> {
+    const context = await exportService.previewPackBinding(storyJson)
+    // Unparseable: let the import produce the real error rather than inventing one here.
+    if (!context) return { packId: DEFAULT_PACK_ID }
+
+    const plan = await planPackBinding(
+      context,
+      settings.experimentalFeatures.legacyImportPackMapping,
+    )
+    if (!plan.ask) return plan.resolution
+
+    return new Promise((resolve) => {
+      packMapping = {
+        context,
+        lockedPack: plan.lockedPack,
+        onlyVariables: plan.onlyVariables,
+        resolve: (value) => {
+          packMapping = null
+          resolve(value)
+        },
+      }
+    })
+  }
 
   // State
   let serverInfo = $state<SyncServerInfo | null>(null)
@@ -129,6 +180,13 @@
   async function importReceivedStory() {
     if (!receivedStoryJson || !receivedStoryPreview) return
 
+    // Pack first — and deliberately outside the block below, whose `finally` discards the
+    // received payload. The poller has already cleared the server's copy, so a cancel that fell
+    // through to it would lose the story outright; backing out must leave it pending so the user
+    // can go install the pack and click again.
+    const packBinding = await resolveIncomingPack(receivedStoryJson)
+    if (!packBinding) return
+
     loading = true
     error = null
     showReceivedConflict = false
@@ -141,7 +199,9 @@
         await syncService.deleteStory(existingId)
       }
 
-      const result = await exportService.importFromContent(receivedStoryJson, true)
+      const result = await exportService.importFromContent(receivedStoryJson, true, {
+        resolvePackBinding: async () => packBinding,
+      })
 
       if (result.success) {
         await story.loadAllStories()
@@ -358,6 +418,17 @@
     showConflictWarning = false
 
     try {
+      // Download first, then settle the pack, and only then delete what we are replacing. The
+      // pull used to sit between the delete and the import, which meant both a failed download
+      // and a cancelled pack choice left the user with neither copy.
+      const storyJson = await syncService.pullStory(connection, selectedRemoteStory.id)
+
+      const packBinding = await resolveIncomingPack(storyJson)
+      if (!packBinding) {
+        ui.setSyncMode('select')
+        return
+      }
+
       // If replacing, delete the existing story first
       const existingId = await syncService.findStoryIdByTitle(selectedRemoteStory.title)
       if (existingId) {
@@ -365,12 +436,11 @@
         await syncService.deleteStory(existingId)
       }
 
-      // Pull the story
-      const storyJson = await syncService.pullStory(connection, selectedRemoteStory.id)
-
       // Import using existing import service
       // Use skipImportedSuffix=true so synced stories keep their original title
-      const result = await exportService.importFromContent(storyJson, true)
+      const result = await exportService.importFromContent(storyJson, true, {
+        resolvePackBinding: async () => packBinding,
+      })
 
       if (result.success) {
         await story.loadAllStories()
@@ -738,3 +808,13 @@
     {/if}
   </ResponsiveModal.Content>
 </ResponsiveModal.Root>
+
+<!-- Pack step of an in-flight transfer. Opens before anything is written or deleted. -->
+{#if packMapping}
+  <PackMappingDialog
+    context={packMapping.context}
+    lockedPack={packMapping.lockedPack}
+    onlyVariables={packMapping.onlyVariables}
+    onResolve={packMapping.resolve}
+  />
+{/if}

--- a/src/lib/components/sync/SyncModal.svelte
+++ b/src/lib/components/sync/SyncModal.svelte
@@ -19,9 +19,8 @@
   import { onDestroy, untrack } from 'svelte'
   import PackMappingDialog from '$lib/components/story/PackMappingDialog.svelte'
   import { settings } from '$lib/stores/settings.svelte'
-  import { DEFAULT_PACK_ID } from '$lib/services/packs/binding'
-  import type { PresetPack } from '$lib/services/packs/types'
-  import { planPackBinding } from '$lib/services/import'
+  import type { PresetPack } from '$lib/services/packs'
+  import { planPackBinding, previewImport } from '$lib/services/import'
   import type { PackBindingContext, PackBindingResolution } from '$lib/services/import'
   import * as ResponsiveModal from '$lib/components/ui/responsive-modal'
   import { Button } from '$lib/components/ui/button'
@@ -50,10 +49,12 @@
    * Returns the resolution, or `null` if the user backed out — in which case the caller must
    * return without touching anything.
    */
-  async function resolveIncomingPack(storyJson: string): Promise<PackBindingResolution | null> {
-    const context = await exportService.previewPackBinding(storyJson)
-    // Unparseable: let the import produce the real error rather than inventing one here.
-    if (!context) return { packId: DEFAULT_PACK_ID }
+  async function resolveIncomingPack(
+    storyJson: string,
+  ): Promise<PackBindingResolution | null | { error: string }> {
+    const preview = await previewImport(storyJson)
+    if ('error' in preview) return preview
+    const { context } = preview
 
     const plan = await planPackBinding(
       context,
@@ -93,6 +94,7 @@
   let receivedStoryPreview = $state<SyncStoryPreview | null>(null)
   let showReceivedConflict = $state(false)
   let pollingInterval: ReturnType<typeof setInterval> | null = null
+  let receivingStory = false
 
   // State for version mismatch warning
   let remoteVersion = $state<string | null>(null)
@@ -132,6 +134,7 @@
     receivedStoryJson = null
     receivedStoryPreview = null
     showReceivedConflict = false
+    receivingStory = false
     remoteVersion = null
     localVersion = null
     showVersionWarning = false
@@ -159,6 +162,7 @@
     try {
       const received = await syncService.getReceivedStories()
       if (received.length > 0) {
+        if (receivedStoryJson || receivingStory) return
         // Take the first received story
         const storyJson = received[0]
         const preview = syncService.getStoryPreview(storyJson)
@@ -166,6 +170,10 @@
         if (preview) {
           receivedStoryJson = storyJson
           receivedStoryPreview = preview
+          // Claim this payload before awaiting any database work or a pack choice. Otherwise a
+          // later poll can replace the resolver while the first import is suspended.
+          stopPolling()
+          await syncService.clearReceivedStories()
 
           // Check for conflict
           const exists = await syncService.checkStoryExists(preview.title)
@@ -177,9 +185,7 @@
           }
         }
 
-        // Clear received stories from server
-        await syncService.clearReceivedStories()
-        stopPolling()
+        if (!preview) await syncService.clearReceivedStories()
       }
     } catch {
       // Ignore polling errors
@@ -187,14 +193,23 @@
   }
 
   async function importReceivedStory() {
-    if (!receivedStoryJson || !receivedStoryPreview) return
+    if (!receivedStoryJson || !receivedStoryPreview || receivingStory) return
+    receivingStory = true
 
     // Pack first — and deliberately outside the block below, whose `finally` discards the
     // received payload. The poller has already cleared the server's copy, so a cancel that fell
     // through to it would lose the story outright; backing out must leave it pending so the user
     // can go install the pack and click again.
     const packBinding = await resolveIncomingPack(receivedStoryJson)
-    if (!packBinding) return
+    if (packBinding && 'error' in packBinding) {
+      error = packBinding.error
+      receivingStory = false
+      return
+    }
+    if (!packBinding) {
+      receivingStory = false
+      return
+    }
 
     loading = true
     error = null
@@ -223,13 +238,15 @@
       error = e instanceof Error ? e.message : 'Import failed'
     } finally {
       loading = false
+      receivingStory = false
       receivedStoryJson = null
       receivedStoryPreview = null
     }
   }
 
-  function cancelReceivedImport() {
+  function discardReceivedStory() {
     showReceivedConflict = false
+    receivingStory = false
     receivedStoryJson = null
     receivedStoryPreview = null
     // Resume polling for more stories
@@ -435,6 +452,11 @@
       const storyJson = await syncService.pullStory(pullConnection, selectedRemoteStory.id)
 
       const packBinding = await resolveIncomingPack(storyJson)
+      if (packBinding && 'error' in packBinding) {
+        error = packBinding.error
+        if (ui.syncModalOpen && connection === pullConnection) ui.setSyncMode('connected')
+        return
+      }
       if (!packBinding) {
         // A user cancellation keeps the established connection usable. A lifecycle cancellation
         // from close/reset must not resurrect an old session over freshly reset state.
@@ -619,8 +641,18 @@
               it will create a "Pre-sync backup" checkpoint first. Continue?
             </p>
             <div class="flex gap-3">
-              <Button variant="outline" onclick={cancelReceivedImport}>Cancel</Button>
+              <Button variant="outline" onclick={discardReceivedStory}>Cancel</Button>
               <Button onclick={importReceivedStory}>Replace</Button>
+            </div>
+          </div>
+        {:else if receivedStoryPreview}
+          <div class="flex flex-col items-center py-4 text-center">
+            <p class="text-muted-foreground mb-4">
+              Received "{receivedStoryPreview.title}". Choose a prompt pack to continue.
+            </p>
+            <div class="flex gap-3">
+              <Button variant="outline" onclick={discardReceivedStory}>Discard</Button>
+              <Button onclick={importReceivedStory}>Continue import</Button>
             </div>
           </div>
         {:else if loading}

--- a/src/lib/components/sync/SyncModal.svelte
+++ b/src/lib/components/sync/SyncModal.svelte
@@ -16,7 +16,7 @@
   } from '@lucide/svelte'
   import { Html5Qrcode } from 'html5-qrcode'
   import type { SyncServerInfo, SyncStoryPreview, SyncConnectionData } from '$lib/types/sync'
-  import { onDestroy } from 'svelte'
+  import { onDestroy, untrack } from 'svelte'
   import PackMappingDialog from '$lib/components/story/PackMappingDialog.svelte'
   import { settings } from '$lib/stores/settings.svelte'
   import { DEFAULT_PACK_ID } from '$lib/services/packs/binding'
@@ -107,11 +107,16 @@
   // Reset state when modal opens
   $effect(() => {
     if (ui.syncModalOpen) {
-      resetState()
+      // resetState reads packMapping to cancel stale work. Do not make that read a dependency or
+      // opening a new pack dialog would retrigger this effect and immediately cancel itself.
+      untrack(resetState)
     }
   })
 
   function resetState() {
+    // Settle an older transfer before discarding the state it was waiting on. Merely removing the
+    // dialog would leave resolveIncomingPack suspended forever.
+    cancelPendingPackMapping()
     serverInfo = null
     connection = null
     remoteStories = []
@@ -132,6 +137,10 @@
     showVersionWarning = false
     pendingConnection = null
     stopPolling()
+  }
+
+  function cancelPendingPackMapping() {
+    packMapping?.resolve(null)
   }
 
   function stopPolling() {
@@ -229,6 +238,7 @@
 
   // Cleanup on destroy
   onDestroy(() => {
+    cancelPendingPackMapping()
     cleanup()
   })
 
@@ -403,6 +413,7 @@
 
   async function pullStory() {
     if (!connection || !selectedRemoteStory) return
+    const pullConnection = connection
 
     // Check for conflict
     const exists = await syncService.checkStoryExists(selectedRemoteStory.title)
@@ -421,11 +432,13 @@
       // Download first, then settle the pack, and only then delete what we are replacing. The
       // pull used to sit between the delete and the import, which meant both a failed download
       // and a cancelled pack choice left the user with neither copy.
-      const storyJson = await syncService.pullStory(connection, selectedRemoteStory.id)
+      const storyJson = await syncService.pullStory(pullConnection, selectedRemoteStory.id)
 
       const packBinding = await resolveIncomingPack(storyJson)
       if (!packBinding) {
-        ui.setSyncMode('select')
+        // A user cancellation keeps the established connection usable. A lifecycle cancellation
+        // from close/reset must not resurrect an old session over freshly reset state.
+        if (ui.syncModalOpen && connection === pullConnection) ui.setSyncMode('connected')
         return
       }
 
@@ -488,8 +501,11 @@
   }
 
   async function close() {
-    await cleanup()
+    // Mark the modal closed before settling the promise so the suspended pull cannot switch the
+    // hidden modal back to its connected state while cleanup is running.
     ui.closeSyncModal()
+    cancelPendingPackMapping()
+    await cleanup()
   }
 
   function formatDate(timestamp: number): string {

--- a/src/lib/services/database.ts
+++ b/src/lib/services/database.ts
@@ -62,6 +62,18 @@ function runtimeVarPath(defId: string, field?: string): string {
 const RUNTIME_VAR_ENTITY_TABLES = ['characters', 'locations', 'items', 'story_beats'] as const
 
 /**
+ * What `createStory` accepts: a `Story` minus its timestamps, plus the two pack columns.
+ *
+ * `packId` and `customVariableValues` are not on `Story` — they are read through
+ * `getStoryPackId` / `getStoryCustomVariables` rather than off the loaded row — so they ride
+ * here as optional extras instead.
+ */
+export type CreateStoryInput = Omit<Story, 'createdAt' | 'updatedAt'> & {
+  packId?: string | null
+  customVariableValues?: Record<string, string> | null
+}
+
+/**
  * Migrate visual descriptors from old string array format to new structured object format.
  * Handles both old format (string[]) and new format (VisualDescriptors object).
  */
@@ -374,7 +386,14 @@ class DatabaseService {
     return results.length > 0 ? this.mapStory(results[0]) : null
   }
 
-  async createStory(story: Omit<Story, 'createdAt' | 'updatedAt'>): Promise<Story> {
+  /**
+   * A new story row, plus the two pack columns that are not part of `Story`.
+   *
+   * Both are optional. The setup wizard leaves them out and writes them a moment later through
+   * `setStoryPack` / `setStoryCustomVariables`, which is unaffected by this; import supplies them
+   * up front so the story never exists bound to a pack its author did not choose.
+   */
+  async createStory(story: CreateStoryInput): Promise<Story> {
     const db = await this.getDb()
     const now = Date.now()
     await db.execute(
@@ -391,9 +410,11 @@ class DatabaseService {
         memory_config,
         retry_state,
         style_review_state,
-        time_tracker
+        time_tracker,
+        pack_id,
+        custom_variable_values
       )
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [
         story.id,
         story.title,
@@ -408,6 +429,8 @@ class DatabaseService {
         story.retryState ? JSON.stringify(story.retryState) : null,
         story.styleReviewState ? JSON.stringify(story.styleReviewState) : null,
         story.timeTracker ? JSON.stringify(story.timeTracker) : null,
+        story.packId ?? null,
+        story.customVariableValues ? JSON.stringify(story.customVariableValues) : null,
       ],
     )
     return { ...story, createdAt: now, updatedAt: now }

--- a/src/lib/services/export.test.ts
+++ b/src/lib/services/export.test.ts
@@ -115,7 +115,7 @@ describe('importFromAventura — reads the picked file natively', () => {
 
     const result = await exportService.importFromAventura()
 
-    expect(importFromFile).toHaveBeenCalledWith('/sdcard/yuka.avt')
+    expect(importFromFile).toHaveBeenCalledWith('/sdcard/yuka.avt', {})
     expect(result).toEqual({ success: true, storyId: 'new-id' })
   })
 

--- a/src/lib/services/export.ts
+++ b/src/lib/services/export.ts
@@ -4,8 +4,9 @@ import { writeTextFile } from '@tauri-apps/plugin-fs'
 import { resolveSaveTarget } from './exportTarget'
 import { errMessage } from '$lib/utils/error'
 import { openFilters } from '$lib/utils/dialogFilters'
-import { importFromJson, importFromFile, EXPORT_FORMAT_VERSION } from './import'
-import type { AventuraExport, ImportResult } from './import'
+import { importFromJson, importFromFile, previewPackBinding, EXPORT_FORMAT_VERSION } from './import'
+import type { AventuraExport, ImportResult, RunImportOptions } from './import'
+import type { PackBindingExport } from './import/types'
 
 // Re-exported for the modules that imported these from here before the import logic moved.
 export type { AventuraExport } from './import'
@@ -39,6 +40,9 @@ class ExportService {
     branches: Branch[] = [],
     chapters: Chapter[] = [],
     currentBgImage: string | null = null,
+    // Identity and variable *shape* only — never the pack's templates, which stay owned by the
+    // pack as installed on whichever device generates. Null for a story with no pack row.
+    packBinding: PackBindingExport | null = null,
   ): Promise<boolean> {
     // embeddedImages is metadata only (no base64). The native exporter fills in each image's
     // imageData from SQLite, so the heavy bytes never sit in the JS heap (their only home would
@@ -61,6 +65,9 @@ class ExportService {
       branches,
       chapters,
       currentBgImage,
+      // Omitted rather than written as null, so a story with no pack produces a file that is
+      // byte-for-byte the legacy shape and takes the legacy import path.
+      ...(packBinding ? { packBinding } : {}),
     }
 
     const target = await resolveSaveTarget(`${this.sanitizeFilename(story.title)}.avt`, [
@@ -189,7 +196,11 @@ class ExportService {
   }
 
   // Import a story through the native file dialog.
-  async importFromAventura(): Promise<ImportResult> {
+  // `resolvePackBinding` is how the caller puts a pack mapping step in front of the import; when
+  // omitted, the headless auto-matcher decides.
+  async importFromAventura(
+    options: Pick<RunImportOptions, 'resolvePackBinding'> = {},
+  ): Promise<ImportResult> {
     // openFilters drops these on Android, where a .avt is not selectable with them. See there.
     const filePath = await open({
       filters: openFilters([
@@ -207,7 +218,7 @@ class ExportService {
       // Read natively: the file's image payloads never enter the JS heap, so a large story
       // imports without hitting Android's WebView heap cap. `filePath` may be a SAF
       // content:// URI there, which the native side opens via the fs plugin.
-      return await importFromFile(filePath)
+      return await importFromFile(filePath, options)
     } catch (error) {
       console.error('Import failed:', error)
       return {
@@ -219,11 +230,21 @@ class ExportService {
 
   // Import from a JSON string (HTML file input, and sync which receives a story over the network).
   // Set skipImportedSuffix to true for sync operations to keep the original title.
+  //
+  // Sync resolves the pack itself, before it deletes the story it is replacing, and passes the
+  // answer here through `options.resolvePackBinding` — so by the time this runs the decision is
+  // already made and simply replayed.
   async importFromContent(
     content: string,
     skipImportedSuffix: boolean = false,
+    options: Pick<RunImportOptions, 'resolvePackBinding'> = {},
   ): Promise<ImportResult> {
-    return importFromJson(content, { skipImportedSuffix })
+    return importFromJson(content, { ...options, skipImportedSuffix })
+  }
+
+  /** What a payload says about its pack, so a caller can settle it before importing. */
+  async previewPackBinding(content: string) {
+    return previewPackBinding(content)
   }
 
   private sanitizeFilename(name: string): string {

--- a/src/lib/services/export.ts
+++ b/src/lib/services/export.ts
@@ -4,9 +4,9 @@ import { writeTextFile } from '@tauri-apps/plugin-fs'
 import { resolveSaveTarget } from './exportTarget'
 import { errMessage } from '$lib/utils/error'
 import { openFilters } from '$lib/utils/dialogFilters'
-import { importFromJson, importFromFile, previewPackBinding, EXPORT_FORMAT_VERSION } from './import'
+import { importFromJson, importFromFile, EXPORT_FORMAT_VERSION } from './import'
 import type { AventuraExport, ImportResult, RunImportOptions } from './import'
-import type { PackBindingExport } from './import/types'
+import type { PackBindingExport } from './import'
 
 // Re-exported for the modules that imported these from here before the import logic moved.
 export type { AventuraExport } from './import'
@@ -243,10 +243,6 @@ class ExportService {
   }
 
   /** What a payload says about its pack, so a caller can settle it before importing. */
-  async previewPackBinding(content: string) {
-    return previewPackBinding(content)
-  }
-
   private sanitizeFilename(name: string): string {
     return name
       .replace(/[<>:"/\\|?*]/g, '')
@@ -258,4 +254,8 @@ class ExportService {
 export const exportService = new ExportService()
 
 // Re-export coordination service
-export { gatherStoryData, type StoryExportData } from './export/ExportCoordinationService'
+export {
+  gatherPackBinding,
+  gatherStoryData,
+  type StoryExportData,
+} from './export/ExportCoordinationService'

--- a/src/lib/services/export/ExportCoordinationService.ts
+++ b/src/lib/services/export/ExportCoordinationService.ts
@@ -16,6 +16,7 @@ import type {
   Branch,
   EmbeddedImageMeta,
 } from '$lib/types'
+import type { PackBindingExport } from '$lib/services/import/types'
 
 /** Complete story data for export */
 export interface StoryExportData {
@@ -31,6 +32,63 @@ export interface StoryExportData {
   checkpoints: Checkpoint[]
   branches: Branch[]
   chapters: Chapter[]
+  /**
+   * The story's prompt pack, as much of it as can safely travel. Null when the story has no pack
+   * row to point at (a story predating the column, or one whose pack has since been deleted) —
+   * the file then records no pack and imports as a legacy file does.
+   */
+  packBinding: PackBindingExport | null
+}
+
+/**
+ * Describe the story's pack for the file: identity, the story's own answers, and the shape of
+ * the variables those answers belong to.
+ *
+ * Template content is deliberately absent. The recipient's own pack narrates on the recipient's
+ * device, so a shared story cannot fork their templates behind their back; `.prompt.json` already
+ * exists for sharing a pack deliberately.
+ *
+ * Definitions travel without ids: `id` and `packId` are assigned per device and would only invite
+ * a later matcher to trust them.
+ */
+async function gatherPackBinding(storyId: string): Promise<PackBindingExport | null> {
+  const packId = await database.getStoryPackId(storyId)
+  if (!packId) return null
+
+  const pack = await database.getPack(packId)
+  if (!pack) return null
+
+  const [variables, runtimeVariables, customVariableValues] = await Promise.all([
+    database.getPackVariables(packId),
+    database.getRuntimeVariables(packId),
+    database.getStoryCustomVariables(storyId),
+  ])
+
+  return {
+    pack: { name: pack.name, author: pack.author },
+    ...(customVariableValues ? { customVariableValues } : {}),
+    variables: variables.map((v) => ({
+      variableName: v.variableName,
+      displayName: v.displayName,
+      description: v.description,
+      variableType: v.variableType,
+      isRequired: v.isRequired,
+      sortOrder: v.sortOrder,
+      defaultValue: v.defaultValue,
+      enumOptions: v.enumOptions,
+    })),
+    runtimeVariables: runtimeVariables.map((v) => ({
+      entityType: v.entityType,
+      variableName: v.variableName,
+      displayName: v.displayName,
+      description: v.description,
+      variableType: v.variableType,
+      defaultValue: v.defaultValue,
+      minValue: v.minValue,
+      maxValue: v.maxValue,
+      enumOptions: v.enumOptions,
+    })),
+  }
 }
 
 /**
@@ -50,6 +108,7 @@ export async function gatherStoryData(storyId: string): Promise<StoryExportData>
     checkpoints,
     branches,
     chapters,
+    packBinding,
   ] = await Promise.all([
     database.getStoryEntries(storyId),
     database.getCharacters(storyId),
@@ -61,6 +120,7 @@ export async function gatherStoryData(storyId: string): Promise<StoryExportData>
     database.getCheckpoints(storyId),
     database.getBranches(storyId),
     database.getChapters(storyId),
+    gatherPackBinding(storyId),
   ])
 
   return {
@@ -74,6 +134,7 @@ export async function gatherStoryData(storyId: string): Promise<StoryExportData>
     checkpoints,
     branches,
     chapters,
+    packBinding,
   }
 }
 

--- a/src/lib/services/export/ExportCoordinationService.ts
+++ b/src/lib/services/export/ExportCoordinationService.ts
@@ -44,6 +44,11 @@ export interface StoryExportData {
  * Describe the story's pack for the file: identity, the story's own answers, and the shape of
  * the variables those answers belong to.
  *
+ * Exported because sync needs exactly this section while keeping its own payload assembly (see
+ * `syncService.exportStoryToJson`). It takes only a story id and reads only through `database`,
+ * so it carries none of the `.avt` path's assumptions — in particular none about how image
+ * payloads are gathered, which is the part the two exporters genuinely disagree about.
+ *
  * Template content is deliberately absent. The recipient's own pack narrates on the recipient's
  * device, so a shared story cannot fork their templates behind their back; `.prompt.json` already
  * exists for sharing a pack deliberately.
@@ -51,7 +56,7 @@ export interface StoryExportData {
  * Definitions travel without ids: `id` and `packId` are assigned per device and would only invite
  * a later matcher to trust them.
  */
-async function gatherPackBinding(storyId: string): Promise<PackBindingExport | null> {
+export async function gatherPackBinding(storyId: string): Promise<PackBindingExport | null> {
   const packId = await database.getStoryPackId(storyId)
   if (!packId) return null
 

--- a/src/lib/services/export/ExportCoordinationService.ts
+++ b/src/lib/services/export/ExportCoordinationService.ts
@@ -16,7 +16,7 @@ import type {
   Branch,
   EmbeddedImageMeta,
 } from '$lib/types'
-import type { PackBindingExport } from '$lib/services/import/types'
+import type { PackBindingExport } from '$lib/services/import'
 
 /** Complete story data for export */
 export interface StoryExportData {

--- a/src/lib/services/export/packBinding.test.ts
+++ b/src/lib/services/export/packBinding.test.ts
@@ -1,0 +1,202 @@
+/**
+ * What an exported story says about its prompt pack.
+ *
+ * Two properties matter and pull in opposite directions: the file must carry enough for a
+ * recipient to re-establish the binding, and it must carry none of the pack's template content —
+ * a story is not a pack-distribution channel, and receiving one must not fork the recipient's
+ * templates.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+const invoke = vi.fn(async (_cmd: string, _args: { storyJson: string }) => 'ok')
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (cmd: string, args: { storyJson: string }) => invoke(cmd, args),
+}))
+vi.mock('@tauri-apps/plugin-dialog', () => ({ open: vi.fn() }))
+vi.mock('@tauri-apps/plugin-fs', () => ({ writeTextFile: vi.fn(), readTextFile: vi.fn() }))
+vi.mock('$lib/services/import/native', () => ({ importFromFile: vi.fn() }))
+vi.mock('$lib/services/exportTarget', () => ({
+  resolveSaveTarget: vi.fn(async () => ({ destPath: '/tmp/out.avt' })),
+}))
+
+const SECRET_TEMPLATE = 'You are a grim narrator. Never break character.'
+
+const db = {
+  storyPackId: 'pack-local' as string | null,
+  pack: {
+    id: 'pack-local',
+    name: 'Grimdark',
+    description: 'Bleak',
+    author: 'Ada',
+    isDefault: false,
+    createdAt: 0,
+    updatedAt: 0,
+  } as Record<string, unknown> | null,
+  variables: [] as Record<string, unknown>[],
+  runtimeVariables: [] as Record<string, unknown>[],
+  customVariableValues: null as Record<string, string> | null,
+}
+
+vi.mock('$lib/services/database', () => ({
+  database: {
+    getStoryEntries: vi.fn(async () => []),
+    getCharacters: vi.fn(async () => []),
+    getLocations: vi.fn(async () => []),
+    getItems: vi.fn(async () => []),
+    getStoryBeats: vi.fn(async () => []),
+    getEntries: vi.fn(async () => []),
+    getEmbeddedImageMetaForStory: vi.fn(async () => []),
+    getCheckpoints: vi.fn(async () => []),
+    getBranches: vi.fn(async () => []),
+    getChapters: vi.fn(async () => []),
+    getStoryPackId: vi.fn(async () => db.storyPackId),
+    getPack: vi.fn(async () => db.pack),
+    getPackVariables: vi.fn(async () => db.variables),
+    getRuntimeVariables: vi.fn(async () => db.runtimeVariables),
+    getStoryCustomVariables: vi.fn(async () => db.customVariableValues),
+    // Templates exist on the pack, and gatherStoryData must never reach for them.
+    getPackTemplates: vi.fn(async () => [{ templateId: 'adventure', content: SECRET_TEMPLATE }]),
+  },
+}))
+
+const { gatherStoryData } = await import('./ExportCoordinationService')
+const { exportService } = await import('../export')
+
+beforeEach(() => {
+  invoke.mockClear()
+  db.storyPackId = 'pack-local'
+  db.pack = {
+    id: 'pack-local',
+    name: 'Grimdark',
+    description: 'Bleak',
+    author: 'Ada',
+    isDefault: false,
+    createdAt: 0,
+    updatedAt: 0,
+  }
+  db.variables = [
+    {
+      id: 'var-1',
+      packId: 'pack-local',
+      variableName: 'writing_style',
+      displayName: 'Writing Style',
+      variableType: 'enum',
+      isRequired: true,
+      sortOrder: 0,
+      defaultValue: 'terse',
+      enumOptions: [{ label: 'Terse', value: 'terse' }],
+      createdAt: 0,
+    },
+  ]
+  db.runtimeVariables = [
+    {
+      id: 'rv-1',
+      packId: 'pack-local',
+      entityType: 'character',
+      variableName: 'morale',
+      displayName: 'Morale',
+      variableType: 'number',
+      minValue: 0,
+      maxValue: 10,
+      color: '#fff',
+      pinned: false,
+      sortOrder: 0,
+      createdAt: 0,
+    },
+  ]
+  db.customVariableValues = { writing_style: 'terse' }
+})
+
+describe('gatherStoryData — packBinding', () => {
+  it('records the pack identity, the story answers and the definitions', async () => {
+    const { packBinding } = await gatherStoryData('s1')
+
+    expect(packBinding?.pack).toEqual({ name: 'Grimdark', author: 'Ada' })
+    expect(packBinding?.customVariableValues).toEqual({ writing_style: 'terse' })
+    expect(packBinding?.variables).toEqual([
+      {
+        variableName: 'writing_style',
+        displayName: 'Writing Style',
+        description: undefined,
+        variableType: 'enum',
+        isRequired: true,
+        sortOrder: 0,
+        defaultValue: 'terse',
+        enumOptions: [{ label: 'Terse', value: 'terse' }],
+      },
+    ])
+    expect(packBinding?.runtimeVariables).toEqual([
+      {
+        entityType: 'character',
+        variableName: 'morale',
+        displayName: 'Morale',
+        description: undefined,
+        variableType: 'number',
+        defaultValue: undefined,
+        minValue: 0,
+        maxValue: 10,
+        enumOptions: undefined,
+      },
+    ])
+  })
+
+  it('carries no definition ids', async () => {
+    // Ids are per-device. Exporting them invites a future matcher to trust one, which is the
+    // exact bug this whole change exists to undo.
+    const { packBinding } = await gatherStoryData('s1')
+    const serialized = JSON.stringify(packBinding)
+    expect(serialized).not.toContain('var-1')
+    expect(serialized).not.toContain('rv-1')
+    expect(serialized).not.toContain('pack-local')
+  })
+
+  it('records no pack when the story has none', async () => {
+    db.storyPackId = null
+    await expect(gatherStoryData('s1')).resolves.toMatchObject({ packBinding: null })
+  })
+
+  it('records no pack when the story points at a pack row that is gone', async () => {
+    db.pack = null
+    await expect(gatherStoryData('s1')).resolves.toMatchObject({ packBinding: null })
+  })
+})
+
+describe('exportToAventura — packBinding', () => {
+  /** The JSON the native writer was handed. */
+  async function exportedFile(packBinding: unknown) {
+    await exportService.exportToAventura(
+      { id: 's1', title: 'T', styleReviewState: null } as never,
+      [],
+      [],
+      [],
+      [],
+      [],
+      [],
+      [],
+      [],
+      [],
+      [],
+      null,
+      packBinding as never,
+    )
+    return invoke.mock.calls[0][1].storyJson
+  }
+
+  it('writes the binding it was given, and no template text', async () => {
+    const { packBinding } = await gatherStoryData('s1')
+
+    const json = await exportedFile(packBinding)
+
+    expect(JSON.parse(json).packBinding).toEqual(packBinding)
+    expect(json).not.toContain(SECRET_TEMPLATE)
+    expect(json).not.toContain('Never break character')
+  })
+
+  it('omits the field entirely for a story with no pack, rather than writing null', async () => {
+    // A file with `packBinding: null` and one with no such key must import identically, and the
+    // cheapest way to guarantee that is to emit only the legacy shape.
+    const json = await exportedFile(null)
+    expect(Object.keys(JSON.parse(json))).not.toContain('packBinding')
+  })
+})

--- a/src/lib/services/export/packBinding.test.ts
+++ b/src/lib/services/export/packBinding.test.ts
@@ -60,8 +60,7 @@ vi.mock('$lib/services/database', () => ({
   },
 }))
 
-const { gatherStoryData } = await import('./ExportCoordinationService')
-const { exportService } = await import('../export')
+const { gatherStoryData, exportService } = await import('$lib/services/export')
 
 beforeEach(() => {
   invoke.mockClear()

--- a/src/lib/services/import/index.ts
+++ b/src/lib/services/import/index.ts
@@ -13,16 +13,36 @@ import type { AventuraExport, ImportResult, IdMaps } from './types'
 import { validateExport, logVersionCompatibilityWarnings } from './validate'
 import { buildIdMaps } from './idMaps'
 import { importStructure } from './structure'
+import type { StoryPackBinding } from './structure'
 import { importImagesInline } from './images'
+import { autoMatchPackBinding, buildBindingContext } from './packBinding'
+import type { PackBindingContext, PackBindingResolution } from './packBinding'
 
 export type { AventuraExport, ImportResult, IdMaps } from './types'
 export { EXPORT_FORMAT_VERSION } from './types'
 export { validateExport, logVersionCompatibilityWarnings, compareVersions } from './validate'
 export { buildIdMaps, createMappers } from './idMaps'
 export { importStructure } from './structure'
+export type { StoryPackBinding } from './structure'
 export { importImagesInline, resolveImageMappings } from './images'
 export type { ImageEntryMapping } from './images'
 export { importFromFile } from './native'
+export {
+  autoMatchPackBinding,
+  buildBindingContext,
+  decidePackPrompt,
+  planPackBinding,
+  sanitizePackBinding,
+  unansweredRequiredVariables,
+} from './packBinding'
+export type {
+  PackBindingContext,
+  PackBindingResolution,
+  PackPromptDecision,
+  PackPromptPlan,
+  RequiredVariableDef,
+  SanitizedPackBinding,
+} from './packBinding'
 
 export interface RunImportOptions {
   /** Sync keeps the original title; a user-facing import marks the copy. */
@@ -32,6 +52,15 @@ export interface RunImportOptions {
    * rows reference already exist. Defaults to the inline path.
    */
   importImages?: (data: AventuraExport, maps: IdMaps) => Promise<void>
+  /**
+   * Which local pack the story binds to. Called before anything is written, so returning `null`
+   * (the user cancelled) leaves nothing behind.
+   *
+   * Defaults to the headless auto-matcher, which is what makes sync correct without a code path
+   * of its own — and what keeps the pipeline UI-agnostic, since the only caller that can ask a
+   * question is the one that supplies this.
+   */
+  resolvePackBinding?: (ctx: PackBindingContext) => Promise<PackBindingResolution | null>
 }
 
 /**
@@ -47,12 +76,24 @@ export async function runImport(
   data: AventuraExport,
   options: RunImportOptions = {},
 ): Promise<ImportResult> {
-  const { skipImportedSuffix = false, importImages = importImagesInline } = options
+  const {
+    skipImportedSuffix = false,
+    importImages = importImagesInline,
+    resolvePackBinding = autoMatchPackBinding,
+  } = options
 
   const invalid = validateExport(data)
   if (invalid) return { success: false, error: invalid }
 
   logVersionCompatibilityWarnings(data.version)
+
+  // Before the first write: a cancel here costs nothing to undo, and the story never exists
+  // bound to a pack the user did not pick.
+  const context = await buildBindingContext(data.packBinding)
+  const resolution = await resolvePackBinding(context)
+  if (!resolution) return { success: false }
+
+  const packBinding = await loadTargetDefinitions(context, resolution)
 
   const maps = buildIdMaps(data)
   let storyCreated = false
@@ -60,6 +101,7 @@ export async function runImport(
   try {
     await importStructure(data, maps, {
       skipImportedSuffix,
+      packBinding,
       onStoryCreated: () => {
         storyCreated = true
       },
@@ -74,6 +116,25 @@ export async function runImport(
 }
 
 /**
+ * Pair the resolved pack's runtime variable definitions with the file's, so the entity values can
+ * be re-keyed as their rows are built.
+ *
+ * Skipped entirely when the file carries no runtime variable definitions — the overwhelmingly
+ * common case, and one extra query is one too many on a path that runs per import.
+ */
+async function loadTargetDefinitions(
+  context: PackBindingContext,
+  resolution: PackBindingResolution,
+): Promise<StoryPackBinding> {
+  const sourceRuntimeVars = context.binding?.runtimeVariables ?? []
+  const targetRuntimeVars = sourceRuntimeVars.length
+    ? await database.getRuntimeVariables(resolution.packId)
+    : []
+
+  return { ...resolution, sourceRuntimeVars, targetRuntimeVars }
+}
+
+/**
  * Undo a partial import. Best-effort: the import has already failed, and reporting a cleanup
  * problem instead of the real cause would only hide it.
  */
@@ -82,6 +143,23 @@ async function rollbackStory(storyId: string): Promise<void> {
     await database.deleteStory(storyId)
   } catch (cleanupError) {
     console.error('[Import] Failed to roll back the partially imported story:', cleanupError)
+  }
+}
+
+/**
+ * Work out what a story payload says about its pack, without importing it.
+ *
+ * Sync needs this because it deletes the story it is replacing before importing: the pack
+ * question has to be asked and answered while that story is still there, which means before
+ * `runImport` is reached. Returns `null` if the content is not parseable — the import will
+ * produce the real error message a moment later, and there is nothing to ask about either way.
+ */
+export async function previewPackBinding(content: string): Promise<PackBindingContext | null> {
+  try {
+    const data: AventuraExport = JSON.parse(content)
+    return await buildBindingContext(data.packBinding)
+  } catch {
+    return null
   }
 }
 

--- a/src/lib/services/import/index.ts
+++ b/src/lib/services/import/index.ts
@@ -9,7 +9,7 @@
 
 import { database } from '$lib/services/database'
 import { errMessage } from '$lib/utils/error'
-import type { AventuraExport, ImportResult, IdMaps } from './types'
+import type { AventuraExport, ImportResult, IdMaps, PackBindingExport } from './types'
 import { validateExport, logVersionCompatibilityWarnings } from './validate'
 import { buildIdMaps } from './idMaps'
 import { importStructure } from './structure'
@@ -18,7 +18,7 @@ import { importImagesInline } from './images'
 import { autoMatchPackBinding, buildBindingContext } from './packBinding'
 import type { PackBindingContext, PackBindingResolution } from './packBinding'
 
-export type { AventuraExport, ImportResult, IdMaps } from './types'
+export type { AventuraExport, ImportResult, IdMaps, PackBindingExport } from './types'
 export { EXPORT_FORMAT_VERSION } from './types'
 export { validateExport, logVersionCompatibilityWarnings, compareVersions } from './validate'
 export { buildIdMaps, createMappers } from './idMaps'
@@ -88,20 +88,20 @@ export async function runImport(
   const invalid = validateExport(data)
   if (invalid) return { success: false, error: invalid }
 
-  logVersionCompatibilityWarnings(data.version)
-
-  // Before the first write: a cancel here costs nothing to undo, and the story never exists
-  // bound to a pack the user did not pick.
-  const context = await buildBindingContext(data.packBinding)
-  const resolution = await resolvePackBinding(context)
-  if (!resolution) return { success: false }
-
-  const packBinding = await loadTargetDefinitions(context, resolution)
-
-  const maps = buildIdMaps(data)
   let storyCreated = false
+  let maps: IdMaps | null = null
 
   try {
+    logVersionCompatibilityWarnings(data)
+
+    // Before the first write: a cancel here costs nothing to undo, and the story never exists
+    // bound to a pack the user did not pick.
+    const context = await buildBindingContext(data.packBinding)
+    const resolution = await resolvePackBinding(context)
+    if (!resolution) return { success: false }
+
+    const packBinding = await loadTargetDefinitions(context, resolution)
+    maps = buildIdMaps(data)
     await importStructure(data, maps, {
       skipImportedSuffix,
       packBinding,
@@ -113,7 +113,7 @@ export async function runImport(
     return { success: true, storyId: maps.newStoryId }
   } catch (error) {
     console.error('Import failed:', error)
-    if (storyCreated) await rollbackStory(maps.newStoryId)
+    if (storyCreated && maps) await rollbackStory(maps.newStoryId)
     return { success: false, error: errMessage(error) }
   }
 }
@@ -149,20 +149,24 @@ async function rollbackStory(storyId: string): Promise<void> {
   }
 }
 
-/**
- * Work out what a story payload says about its pack, without importing it.
- *
- * Sync needs this because it deletes the story it is replacing before importing: the pack
- * question has to be asked and answered while that story is still there, which means before
- * `runImport` is reached. Returns `null` if the content is not parseable — the import will
- * produce the real error message a moment later, and there is nothing to ask about either way.
- */
-export async function previewPackBinding(content: string): Promise<PackBindingContext | null> {
+/** Parse and validate a sync payload before any replacement work begins. */
+export async function previewImport(
+  content: string,
+): Promise<{ context: PackBindingContext } | { error: string }> {
+  let data: AventuraExport
   try {
-    const data: AventuraExport = JSON.parse(content)
-    return await buildBindingContext(data.packBinding)
+    data = JSON.parse(content)
   } catch {
-    return null
+    return { error: 'Invalid file: Not a valid JSON file.' }
+  }
+
+  const invalid = validateExport(data)
+  if (invalid) return { error: invalid }
+
+  try {
+    return { context: await buildBindingContext(data.packBinding) }
+  } catch (error) {
+    return { error: errMessage(error) }
   }
 }
 

--- a/src/lib/services/import/index.ts
+++ b/src/lib/services/import/index.ts
@@ -30,7 +30,10 @@ export { importFromFile } from './native'
 export {
   autoMatchPackBinding,
   buildBindingContext,
+  canonicalizeCustomVariableValues,
+  customVariableValue,
   decidePackPrompt,
+  mergeCustomVariableValues,
   planPackBinding,
   sanitizePackBinding,
   unansweredRequiredVariables,

--- a/src/lib/services/import/index.ts
+++ b/src/lib/services/import/index.ts
@@ -9,7 +9,7 @@
 
 import { database } from '$lib/services/database'
 import { errMessage } from '$lib/utils/error'
-import type { AventuraExport, ImportResult, IdMaps, PackBindingExport } from './types'
+import type { AventuraExport, ImportResult, IdMaps } from './types'
 import { validateExport, logVersionCompatibilityWarnings } from './validate'
 import { buildIdMaps } from './idMaps'
 import { importStructure } from './structure'

--- a/src/lib/services/import/native.ts
+++ b/src/lib/services/import/native.ts
@@ -16,6 +16,7 @@
 import { invoke } from '@tauri-apps/api/core'
 import type { AventuraExport, ImportResult, IdMaps } from './types'
 import { runImport } from './index'
+import type { RunImportOptions } from './index'
 import { resolveImageMappings } from './images'
 
 /**
@@ -24,12 +25,18 @@ import { resolveImageMappings } from './images'
  * Falls back to nothing: if the native side cannot read the file, the error surfaces as-is.
  * `runImport` deletes the partially imported story if the image pass fails.
  */
-export async function importFromFile(filePath: string): Promise<ImportResult> {
+export async function importFromFile(
+  filePath: string,
+  options: Pick<RunImportOptions, 'resolvePackBinding'> = {},
+): Promise<ImportResult> {
   // Pass 1 — structure only. Rust skips each imageData without ever allocating it.
+  // The parsed export is available here, before any row is written, which is what lets a pack
+  // dialog run without a second read and without anything to clean up if it is cancelled.
   const lightJson = await invoke<string>('avt_read_light', { srcPath: filePath })
   const data: AventuraExport = JSON.parse(lightJson)
 
   return runImport(data, {
+    ...options,
     importImages: (parsed, maps) => importImagesNatively(filePath, parsed, maps),
   })
 }

--- a/src/lib/services/import/packBinding.test.ts
+++ b/src/lib/services/import/packBinding.test.ts
@@ -22,17 +22,19 @@ const db = {
 
 const calls = {
   stories: [] as any[],
+  entries: [] as any[],
   characters: [] as any[],
   locations: [] as any[],
   items: [] as any[],
   beats: [] as any[],
+  checkpoints: [] as any[],
   deleted: [] as string[],
 }
 
 vi.mock('$lib/services/database', () => ({
   database: {
     createStory: vi.fn(async (s: any) => void calls.stories.push(s)),
-    addStoryEntry: vi.fn(async () => {}),
+    addStoryEntry: vi.fn(async (e: any) => void calls.entries.push(e)),
     addCharacter: vi.fn(async (c: any) => void calls.characters.push(c)),
     addLocation: vi.fn(async (l: any) => void calls.locations.push(l)),
     addItem: vi.fn(async (i: any) => void calls.items.push(i)),
@@ -40,7 +42,7 @@ vi.mock('$lib/services/database', () => ({
     addEntry: vi.fn(async () => {}),
     addChapter: vi.fn(async () => {}),
     addBranch: vi.fn(async () => {}),
-    createCheckpoint: vi.fn(async () => {}),
+    createCheckpoint: vi.fn(async (c: any) => void calls.checkpoints.push(c)),
     createEmbeddedImage: vi.fn(async () => {}),
     updateBranch: vi.fn(async () => {}),
     setStoryCurrentBranch: vi.fn(async () => {}),
@@ -51,8 +53,13 @@ vi.mock('$lib/services/database', () => ({
   },
 }))
 
-const { runImport, decidePackPrompt, planPackBinding, buildBindingContext } =
-  await import('./index')
+const {
+  runImport,
+  decidePackPrompt,
+  planPackBinding,
+  buildBindingContext,
+  mergeCustomVariableValues,
+} = await import('./index')
 const { importFromFile } = await import('./native')
 
 function pack(overrides: Partial<PresetPack>): PresetPack {
@@ -281,6 +288,15 @@ describe('decidePackPrompt — what the interactive import asks about', () => {
       ).toEqual({ prompt: 'none' })
     })
 
+    it('matches a story answer using the same normalized name as pack binding', () => {
+      expect(
+        decidePackPrompt(
+          file('exact', { ' Writing_Style ': 'terse' }),
+          device({ matchedPackVariables: required() }),
+        ),
+      ).toEqual({ prompt: 'none' })
+    })
+
     it('does not ask when the pack supplies a default', () => {
       // A default is a usable value. Stopping an import to have someone retype it is exactly the
       // prompt this design removes.
@@ -335,6 +351,25 @@ describe('planPackBinding — the one policy both callers use', () => {
     expect(plan).toEqual({
       ask: false,
       resolution: { packId: 'local-grimdark', customVariableValues: { writing_style: 'terse' } },
+    })
+  })
+
+  it("adds the selected pack's canonical variable spelling on a confident match", async () => {
+    db.packs.push(pack({ id: 'local-grimdark' }))
+    db.packVariables = [{ variableName: 'mood', isRequired: false }]
+    const ctx = await buildBindingContext({
+      pack: named.pack,
+      customVariableValues: { Mood: 'somber' },
+    } as never)
+
+    const plan = await planPackBinding(ctx, false)
+
+    expect(plan).toEqual({
+      ask: false,
+      resolution: {
+        packId: 'local-grimdark',
+        customVariableValues: { Mood: 'somber', mood: 'somber' },
+      },
     })
   })
 
@@ -397,6 +432,102 @@ describe('runImport — re-keying entity values', () => {
 
     expect(calls.characters[0].metadata.runtimeVars).toEqual({
       'src-morale': { variableName: 'morale', v: 7 },
+    })
+  })
+
+  it('re-keys rollback deltas and checkpoint snapshots as well as live rows', async () => {
+    db.packs.push(pack({ id: 'local-grimdark' }))
+    const entityTypes = ['character', 'location', 'item', 'story_beat'] as const
+    db.runtimeVars = entityTypes.map((entityType) => ({
+      id: `local-${entityType}`,
+      packId: 'local-grimdark',
+      entityType,
+      variableName: 'state',
+      displayName: 'State',
+      variableType: 'text',
+      color: '#fff',
+      pinned: false,
+      sortOrder: 0,
+      createdAt: 0,
+    }))
+    const binding = {
+      ...namedBinding,
+      runtimeVariables: entityTypes.map((entityType) => ({ entityType, variableName: 'state' })),
+    }
+    const data = sampleExport(binding)
+    const metadata = (entityType: string) => ({
+      runtimeVars: { [`src-${entityType}`]: { variableName: 'state', v: entityType } },
+    })
+    data.characters[0].metadata = metadata('character')
+    data.locations = [
+      { id: 'loc-1', name: 'Cave', connections: [], metadata: metadata('location') },
+    ]
+    data.items = [
+      { id: 'item-1', name: 'Blade', location: 'inventory', metadata: metadata('item') },
+    ]
+    data.storyBeats = [{ id: 'beat-1', title: 'Quest', metadata: metadata('story_beat') }]
+    data.entries[0].worldStateDelta = {
+      classificationResult: {},
+      previousState: {
+        characters: [{ id: 'char-1', metadata: metadata('character') }],
+        locations: [{ id: 'loc-1', metadata: metadata('location') }],
+        items: [{ id: 'item-1', location: 'inventory', metadata: metadata('item') }],
+        storyBeats: [{ id: 'beat-1', metadata: metadata('story_beat') }],
+        currentLocationId: null,
+        timeTracker: null,
+      },
+      createdEntities: { characterIds: [], locationIds: [], itemIds: [], storyBeatIds: [] },
+    }
+    data.checkpoints = [
+      {
+        id: 'checkpoint-1',
+        storyId: 'story-old',
+        name: 'Before',
+        lastEntryId: 'entry-1',
+        lastEntryPreview: 'c',
+        entryCount: 1,
+        entriesSnapshot: [],
+        charactersSnapshot: [structuredClone(data.characters[0])],
+        locationsSnapshot: [structuredClone(data.locations[0])],
+        itemsSnapshot: [structuredClone(data.items[0])],
+        storyBeatsSnapshot: [structuredClone(data.storyBeats[0])],
+        chaptersSnapshot: [],
+        timeTrackerSnapshot: null,
+      },
+    ]
+
+    expect((await runImport(data)).success).toBe(true)
+    const deltaEntities = calls.entries[0].worldStateDelta.previousState
+    const checkpoint = calls.checkpoints[0]
+    const pairs = [
+      [deltaEntities.characters[0], checkpoint.charactersSnapshot[0], 'character'],
+      [deltaEntities.locations[0], checkpoint.locationsSnapshot[0], 'location'],
+      [deltaEntities.items[0], checkpoint.itemsSnapshot[0], 'item'],
+      [deltaEntities.storyBeats[0], checkpoint.storyBeatsSnapshot[0], 'story_beat'],
+    ] as const
+    for (const [deltaEntity, snapshotEntity, entityType] of pairs) {
+      expect(deltaEntity.metadata.runtimeVars[`local-${entityType}`]).toEqual({
+        variableName: 'state',
+        v: entityType,
+      })
+      expect(snapshotEntity.metadata.runtimeVars[`local-${entityType}`]).toEqual({
+        variableName: 'state',
+        v: entityType,
+      })
+    }
+  })
+})
+
+describe('dialog custom-variable persistence', () => {
+  it('keeps file answers and edits without materialising untouched pack defaults', () => {
+    const variables = [{ variableName: 'mood', defaultValue: 'bright' }]
+    expect(mergeCustomVariableValues(undefined, variables, {})).toEqual({})
+    expect(mergeCustomVariableValues({ Mood: 'somber' }, variables, {})).toEqual({
+      Mood: 'somber',
+      mood: 'somber',
+    })
+    expect(mergeCustomVariableValues(undefined, variables, { mood: 'stormy' })).toEqual({
+      mood: 'stormy',
     })
   })
 })

--- a/src/lib/services/import/packBinding.test.ts
+++ b/src/lib/services/import/packBinding.test.ts
@@ -1,0 +1,485 @@
+/**
+ * The pack decision inside `runImport`.
+ *
+ * Three behaviours carry the weight here. A story must never land bound to a pack nobody chose;
+ * a file that named nothing must import exactly as it did before this existed, flag and all
+ * (that is: no flag); and a cancel must be free, which is only true while the callback runs
+ * ahead of the first write.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { PresetPack, RuntimeVariable, RuntimeVarsMap } from '$lib/services/packs/types'
+import type { MatchConfidence } from '$lib/services/packs/binding'
+
+const invoke = vi.fn()
+vi.mock('@tauri-apps/api/core', () => ({ invoke: (...args: unknown[]) => invoke(...args) }))
+
+const db = {
+  packs: [] as PresetPack[],
+  runtimeVars: [] as RuntimeVariable[],
+  packVariables: [] as unknown[],
+}
+
+const calls = {
+  stories: [] as any[],
+  characters: [] as any[],
+  locations: [] as any[],
+  items: [] as any[],
+  beats: [] as any[],
+  deleted: [] as string[],
+}
+
+vi.mock('$lib/services/database', () => ({
+  database: {
+    createStory: vi.fn(async (s: any) => void calls.stories.push(s)),
+    addStoryEntry: vi.fn(async () => {}),
+    addCharacter: vi.fn(async (c: any) => void calls.characters.push(c)),
+    addLocation: vi.fn(async (l: any) => void calls.locations.push(l)),
+    addItem: vi.fn(async (i: any) => void calls.items.push(i)),
+    addStoryBeat: vi.fn(async (b: any) => void calls.beats.push(b)),
+    addEntry: vi.fn(async () => {}),
+    addChapter: vi.fn(async () => {}),
+    addBranch: vi.fn(async () => {}),
+    createCheckpoint: vi.fn(async () => {}),
+    createEmbeddedImage: vi.fn(async () => {}),
+    updateBranch: vi.fn(async () => {}),
+    setStoryCurrentBranch: vi.fn(async () => {}),
+    deleteStory: vi.fn(async (id: string) => void calls.deleted.push(id)),
+    getAllPacks: vi.fn(async () => db.packs),
+    getRuntimeVariables: vi.fn(async () => db.runtimeVars),
+    getPackVariables: vi.fn(async () => db.packVariables),
+  },
+}))
+
+const { runImport, decidePackPrompt, planPackBinding, buildBindingContext } =
+  await import('./index')
+const { importFromFile } = await import('./native')
+
+function pack(overrides: Partial<PresetPack>): PresetPack {
+  return {
+    id: 'p',
+    name: 'Grimdark',
+    description: null,
+    author: 'Ada',
+    isDefault: false,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  }
+}
+
+/** A file whose characters carry a runtime value keyed by the *source* device's definition id. */
+function sampleExport(packBinding?: unknown) {
+  return {
+    version: '1.9.0',
+    exportedAt: 1,
+    story: { id: 'story-old', title: 'T', settings: { tone: 'wry' } },
+    entries: [{ id: 'entry-1', type: 'narration', content: 'c', parentId: null, position: 0 }],
+    characters: [
+      {
+        id: 'char-1',
+        name: 'Yuka',
+        connections: [],
+        metadata: { runtimeVars: { 'src-morale': { variableName: 'morale', v: 7 } } },
+      },
+    ],
+    ...(packBinding === undefined ? {} : { packBinding }),
+  } as any
+}
+
+const namedBinding = {
+  pack: { name: 'Grimdark', author: 'Ada' },
+  customVariableValues: { writing_style: 'terse' },
+  runtimeVariables: [{ entityType: 'character', variableName: 'morale', variableType: 'number' }],
+}
+
+beforeEach(() => {
+  for (const key of Object.keys(calls) as (keyof typeof calls)[]) calls[key].length = 0
+  db.packs = [pack({ id: 'default-pack', name: 'Default', author: 'Aventuras', isDefault: true })]
+  db.runtimeVars = []
+  db.packVariables = []
+  invoke.mockReset()
+})
+
+describe('runImport — resolving the pack binding', () => {
+  it('binds to a local pack whose name and author match the file', async () => {
+    db.packs.push(pack({ id: 'local-grimdark' }))
+
+    const result = await runImport(sampleExport(namedBinding))
+
+    expect(result.success).toBe(true)
+    expect(calls.stories[0]).toMatchObject({
+      packId: 'local-grimdark',
+      customVariableValues: { writing_style: 'terse' },
+    })
+  })
+
+  it('falls back to the built-in pack when nobody is there to ask', async () => {
+    // No resolver supplied, so the headless fallback answers. Both real callers are interactive
+    // and would have prompted instead; this is what a caller with no user attached produces.
+    const result = await runImport(sampleExport(namedBinding))
+
+    expect(result.success).toBe(true)
+    expect(calls.stories[0].packId).toBe('default-pack')
+    // Nothing is recorded about the pack it wanted: the story is bound, full stop.
+    expect(calls.stories[0].settings).toEqual({ tone: 'wry' })
+    // The answers survive the fallback rather than being discarded.
+    expect(calls.stories[0].customVariableValues).toEqual({ writing_style: 'terse' })
+  })
+
+  it('does not bind silently on a name match with a different author', async () => {
+    // One candidate is guaranteed by UNIQUE(name); the right one is not.
+    db.packs.push(pack({ id: 'local-grimdark', author: 'Grace' }))
+
+    await runImport(sampleExport(namedBinding))
+
+    expect(calls.stories[0].packId).toBe('default-pack')
+  })
+
+  it('imports a file that records no pack exactly as it did before', async () => {
+    // Every file written before v1.9.0.
+    const result = await runImport(sampleExport(undefined))
+
+    expect(result.success).toBe(true)
+    expect(calls.stories[0].packId).toBe('default-pack')
+    expect(calls.stories[0].settings).toEqual({ tone: 'wry' })
+    expect(calls.stories[0].customVariableValues).toBeNull()
+  })
+
+  it('treats a malformed packBinding as a file that records no pack', async () => {
+    const result = await runImport(sampleExport({ pack: { author: 'Ada' } }))
+
+    expect(result.success).toBe(true)
+    expect(calls.stories[0].packId).toBe('default-pack')
+  })
+
+  it('leaves no story row when the resolver returns null', async () => {
+    const result = await runImport(sampleExport(namedBinding), {
+      resolvePackBinding: async () => null,
+    })
+
+    expect(result.success).toBe(false)
+    // Nothing to roll back, because nothing was written: the callback runs before the first
+    // insert. A refactor that moved it after createStory would break this silently.
+    expect(calls.stories).toEqual([])
+    expect(calls.deleted).toEqual([])
+  })
+
+  it('hands the resolver the file binding and the auto-match to pre-select', async () => {
+    db.packs.push(pack({ id: 'local-grimdark' }))
+    const seen: any[] = []
+
+    await runImport(sampleExport(namedBinding), {
+      resolvePackBinding: async (ctx) => {
+        seen.push(ctx)
+        return { packId: 'chosen-by-user', customVariableValues: { writing_style: 'lush' } }
+      },
+    })
+
+    expect(seen[0].binding.pack).toEqual({ name: 'Grimdark', author: 'Ada' })
+    expect(seen[0].match).toMatchObject({ confidence: 'exact' })
+    expect(seen[0].match.pack.id).toBe('local-grimdark')
+    // The resolver's answer wins over the match it was offered.
+    expect(calls.stories[0]).toMatchObject({
+      packId: 'chosen-by-user',
+      customVariableValues: { writing_style: 'lush' },
+    })
+  })
+})
+
+describe('decidePackPrompt — what the interactive import asks about', () => {
+  const recordsNoPack = { binding: null, match: { pack: null, confidence: 'none' } } as never
+  const matched = pack({ id: 'local-grimdark' })
+
+  /** A file naming Grimdark, resolved against the local packs with the given confidence. */
+  function file(confidence: MatchConfidence, values?: Record<string, string>) {
+    return {
+      binding: {
+        pack: { name: 'Grimdark', author: 'Ada' },
+        ...(values ? { customVariableValues: values } : {}),
+      },
+      match: { pack: confidence === 'none' ? null : matched, confidence },
+    } as never
+  }
+
+  const required = (defaultValue?: string) => [
+    { variableName: 'writing_style', isRequired: true, defaultValue },
+  ]
+
+  const device = (over: Partial<Parameters<typeof decidePackPrompt>[1]> = {}) => ({
+    legacyImportPackMapping: false,
+    packCount: 3,
+    ...over,
+  })
+
+  describe('a file that records no pack', () => {
+    it('is not asked about while the opt-in is off', () => {
+      // The compatibility promise: files written before packs were recorded import exactly as
+      // they did, with no new step in a workflow people already rely on.
+      expect(decidePackPrompt(recordsNoPack, device({ packCount: 4 }))).toEqual({ prompt: 'none' })
+    })
+
+    it('is asked about when the opt-in is on and there is more than one pack', () => {
+      expect(
+        decidePackPrompt(recordsNoPack, device({ legacyImportPackMapping: true, packCount: 2 })),
+      ).toEqual({ prompt: 'choose-pack' })
+    })
+
+    it('is not asked about on a single-pack device, opt-in or not', () => {
+      // Nothing was named, so there is no information to convey and no choice to make. Counting
+      // packs rather than looking for a custom one also covers a renamed built-in pack.
+      expect(
+        decidePackPrompt(recordsNoPack, device({ legacyImportPackMapping: true, packCount: 1 })),
+      ).toEqual({ prompt: 'none' })
+    })
+  })
+
+  describe('a file that records a pack', () => {
+    it('binds without asking on a name-and-author match', () => {
+      // The point of the whole policy: every file written from 1.9.0 on records a pack, so a
+      // confirm-on-match rule would put a modal in front of every import forever.
+      expect(decidePackPrompt(file('exact'), device())).toEqual({ prompt: 'none' })
+    })
+
+    it('binds without asking whatever the legacy opt-in says', () => {
+      for (const legacyImportPackMapping of [true, false]) {
+        expect(decidePackPrompt(file('exact'), device({ legacyImportPackMapping }))).toEqual({
+          prompt: 'none',
+        })
+      }
+    })
+
+    it('asks which pack when the name matches but the author does not', () => {
+      // One candidate, guaranteed by UNIQUE(name). Not the right one, guaranteed by nothing.
+      expect(decidePackPrompt(file('name-only'), device())).toEqual({ prompt: 'choose-pack' })
+    })
+
+    it('asks which pack when nothing matches, even on a single-pack device', () => {
+      // Unlike a legacy file, this one carries information — the pack it wants is absent — and
+      // the useful response may be to cancel and go install it.
+      expect(decidePackPrompt(file('none'), device({ packCount: 1 }))).toEqual({
+        prompt: 'choose-pack',
+      })
+    })
+  })
+
+  describe('a confident match that still needs something', () => {
+    it('asks for a required value the story has no answer for', () => {
+      // Reachable on an exact match because packs are not versioned: the recipient's copy can
+      // define a required variable the sender's did not.
+      expect(decidePackPrompt(file('exact'), device({ matchedPackVariables: required() }))).toEqual(
+        { prompt: 'fill-values', missing: ['writing_style'] },
+      )
+    })
+
+    it('does not ask when the story already answered it', () => {
+      expect(
+        decidePackPrompt(
+          file('exact', { writing_style: 'terse' }),
+          device({ matchedPackVariables: required() }),
+        ),
+      ).toEqual({ prompt: 'none' })
+    })
+
+    it('does not ask when the pack supplies a default', () => {
+      // A default is a usable value. Stopping an import to have someone retype it is exactly the
+      // prompt this design removes.
+      expect(
+        decidePackPrompt(file('exact'), device({ matchedPackVariables: required('lush') })),
+      ).toEqual({ prompt: 'none' })
+    })
+
+    it('treats a blank answer as no answer', () => {
+      expect(
+        decidePackPrompt(
+          file('exact', { writing_style: '   ' }),
+          device({ matchedPackVariables: required() }),
+        ),
+      ).toEqual({ prompt: 'fill-values', missing: ['writing_style'] })
+    })
+
+    it('ignores optional variables the story has no answer for', () => {
+      expect(
+        decidePackPrompt(
+          file('exact'),
+          device({ matchedPackVariables: [{ variableName: 'mood', isRequired: false }] }),
+        ),
+      ).toEqual({ prompt: 'none' })
+    })
+
+    it('does not consult variables when the pack itself is the question', () => {
+      // No point asking for a value belonging to a pack the user may be about to reject.
+      expect(
+        decidePackPrompt(file('name-only'), device({ matchedPackVariables: required() })),
+      ).toEqual({ prompt: 'choose-pack' })
+    })
+  })
+})
+
+describe('planPackBinding — the one policy both callers use', () => {
+  /**
+   * The library import and sync differ only in how they show a dialog. Everything up to that
+   * point lives here, so a change in policy cannot land on one path and miss the other.
+   */
+  const named = {
+    pack: { name: 'Grimdark', author: 'Ada' },
+    customVariableValues: { writing_style: 'terse' },
+  }
+
+  it('answers outright on a confident match, loading nothing for the caller to decide', async () => {
+    db.packs.push(pack({ id: 'local-grimdark' }))
+    const ctx = await buildBindingContext(named as never)
+
+    const plan = await planPackBinding(ctx, false)
+
+    expect(plan).toEqual({
+      ask: false,
+      resolution: { packId: 'local-grimdark', customVariableValues: { writing_style: 'terse' } },
+    })
+  })
+
+  it('asks which pack, with nothing locked, when the named pack is absent', async () => {
+    const ctx = await buildBindingContext(named as never)
+
+    await expect(planPackBinding(ctx, false)).resolves.toEqual({ ask: true, lockedPack: null })
+  })
+
+  it('locks the pack and names the gap when only a required value is missing', async () => {
+    const local = pack({ id: 'local-grimdark' })
+    db.packs.push(local)
+    db.packVariables = [{ variableName: 'mood', isRequired: true } as never]
+    const ctx = await buildBindingContext({ pack: named.pack } as never)
+
+    const plan = await planPackBinding(ctx, false)
+
+    expect(plan).toEqual({ ask: true, lockedPack: local, onlyVariables: ['mood'] })
+  })
+
+  it('passes the legacy opt-in through for a file that records no pack', async () => {
+    db.packs.push(pack({ id: 'local-grimdark' }))
+    const ctx = await buildBindingContext(undefined)
+
+    await expect(planPackBinding(ctx, false)).resolves.toMatchObject({ ask: false })
+    await expect(planPackBinding(ctx, true)).resolves.toEqual({ ask: true, lockedPack: null })
+  })
+})
+
+describe('runImport — re-keying entity values', () => {
+  it('makes the source device values readable under the local definition', async () => {
+    db.packs.push(pack({ id: 'local-grimdark' }))
+    db.runtimeVars = [
+      {
+        id: 'local-morale',
+        packId: 'local-grimdark',
+        entityType: 'character',
+        variableName: 'morale',
+        displayName: 'Morale',
+        variableType: 'number',
+        color: '#fff',
+        pinned: false,
+        sortOrder: 0,
+        createdAt: 0,
+      },
+    ]
+
+    await runImport(sampleExport(namedBinding))
+
+    const runtimeVars = calls.characters[0].metadata.runtimeVars as RuntimeVarsMap
+    expect(runtimeVars['local-morale']).toEqual({ variableName: 'morale', v: 7 })
+    // The source key stays, which is what makes re-binding to the original pack reversible.
+    expect(runtimeVars['src-morale']).toEqual({ variableName: 'morale', v: 7 })
+  })
+
+  it('leaves the values alone when the file carries no runtime definitions', async () => {
+    db.packs.push(pack({ id: 'local-grimdark' }))
+
+    await runImport(sampleExport({ pack: { name: 'Grimdark', author: 'Ada' } }))
+
+    expect(calls.characters[0].metadata.runtimeVars).toEqual({
+      'src-morale': { variableName: 'morale', v: 7 },
+    })
+  })
+})
+
+describe('sync — the decision is made before anything is written', () => {
+  /**
+   * What `SyncModal` does now: settle the pack up front, then hand the answer to the import.
+   * The dialog itself lives in the component; what is testable here is that a held decision is
+   * replayed rather than re-asked, and that a refusal writes nothing.
+   */
+  const syncImport = (data: unknown, held?: unknown) =>
+    runImport(data as never, {
+      skipImportedSuffix: true,
+      ...(held === undefined ? {} : { resolvePackBinding: async () => held as never }),
+    })
+
+  it('binds to a confident match without the caller having to decide', async () => {
+    db.packs.push(pack({ id: 'local-grimdark' }))
+
+    const result = await syncImport(sampleExport(namedBinding))
+
+    expect(result.success).toBe(true)
+    expect(calls.stories[0]).toMatchObject({
+      packId: 'local-grimdark',
+      customVariableValues: { writing_style: 'terse' },
+    })
+  })
+
+  it('uses the answer the caller already collected instead of asking again', async () => {
+    // SyncModal resolves before it deletes the story being replaced, so by the time the import
+    // runs the question is settled; the resolver here just returns what the user picked.
+    let asked = 0
+    await syncImport(sampleExport(namedBinding), { packId: 'picked-by-user' })
+    await runImport(sampleExport(namedBinding), {
+      resolvePackBinding: async () => {
+        asked += 1
+        return { packId: 'picked-by-user' }
+      },
+    })
+
+    expect(calls.stories[0].packId).toBe('picked-by-user')
+    expect(asked).toBe(1)
+  })
+
+  it('writes nothing when the user abandons the transfer at the pack step', async () => {
+    // The property the ordering in SyncModal exists to protect: a cancel must reach this with
+    // the story being replaced still on disk, so no row is created and none is removed.
+    const result = await syncImport(sampleExport(namedBinding), null)
+
+    expect(result.success).toBe(false)
+    expect(calls.stories).toEqual([])
+    expect(calls.deleted).toEqual([])
+  })
+
+  it('binds a legacy file to the built-in pack without consulting the opt-in', async () => {
+    await syncImport(sampleExport(undefined))
+
+    expect(calls.stories[0].packId).toBe('default-pack')
+    expect(calls.stories[0].settings).toEqual({ tone: 'wry' })
+  })
+})
+
+describe('importFromFile — where the decision happens', () => {
+  it('resolves the binding after the native read and before any write', async () => {
+    const order: string[] = []
+    invoke.mockImplementation(async (cmd: string) => {
+      order.push(cmd)
+      if (cmd === 'avt_read_light') return JSON.stringify(sampleExport(namedBinding))
+      return 0
+    })
+
+    const result = await importFromFile('/tmp/story.avt', {
+      resolvePackBinding: async () => {
+        order.push('resolve')
+        expect(calls.stories).toEqual([])
+        return null
+      },
+    })
+
+    expect(order).toEqual(['avt_read_light', 'resolve'])
+    expect(result).toEqual({ success: false })
+    // Cancelling costs no partial import: the file was read, and nothing else happened.
+    expect(calls.stories).toEqual([])
+    expect(calls.deleted).toEqual([])
+  })
+})

--- a/src/lib/services/import/packBinding.test.ts
+++ b/src/lib/services/import/packBinding.test.ts
@@ -172,6 +172,17 @@ describe('runImport — resolving the pack binding', () => {
     expect(calls.deleted).toEqual([])
   })
 
+  it('returns an import failure when pack resolution throws before the first write', async () => {
+    const result = await runImport(sampleExport(namedBinding), {
+      resolvePackBinding: async () => {
+        throw new Error('pack database unavailable')
+      },
+    })
+
+    expect(result).toMatchObject({ success: false, error: 'pack database unavailable' })
+    expect(calls.stories).toEqual([])
+  })
+
   it('hands the resolver the file binding and the auto-match to pre-select', async () => {
     db.packs.push(pack({ id: 'local-grimdark' }))
     const seen: any[] = []
@@ -569,6 +580,7 @@ describe('sync — the decision is made before anything is written', () => {
     })
 
     expect(calls.stories[0].packId).toBe('picked-by-user')
+    expect(calls.stories[1].packId).toBe('picked-by-user')
     expect(asked).toBe(1)
   })
 

--- a/src/lib/services/import/packBinding.test.ts
+++ b/src/lib/services/import/packBinding.test.ts
@@ -59,6 +59,7 @@ const {
   planPackBinding,
   buildBindingContext,
   mergeCustomVariableValues,
+  sanitizePackBinding,
 } = await import('./index')
 const { importFromFile } = await import('./native')
 
@@ -202,6 +203,43 @@ describe('runImport — resolving the pack binding', () => {
       packId: 'chosen-by-user',
       customVariableValues: { writing_style: 'lush' },
     })
+  })
+})
+
+describe('sanitizePackBinding', () => {
+  it('drops variable definitions with malformed optional fields', () => {
+    const binding = sanitizePackBinding({
+      pack: { name: 'Grimdark', author: 'Ada' },
+      variables: [
+        {
+          variableName: 'mood',
+          displayName: 'Mood',
+          variableType: 'text',
+          isRequired: false,
+          sortOrder: 0,
+          description: 3,
+        },
+        {
+          variableName: 'tone',
+          displayName: 'Tone',
+          variableType: 'enum',
+          isRequired: false,
+          sortOrder: 1,
+          enumOptions: [{ label: 'Warm', value: 'warm' }],
+        },
+      ],
+    } as never)
+
+    expect(binding?.variables).toEqual([
+      {
+        variableName: 'tone',
+        displayName: 'Tone',
+        variableType: 'enum',
+        isRequired: false,
+        sortOrder: 1,
+        enumOptions: [{ label: 'Warm', value: 'warm' }],
+      },
+    ])
   })
 })
 

--- a/src/lib/services/import/packBinding.ts
+++ b/src/lib/services/import/packBinding.ts
@@ -49,7 +49,17 @@ function isPackVariableExport(value: unknown): value is PackVariableExport {
     typeof value.displayName === 'string' &&
     ['text', 'textarea', 'enum', 'number', 'boolean'].includes(value.variableType as string) &&
     typeof value.isRequired === 'boolean' &&
-    typeof value.sortOrder === 'number'
+    typeof value.sortOrder === 'number' &&
+    (value.description === undefined || typeof value.description === 'string') &&
+    (value.defaultValue === undefined || typeof value.defaultValue === 'string') &&
+    (value.enumOptions === undefined ||
+      (Array.isArray(value.enumOptions) &&
+        value.enumOptions.every(
+          (option) =>
+            isRecord(option) &&
+            typeof option.label === 'string' &&
+            typeof option.value === 'string',
+        )))
   )
 }
 

--- a/src/lib/services/import/packBinding.ts
+++ b/src/lib/services/import/packBinding.ts
@@ -42,6 +42,17 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
+function isPackVariableExport(value: unknown): value is PackVariableExport {
+  return (
+    isRecord(value) &&
+    typeof value.variableName === 'string' &&
+    typeof value.displayName === 'string' &&
+    ['text', 'textarea', 'enum', 'number', 'boolean'].includes(value.variableType as string) &&
+    typeof value.isRequired === 'boolean' &&
+    typeof value.sortOrder === 'number'
+  )
+}
+
 /**
  * Read a file's `packBinding`, tolerating anything.
  *
@@ -66,7 +77,7 @@ export function sanitizePackBinding(
   return {
     pack: { name: pack.name, author: typeof pack.author === 'string' ? pack.author : null },
     ...(values && Object.keys(values).length > 0 ? { customVariableValues: values } : {}),
-    variables: Array.isArray(raw.variables) ? raw.variables.filter(isRecord) : [],
+    variables: Array.isArray(raw.variables) ? raw.variables.filter(isPackVariableExport) : [],
     runtimeVariables: Array.isArray(raw.runtimeVariables)
       ? raw.runtimeVariables.filter(
           (v): v is PackRuntimeVariableExport =>

--- a/src/lib/services/import/packBinding.ts
+++ b/src/lib/services/import/packBinding.ts
@@ -1,0 +1,232 @@
+/**
+ * Deciding which local pack an imported story binds to.
+ *
+ * The decision is a callback on `RunImportOptions` rather than a phase around the import, because
+ * the two callers need opposite things from it: a file import can put a dialog in front of the
+ * user, while sync must never block a transfer on a question. Same seam, different policy.
+ *
+ * Whatever answers, it answers *before* the story row is written — a story that exists bound to
+ * the wrong pack is generatable in that state, and patching it afterwards would be a second write
+ * outside the rollback window.
+ */
+
+import { database } from '$lib/services/database'
+import { DEFAULT_PACK_ID, matchPack } from '$lib/services/packs/binding'
+import type { PackMatch } from '$lib/services/packs/binding'
+import type { PresetPack } from '$lib/services/packs/types'
+import type { PackBindingExport, PackRuntimeVariableExport, PackVariableExport } from './types'
+
+/** What a resolver is told about the file it is being asked to bind. */
+export interface PackBindingContext {
+  /** The file's pack section, already sanitized. Undefined for a file that records no pack. */
+  binding: SanitizedPackBinding | null
+  /** The auto-match against the local packs, for a resolver that wants to pre-select it. */
+  match: PackMatch
+}
+
+/** What a resolver decides. */
+export interface PackBindingResolution {
+  packId: string
+  customVariableValues?: Record<string, string>
+}
+
+/** A `packBinding` section with every field checked, so downstream code can trust its shape. */
+export interface SanitizedPackBinding {
+  pack: { name: string; author: string | null }
+  customVariableValues?: Record<string, string>
+  variables: PackVariableExport[]
+  runtimeVariables: PackRuntimeVariableExport[]
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Read a file's `packBinding`, tolerating anything.
+ *
+ * `validateExport` deliberately lets a malformed binding through: the field decides which
+ * templates narrate the story, and rejecting the file over it would cost the user the story
+ * itself. So a binding that does not parse degrades here to "records no pack" and takes the
+ * legacy path.
+ */
+export function sanitizePackBinding(
+  raw: PackBindingExport | undefined,
+): SanitizedPackBinding | null {
+  if (!isRecord(raw)) return null
+  const pack = raw.pack
+  if (!isRecord(pack) || typeof pack.name !== 'string' || !pack.name.trim()) return null
+
+  const values = isRecord(raw.customVariableValues)
+    ? (Object.fromEntries(
+        Object.entries(raw.customVariableValues).filter(([, v]) => typeof v === 'string'),
+      ) as Record<string, string>)
+    : undefined
+
+  return {
+    pack: { name: pack.name, author: typeof pack.author === 'string' ? pack.author : null },
+    ...(values && Object.keys(values).length > 0 ? { customVariableValues: values } : {}),
+    variables: Array.isArray(raw.variables) ? raw.variables.filter(isRecord) : [],
+    runtimeVariables: Array.isArray(raw.runtimeVariables)
+      ? raw.runtimeVariables.filter(
+          (v): v is PackRuntimeVariableExport =>
+            isRecord(v) && typeof v.variableName === 'string' && typeof v.entityType === 'string',
+        )
+      : [],
+  }
+}
+
+/** Build the context a resolver is handed, matching the file's pack against the local ones. */
+export async function buildBindingContext(
+  raw: PackBindingExport | undefined,
+): Promise<PackBindingContext> {
+  const binding = sanitizePackBinding(raw)
+  const match = await matchPack(binding?.pack ?? null)
+  return { binding, match }
+}
+
+/** The subset of a pack variable definition the prompt decision needs. */
+export interface RequiredVariableDef {
+  variableName: string
+  isRequired: boolean
+  defaultValue?: string
+}
+
+/**
+ * Required variables of the target pack that the story has no answer for.
+ *
+ * A pack-supplied default counts as an answer: the variable has a usable value without anyone
+ * being asked, and interrupting an import to retype a default is the kind of prompt this design
+ * exists to remove. Only a required variable with neither a story answer nor a default is a
+ * genuine hole.
+ *
+ * This is reachable on an otherwise-confident match because packs are not versioned — the
+ * recipient's copy of "the same" pack can define a required variable the sender's did not.
+ */
+export function unansweredRequiredVariables(
+  variables: RequiredVariableDef[],
+  values: Record<string, string> | undefined,
+): string[] {
+  return variables
+    .filter((v) => v.isRequired)
+    .filter((v) => !values?.[v.variableName]?.trim() && !v.defaultValue?.trim())
+    .map((v) => v.variableName)
+}
+
+/**
+ * What, if anything, an interactive import needs to ask about this file.
+ *
+ * - `none` — bind and get on with it.
+ * - `choose-pack` — which pack, because the match is uncertain or absent.
+ * - `fill-values` — the pack is settled; only these required values are missing.
+ */
+export type PackPromptDecision =
+  { prompt: 'none' } | { prompt: 'choose-pack' } | { prompt: 'fill-values'; missing: string[] }
+
+/**
+ * Decide what an interactive import asks the user about this file.
+ *
+ * A name+author match binds without a word. Every file written from 1.9.0 on records a pack (the
+ * wizard always sets `pack_id`), so a confirm-on-match rule would put a modal in front of every
+ * import forever — including re-importing one's own export, where no other answer exists. A
+ * prompt whose only sensible answer is "yes" teaches people to dismiss prompts.
+ *
+ * Anything less than a confident match *is* a question: a name-only hit means one candidate, not
+ * the right one, and no hit means the pack the story wants is not here — worth saying even when
+ * the user has a single pack to accept, because the useful response may be to cancel and go
+ * install it. A legacy file, having named nothing, has no such information to convey, which is
+ * why the pack-count gate applies there and not here.
+ *
+ * A pure decision rather than a branch inside `runImport`: the pipeline keeps one rule ("ask the
+ * resolver"), and the UI decides what it has to ask. Sync never calls this at all.
+ */
+export function decidePackPrompt(
+  ctx: PackBindingContext,
+  device: {
+    legacyImportPackMapping: boolean
+    packCount: number
+    /** The matched pack's variables. Only consulted on a confident match. */
+    matchedPackVariables?: RequiredVariableDef[]
+  },
+): PackPromptDecision {
+  // A file that records no pack: today's silent path, unless the Labs opt-in is on and the
+  // device has a choice worth offering.
+  if (!ctx.binding) {
+    return device.legacyImportPackMapping && device.packCount > 1
+      ? { prompt: 'choose-pack' }
+      : { prompt: 'none' }
+  }
+
+  if (ctx.match.confidence !== 'exact' || !ctx.match.pack) return { prompt: 'choose-pack' }
+
+  const missing = unansweredRequiredVariables(
+    device.matchedPackVariables ?? [],
+    ctx.binding.customVariableValues,
+  )
+  return missing.length > 0 ? { prompt: 'fill-values', missing } : { prompt: 'none' }
+}
+
+/**
+ * Everything a caller needs to act on, with none of the deciding left to do.
+ *
+ * `ask: false` carries the answer outright; `ask: true` carries what the dialog should be
+ * configured with. The split exists because the two hosts differ only in *how* they show a
+ * dialog — each owns its own component state — and not at all in when or what to show.
+ */
+export type PackPromptPlan =
+  | { ask: false; resolution: PackBindingResolution }
+  | { ask: true; lockedPack: PresetPack | null; onlyVariables?: string[] }
+
+/**
+ * Decide the binding, loading whatever the decision needs.
+ *
+ * Both interactive callers — the library's file import and sync — go through this, so the policy
+ * lives in one place and the components keep only their own dialog plumbing. `database` is
+ * reached from here rather than from the components for the same reason.
+ */
+export async function planPackBinding(
+  ctx: PackBindingContext,
+  legacyImportPackMapping: boolean,
+): Promise<PackPromptPlan> {
+  const matched = ctx.match.pack
+  const [packs, matchedPackVariables] = await Promise.all([
+    database.getAllPacks(),
+    matched ? database.getPackVariables(matched.id) : Promise.resolve(undefined),
+  ])
+
+  const decision = decidePackPrompt(ctx, {
+    legacyImportPackMapping,
+    packCount: packs.length,
+    matchedPackVariables,
+  })
+
+  if (decision.prompt === 'none') return { ask: false, resolution: await autoMatchPackBinding(ctx) }
+
+  // On `fill-values` the pack is settled; only the gap is up for discussion.
+  return decision.prompt === 'fill-values'
+    ? { ask: true, lockedPack: matched, onlyVariables: decision.missing }
+    : { ask: true, lockedPack: null }
+}
+
+/**
+ * The headless fallback, used when a caller supplies no resolver.
+ *
+ * Both real callers are interactive and ask when `decidePackPrompt` says to, so this only runs
+ * where there is nobody to ask. It binds on a confident match and otherwise falls back to the
+ * built-in pack — a usable story bound by default, which is the most a caller with no user
+ * attached can honestly produce.
+ *
+ * A name-only match does not bind silently: `preset_packs` has `UNIQUE(name)`, so one candidate
+ * means unambiguous, not right, and two people can both call a pack "Grimdark".
+ */
+export async function autoMatchPackBinding(
+  ctx: PackBindingContext,
+): Promise<PackBindingResolution> {
+  const values = ctx.binding?.customVariableValues
+
+  if (ctx.match.confidence === 'exact' && ctx.match.pack) {
+    return { packId: ctx.match.pack.id, ...(values ? { customVariableValues: values } : {}) }
+  }
+
+  return { packId: DEFAULT_PACK_ID, ...(values ? { customVariableValues: values } : {}) }
+}

--- a/src/lib/services/import/packBinding.ts
+++ b/src/lib/services/import/packBinding.ts
@@ -92,6 +92,49 @@ export interface RequiredVariableDef {
   defaultValue?: string
 }
 
+/** Variable names cross devices as user-authored strings, so compare them consistently. */
+function normalizeVariableName(value: string): string {
+  return value.trim().toLowerCase()
+}
+
+/** Find a story value by the same case-insensitive, trimmed name used for pack matching. */
+export function customVariableValue(
+  values: Record<string, string> | undefined,
+  variableName: string,
+): string | undefined {
+  if (!values) return undefined
+  if (Object.prototype.hasOwnProperty.call(values, variableName)) return values[variableName]
+
+  const wanted = normalizeVariableName(variableName)
+  return Object.entries(values).find(([name]) => normalizeVariableName(name) === wanted)?.[1]
+}
+
+/**
+ * Add values under the selected pack's canonical spelling while retaining the source spelling.
+ * Keeping both makes a later re-bind reversible, just like runtime-variable re-keying.
+ */
+export function canonicalizeCustomVariableValues(
+  values: Record<string, string> | undefined,
+  variables: Array<{ variableName: string }>,
+): Record<string, string> {
+  const canonical = { ...(values ?? {}) }
+  for (const variable of variables) {
+    if (Object.prototype.hasOwnProperty.call(canonical, variable.variableName)) continue
+    const value = customVariableValue(values, variable.variableName)
+    if (value !== undefined) canonical[variable.variableName] = value
+  }
+  return canonical
+}
+
+/** Persist imported answers plus fields the user actually edited, never untouched pack defaults. */
+export function mergeCustomVariableValues(
+  fileValues: Record<string, string> | undefined,
+  variables: Array<{ variableName: string }>,
+  editedValues: Record<string, string>,
+): Record<string, string> {
+  return { ...canonicalizeCustomVariableValues(fileValues, variables), ...editedValues }
+}
+
 /**
  * Required variables of the target pack that the story has no answer for.
  *
@@ -109,7 +152,7 @@ export function unansweredRequiredVariables(
 ): string[] {
   return variables
     .filter((v) => v.isRequired)
-    .filter((v) => !values?.[v.variableName]?.trim() && !v.defaultValue?.trim())
+    .filter((v) => !customVariableValue(values, v.variableName)?.trim() && !v.defaultValue?.trim())
     .map((v) => v.variableName)
 }
 
@@ -200,7 +243,12 @@ export async function planPackBinding(
     matchedPackVariables,
   })
 
-  if (decision.prompt === 'none') return { ask: false, resolution: await autoMatchPackBinding(ctx) }
+  if (decision.prompt === 'none') {
+    return {
+      ask: false,
+      resolution: await autoMatchPackBinding(ctx, matchedPackVariables),
+    }
+  }
 
   // On `fill-values` the pack is settled; only the gap is up for discussion.
   return decision.prompt === 'fill-values'
@@ -221,12 +269,14 @@ export async function planPackBinding(
  */
 export async function autoMatchPackBinding(
   ctx: PackBindingContext,
+  knownTargetVariables?: Array<{ variableName: string }>,
 ): Promise<PackBindingResolution> {
   const values = ctx.binding?.customVariableValues
+  const packId =
+    ctx.match.confidence === 'exact' && ctx.match.pack ? ctx.match.pack.id : DEFAULT_PACK_ID
+  if (!values) return { packId }
 
-  if (ctx.match.confidence === 'exact' && ctx.match.pack) {
-    return { packId: ctx.match.pack.id, ...(values ? { customVariableValues: values } : {}) }
-  }
-
-  return { packId: DEFAULT_PACK_ID, ...(values ? { customVariableValues: values } : {}) }
+  const targetVariables = knownTargetVariables ?? (await database.getPackVariables(packId))
+  const canonicalValues = canonicalizeCustomVariableValues(values, targetVariables)
+  return { packId, customVariableValues: canonicalValues }
 }

--- a/src/lib/services/import/structure.ts
+++ b/src/lib/services/import/structure.ts
@@ -7,7 +7,6 @@
 import { database } from '$lib/services/database'
 import type { CreateStoryInput } from '$lib/services/database'
 import type {
-  Story,
   StoryEntry,
   Character,
   Location,

--- a/src/lib/services/import/structure.ts
+++ b/src/lib/services/import/structure.ts
@@ -5,6 +5,7 @@
  */
 
 import { database } from '$lib/services/database'
+import type { CreateStoryInput } from '$lib/services/database'
 import type {
   Story,
   StoryEntry,
@@ -18,8 +19,8 @@ import type {
   WorldStateDelta,
 } from '$lib/types'
 import type { AventuraExport, IdMaps, PackRuntimeVariableExport } from './types'
-import type { RuntimeVariable, RuntimeEntityType } from '$lib/services/packs/types'
-import { remapRuntimeVars } from '$lib/services/packs/binding'
+import { remapRuntimeVars } from '$lib/services/packs'
+import type { RuntimeVariable, RuntimeEntityType } from '$lib/services/packs'
 import type { PackBindingResolution } from './packBinding'
 import { createMappers } from './idMaps'
 
@@ -71,10 +72,7 @@ export async function importStructure(
       packBinding?.targetRuntimeVars,
     ) as T
 
-  const importedStory: Omit<Story, 'createdAt' | 'updatedAt'> & {
-    packId?: string | null
-    customVariableValues?: Record<string, string> | null
-  } = {
+  const importedStory: CreateStoryInput = {
     id: newStoryId,
     title: skipImportedSuffix ? data.story.title : `${data.story.title} (Imported)`,
     description: data.story.description,

--- a/src/lib/services/import/structure.ts
+++ b/src/lib/services/import/structure.ts
@@ -178,17 +178,24 @@ export async function importStructure(
         characters: (previousState?.characters ?? []).map((c) => ({
           ...c,
           id: remapEntityId(c.id),
+          metadata: remapMetadata(c.metadata, 'character'),
         })),
-        locations: (previousState?.locations ?? []).map((l) => ({ ...l, id: remapEntityId(l.id) })),
+        locations: (previousState?.locations ?? []).map((l) => ({
+          ...l,
+          id: remapEntityId(l.id),
+          metadata: remapMetadata(l.metadata, 'location'),
+        })),
         items: (previousState?.items ?? []).map((i) => ({
           ...i,
           id: remapEntityId(i.id),
+          metadata: remapMetadata(i.metadata, 'item'),
           // 'inventory' is a sentinel, not an id — same rule as the item loop below.
           location: i.location === 'inventory' ? 'inventory' : remapEntityId(i.location),
         })),
         storyBeats: (previousState?.storyBeats ?? []).map((b) => ({
           ...b,
           id: remapEntityId(b.id),
+          metadata: remapMetadata(b.metadata, 'story_beat'),
         })),
         currentLocationId: previousState?.currentLocationId
           ? remapEntityId(previousState.currentLocationId)
@@ -365,6 +372,7 @@ export async function importStructure(
       id: remapEntityId(char.id),
       storyId: newStoryId,
       branchId: mapBranchId(char.branchId ?? null),
+      metadata: remapMetadata(char.metadata, 'character'),
     })
     const remapLocation = (loc: Location): Location => ({
       ...loc,
@@ -372,6 +380,7 @@ export async function importStructure(
       storyId: newStoryId,
       branchId: mapBranchId(loc.branchId ?? null),
       connections: loc.connections.map((id) => oldToNewId.get(id) ?? id),
+      metadata: remapMetadata(loc.metadata, 'location'),
     })
     const remapItem = (item: Item): Item => ({
       ...item,
@@ -382,12 +391,14 @@ export async function importStructure(
         item.location === 'inventory'
           ? 'inventory'
           : (oldToNewId.get(item.location) ?? item.location),
+      metadata: remapMetadata(item.metadata, 'item'),
     })
     const remapStoryBeat = (beat: StoryBeat): StoryBeat => ({
       ...beat,
       id: remapEntityId(beat.id),
       storyId: newStoryId,
       branchId: mapBranchId(beat.branchId ?? null),
+      metadata: remapMetadata(beat.metadata, 'story_beat'),
     })
     const remapChapter = (chapter: Chapter): Chapter => ({
       ...chapter,

--- a/src/lib/services/import/structure.ts
+++ b/src/lib/services/import/structure.ts
@@ -17,12 +17,26 @@ import type {
   Branch,
   WorldStateDelta,
 } from '$lib/types'
-import type { AventuraExport, IdMaps } from './types'
+import type { AventuraExport, IdMaps, PackRuntimeVariableExport } from './types'
+import type { RuntimeVariable, RuntimeEntityType } from '$lib/services/packs/types'
+import { remapRuntimeVars } from '$lib/services/packs/binding'
+import type { PackBindingResolution } from './packBinding'
 import { createMappers } from './idMaps'
+
+/** The resolved binding, plus both sides' runtime variable definitions for the re-keying. */
+export interface StoryPackBinding extends PackBindingResolution {
+  sourceRuntimeVars: PackRuntimeVariableExport[]
+  targetRuntimeVars: RuntimeVariable[]
+}
 
 export interface ImportStructureOptions {
   /** Sync keeps the original title; a user-facing import marks the copy. */
   skipImportedSuffix?: boolean
+  /**
+   * Which pack the story binds to, and how to re-key its entities' values for that pack. Absent
+   * only in tests that predate the binding step; the pipeline always supplies it.
+   */
+  packBinding?: StoryPackBinding
   /**
    * Fired the moment the story row exists, before the rest of the structure is written. Lets a
    * caller start treating the import as rollback-eligible without waiting for this whole
@@ -42,9 +56,25 @@ export async function importStructure(
 ): Promise<void> {
   const { newStoryId, oldToNewId, branchIdMap, checkpointIdMap } = maps
   const { mapBranchId, mapEntryId, mapOverridesId, remapEntityId } = createMappers(maps)
-  const { skipImportedSuffix = false, onStoryCreated } = options
+  const { skipImportedSuffix = false, packBinding, onStoryCreated } = options
 
-  const importedStory: Omit<Story, 'createdAt' | 'updatedAt'> = {
+  /**
+   * Re-key one entity's runtime variable values for the pack the story is being bound to, before
+   * its row is inserted. In memory and in passing: no extra pass over the rows, and nothing new
+   * inside the rollback window.
+   */
+  const remapMetadata = <T>(metadata: T, entityType: RuntimeEntityType): T =>
+    remapRuntimeVars(
+      metadata as Record<string, unknown> | null,
+      entityType,
+      packBinding?.sourceRuntimeVars,
+      packBinding?.targetRuntimeVars,
+    ) as T
+
+  const importedStory: Omit<Story, 'createdAt' | 'updatedAt'> & {
+    packId?: string | null
+    customVariableValues?: Record<string, string> | null
+  } = {
     id: newStoryId,
     title: skipImportedSuffix ? data.story.title : `${data.story.title} (Imported)`,
     description: data.story.description,
@@ -58,6 +88,8 @@ export async function importStructure(
     timeTracker: data.story.timeTracker ?? null, // Restore time tracker from export
     currentBranchId: null, // Set after branch import (if available)
     currentBgImage: data.story.currentBgImage || null,
+    packId: packBinding?.packId ?? null,
+    customVariableValues: packBinding?.customVariableValues ?? null,
   }
 
   await database.createStory(importedStory)
@@ -206,7 +238,7 @@ export async function importStructure(
       relationship: char.relationship,
       traits: char.traits,
       status: char.status,
-      metadata: char.metadata,
+      metadata: remapMetadata(char.metadata, 'character'),
       visualDescriptors: char.visualDescriptors ?? {},
       portrait: char.portrait ?? null,
       branchId: mapBranchId(char.branchId ?? null),
@@ -232,7 +264,7 @@ export async function importStructure(
       visited: loc.visited,
       current: loc.current,
       connections: loc.connections.map((c) => oldToNewId.get(c) ?? c),
-      metadata: loc.metadata,
+      metadata: remapMetadata(loc.metadata, 'location'),
       branchId: mapBranchId(loc.branchId ?? null),
       overridesId: mapOverridesId(loc.overridesId),
       deleted: loc.deleted ?? false,
@@ -257,7 +289,7 @@ export async function importStructure(
       quantity: item.quantity,
       equipped: item.equipped,
       location: mappedLocation,
-      metadata: item.metadata,
+      metadata: remapMetadata(item.metadata, 'item'),
       branchId: mapBranchId(item.branchId ?? null),
       overridesId: mapOverridesId(item.overridesId),
       deleted: item.deleted ?? false,
@@ -279,7 +311,7 @@ export async function importStructure(
       status: beat.status,
       triggeredAt: beat.triggeredAt,
       resolvedAt: beat.resolvedAt ?? null,
-      metadata: beat.metadata,
+      metadata: remapMetadata(beat.metadata, 'story_beat'),
       branchId: mapBranchId(beat.branchId ?? null),
       overridesId: mapOverridesId(beat.overridesId),
       deleted: beat.deleted ?? false,

--- a/src/lib/services/import/types.ts
+++ b/src/lib/services/import/types.ts
@@ -20,6 +20,57 @@ import type {
   PersistentStyleReviewState,
   EmbeddedImage,
 } from '$lib/types'
+import type {
+  CustomVariableType,
+  EnumOption,
+  RuntimeEntityType,
+  RuntimeVariableType,
+} from '$lib/services/packs/types'
+
+/**
+ * A pack variable definition as it travels in a `.avt`.
+ *
+ * Deliberately id-less: `CustomVariable.id` and `packId` are assigned per device, so carrying
+ * them off-device would only invite someone to match on them later. Matching is by name.
+ */
+export interface PackVariableExport {
+  variableName: string
+  displayName: string
+  description?: string
+  variableType: CustomVariableType
+  isRequired: boolean
+  sortOrder: number
+  defaultValue?: string
+  enumOptions?: EnumOption[]
+}
+
+/** A pack runtime-variable definition as it travels in a `.avt`. Id-less, for the same reason. */
+export interface PackRuntimeVariableExport {
+  entityType: RuntimeEntityType
+  variableName: string
+  displayName: string
+  description?: string
+  variableType: RuntimeVariableType
+  defaultValue?: string
+  minValue?: number
+  maxValue?: number
+  enumOptions?: EnumOption[]
+}
+
+/**
+ * What a story file records about the prompt pack it was written with.
+ *
+ * Enough for a recipient to re-establish the binding — identity, the story's own answers, and
+ * the shape of the variables those answers belong to — and deliberately *not* the pack's
+ * template content. Templates stay owned by the pack as installed on the device that generates,
+ * so receiving a story can never fork the recipient's packs behind their back.
+ */
+export interface PackBindingExport {
+  pack: { name: string; author: string | null }
+  customVariableValues?: Record<string, string>
+  variables?: PackVariableExport[]
+  runtimeVariables?: PackRuntimeVariableExport[]
+}
 
 export interface AventuraExport {
   version: string
@@ -38,6 +89,7 @@ export interface AventuraExport {
   branches?: Branch[] // Added in v1.6.0
   chapters?: Chapter[] // Added in v1.7.0
   currentBgImage?: string | null // Added in v1.8.0
+  packBinding?: PackBindingExport // Added in v1.9.0
 }
 
 /**
@@ -58,8 +110,10 @@ export interface AventuraExport {
  * - v1.6.0 Added checkpoints and branches
  * - v1.7.0 Added chapters (memory system)
  * - v1.8.0 Added currentBgImage (carried on the story record)
+ * - v1.9.0 Added packBinding (prompt pack identity, the story's variable answers, and the
+ *          pack's variable definitions — never its template content)
  */
-export const EXPORT_FORMAT_VERSION = '1.8.0'
+export const EXPORT_FORMAT_VERSION = '1.9.0'
 
 export interface ImportResult {
   success: boolean

--- a/src/lib/services/import/validate.test.ts
+++ b/src/lib/services/import/validate.test.ts
@@ -123,6 +123,16 @@ describe('logVersionCompatibilityWarnings', () => {
     expect(warn).not.toHaveBeenCalled()
   })
 
+  it('does not warn about a missing pack binding when an older sync payload carries one', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    logVersionCompatibilityWarnings({
+      version: '1.7.0',
+      packBinding: { pack: { name: 'Grimdark', author: 'Ada' } },
+    })
+
+    expect(warn.mock.calls.map(String).join('\n')).not.toContain('prompt pack information')
+  })
+
   it('warns about every feature for the oldest possible file', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     logVersionCompatibilityWarnings('1.0.0')

--- a/src/lib/services/import/validate.test.ts
+++ b/src/lib/services/import/validate.test.ts
@@ -133,6 +133,13 @@ describe('logVersionCompatibilityWarnings', () => {
     expect(warn.mock.calls.map(String).join('\n')).not.toContain('prompt pack information')
   })
 
+  it('warns when an older payload carries a malformed pack binding', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    logVersionCompatibilityWarnings({ version: '1.7.0', packBinding: {} as never })
+
+    expect(warn.mock.calls.map(String).join('\n')).toContain('prompt pack information')
+  })
+
   it('warns about every feature for the oldest possible file', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     logVersionCompatibilityWarnings('1.0.0')

--- a/src/lib/services/import/validate.test.ts
+++ b/src/lib/services/import/validate.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { compareVersions, validateExport, logVersionCompatibilityWarnings } from './validate'
+import { EXPORT_FORMAT_VERSION } from './types'
 import type { AventuraExport } from './types'
 
 /**
@@ -77,6 +78,23 @@ describe('validateExport', () => {
     const message = validateExport(validExport({ entries: [] }))
     expect(message).toContain('no story entries')
   })
+
+  it('accepts a file that records no pack at all', () => {
+    // Every file written before v1.9.0. It must stay an ordinary import, not an invalid file.
+    expect(validateExport(validExport({ packBinding: undefined }))).toBeNull()
+  })
+
+  it.each([
+    ['a non-object', 'not-a-binding'],
+    ['no pack identity', {}],
+    ['a nameless pack', { pack: {} }],
+    ['definitions of the wrong type', { pack: { name: 'P', author: 'A' }, variables: 'nope' }],
+  ])('accepts a file whose packBinding is %s', (_label, packBinding) => {
+    // packBinding is advisory: a malformed one degrades to "unknown pack" downstream, where the
+    // user picks (or the auto-matcher falls back). Rejecting the file would cost the user their
+    // whole story over a field that only decides which templates narrate it.
+    expect(validateExport(validExport({ packBinding } as Partial<AventuraExport>))).toBeNull()
+  })
 })
 
 describe('logVersionCompatibilityWarnings', () => {
@@ -85,14 +103,17 @@ describe('logVersionCompatibilityWarnings', () => {
   it('warns once per feature the file predates', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     logVersionCompatibilityWarnings('1.5.0')
-    // Predates 1.6.0, 1.7.0 and 1.8.0; carries everything up to and including 1.5.0.
-    expect(warn).toHaveBeenCalledTimes(3)
+    // Predates 1.6.0, 1.7.0, 1.8.0 and 1.9.0; carries everything up to and including 1.5.0.
+    expect(warn).toHaveBeenCalledTimes(4)
     expect(warn.mock.calls.map(String).join('\n')).toContain('branching data')
   })
 
   it('says nothing about a file at the current format version', () => {
+    // Written against the constant, not a literal: a version bump whose FEATURE_HISTORY arm was
+    // forgotten makes this app stamp its own exports as older than their contents, so every
+    // re-import of a file it just wrote warns about a feature the file actually carries.
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    logVersionCompatibilityWarnings('1.8.0')
+    logVersionCompatibilityWarnings(EXPORT_FORMAT_VERSION)
     expect(warn).not.toHaveBeenCalled()
   })
 
@@ -105,6 +126,6 @@ describe('logVersionCompatibilityWarnings', () => {
   it('warns about every feature for the oldest possible file', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     logVersionCompatibilityWarnings('1.0.0')
-    expect(warn).toHaveBeenCalledTimes(8)
+    expect(warn).toHaveBeenCalledTimes(9)
   })
 })

--- a/src/lib/services/import/validate.ts
+++ b/src/lib/services/import/validate.ts
@@ -58,6 +58,10 @@ const FEATURE_HISTORY: { version: string; warning: string }[] = [
     version: '1.8.0',
     warning: 'current background image (v1.8.0). Current background image will not be restored.',
   },
+  {
+    version: '1.9.0',
+    warning: 'prompt pack information (v1.9.0). The story will be bound to the built-in pack.',
+  },
 ]
 
 /** Log warnings for imports from older versions that may be missing features. */

--- a/src/lib/services/import/validate.ts
+++ b/src/lib/services/import/validate.ts
@@ -1,6 +1,7 @@
 /** Shape checks and version warnings for an incoming `.avt`. */
 
 import type { AventuraExport } from './types'
+import { sanitizePackBinding } from './packBinding'
 
 /**
  * Compare semantic versions. Returns negative if a < b, 0 if equal, positive if a > b.
@@ -70,7 +71,7 @@ export function logVersionCompatibilityWarnings(
 ): void {
   // Keep the version-only form for callers that cannot inspect the payload yet.
   const importVersion = typeof data === 'string' ? data : data.version
-  const hasPackBinding = typeof data !== 'string' && !!data.packBinding
+  const hasPackBinding = typeof data !== 'string' && sanitizePackBinding(data.packBinding) !== null
   for (const { version, warning } of FEATURE_HISTORY) {
     if (compareVersions(importVersion, version) < 0) {
       if (version === '1.9.0' && hasPackBinding) continue

--- a/src/lib/services/import/validate.ts
+++ b/src/lib/services/import/validate.ts
@@ -65,9 +65,15 @@ const FEATURE_HISTORY: { version: string; warning: string }[] = [
 ]
 
 /** Log warnings for imports from older versions that may be missing features. */
-export function logVersionCompatibilityWarnings(importVersion: string): void {
+export function logVersionCompatibilityWarnings(
+  data: Pick<AventuraExport, 'version' | 'packBinding'> | string,
+): void {
+  // Keep the version-only form for callers that cannot inspect the payload yet.
+  const importVersion = typeof data === 'string' ? data : data.version
+  const hasPackBinding = typeof data !== 'string' && !!data.packBinding
   for (const { version, warning } of FEATURE_HISTORY) {
     if (compareVersions(importVersion, version) < 0) {
+      if (version === '1.9.0' && hasPackBinding) continue
       console.warn(`[Import] File from v${importVersion} predates ${warning}`)
     }
   }

--- a/src/lib/services/packs/binding.test.ts
+++ b/src/lib/services/packs/binding.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Pack binding: matching a story's recorded pack to a local one, and carrying the story's
+ * per-entity values across when the binding moves.
+ *
+ * The properties worth pinning are the ones that lose user data when they break: a name-only
+ * match must never read as certain, and a remap must never drop a key.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { PresetPack, RuntimeVarsMap } from './types'
+
+const db = { packs: [] as PresetPack[] }
+
+vi.mock('$lib/services/database', () => ({
+  database: { getAllPacks: vi.fn(async () => db.packs) },
+}))
+
+const { matchPack, remapRuntimeVars } = await import('./binding')
+
+function pack(overrides: Partial<PresetPack>): PresetPack {
+  return {
+    id: 'p1',
+    name: 'Grimdark',
+    description: null,
+    author: 'Ada',
+    isDefault: false,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  db.packs = []
+})
+
+describe('matchPack', () => {
+  it('matches on name and author, ignoring case and surrounding space', () => {
+    db.packs = [pack({ id: 'local-1' })]
+    return expect(matchPack({ name: '  grimdark ', author: 'ADA' })).resolves.toEqual({
+      pack: db.packs[0],
+      confidence: 'exact',
+    })
+  })
+
+  it('reports a name hit with a different author as name-only, not exact', async () => {
+    // UNIQUE(name) means there is exactly one candidate, which says the match is unambiguous,
+    // not that it is the right pack. Binding silently here narrates the story through a
+    // stranger's templates.
+    db.packs = [pack({ id: 'local-1', author: 'Grace' })]
+
+    const match = await matchPack({ name: 'Grimdark', author: 'Ada' })
+
+    expect(match.confidence).toBe('name-only')
+    expect(match.pack?.id).toBe('local-1')
+  })
+
+  it('treats a null author and an empty one as the same value', async () => {
+    db.packs = [pack({ id: 'local-1', author: null })]
+    await expect(matchPack({ name: 'Grimdark', author: '' })).resolves.toMatchObject({
+      confidence: 'exact',
+    })
+    await expect(matchPack({ name: 'Grimdark', author: null })).resolves.toMatchObject({
+      confidence: 'exact',
+    })
+  })
+
+  it('asserts nothing when no local pack carries the name', async () => {
+    db.packs = [pack({ id: 'local-1', name: 'Cosy' })]
+    await expect(matchPack({ name: 'Grimdark', author: 'Ada' })).resolves.toEqual({
+      pack: null,
+      confidence: 'none',
+    })
+  })
+
+  it('asserts nothing for a file with no usable pack identity', async () => {
+    db.packs = [pack({})]
+    await expect(matchPack(null)).resolves.toEqual({ pack: null, confidence: 'none' })
+    await expect(matchPack({ name: '   ', author: null })).resolves.toEqual({
+      pack: null,
+      confidence: 'none',
+    })
+  })
+
+  it('uses a caller-supplied pack list rather than loading one', async () => {
+    db.packs = [pack({ id: 'from-db' })]
+    const match = await matchPack({ name: 'Grimdark', author: 'Ada' }, [pack({ id: 'passed-in' })])
+    expect(match.pack?.id).toBe('passed-in')
+  })
+})
+
+describe('remapRuntimeVars', () => {
+  const sourceDefs = [
+    { entityType: 'character' as const, variableName: 'morale' },
+    { entityType: 'character' as const, variableName: 'secret' },
+  ]
+  const targetDefs = [
+    { id: 'local-morale', entityType: 'character' as const, variableName: 'morale' },
+  ]
+
+  function metadataWith(runtimeVars: RuntimeVarsMap) {
+    return { runtimeVars, notes: 'kept' }
+  }
+
+  it('adds the local key while keeping the source key', () => {
+    const metadata = metadataWith({ 'src-morale': { variableName: 'morale', v: 7 } })
+
+    const result = remapRuntimeVars(metadata, 'character', sourceDefs, targetDefs)
+
+    expect(result.runtimeVars).toEqual({
+      'src-morale': { variableName: 'morale', v: 7 },
+      'local-morale': { variableName: 'morale', v: 7 },
+    })
+    expect(result.notes).toBe('kept')
+  })
+
+  it('keeps a value whose name the target pack does not define, and adds no key for it', () => {
+    const metadata = metadataWith({
+      'src-morale': { variableName: 'morale', v: 7 },
+      'src-secret': { variableName: 'secret', v: 'hidden' },
+    })
+
+    const result = remapRuntimeVars(metadata, 'character', sourceDefs, targetDefs)
+
+    expect(result.runtimeVars).toEqual({
+      'src-morale': { variableName: 'morale', v: 7 },
+      'src-secret': { variableName: 'secret', v: 'hidden' },
+      'local-morale': { variableName: 'morale', v: 7 },
+    })
+  })
+
+  it('makes the original values readable again when the story is re-bound to the source pack', () => {
+    // The round trip the spec requires: A -> B -> A must present what A presented, which only
+    // holds because the first remap left A's key alone.
+    const packA = [{ id: 'a-morale', entityType: 'character' as const, variableName: 'morale' }]
+    const packB = [{ id: 'b-morale', entityType: 'character' as const, variableName: 'morale' }]
+    const start = metadataWith({ 'a-morale': { variableName: 'morale', v: 7 } })
+
+    const onB = remapRuntimeVars(start, 'character', sourceDefs, packB)
+    const backOnA = remapRuntimeVars(onB, 'character', sourceDefs, packA)
+
+    expect((backOnA.runtimeVars as RuntimeVarsMap)['a-morale']).toEqual({
+      variableName: 'morale',
+      v: 7,
+    })
+    expect((backOnA.runtimeVars as RuntimeVarsMap)['b-morale']).toEqual({
+      variableName: 'morale',
+      v: 7,
+    })
+  })
+
+  it('does not re-key a value onto a definition for a different entity type', () => {
+    const locationDefs = [
+      { id: 'local-loc-morale', entityType: 'location' as const, variableName: 'morale' },
+    ]
+    const metadata = metadataWith({ 'src-morale': { variableName: 'morale', v: 7 } })
+
+    const result = remapRuntimeVars(metadata, 'character', sourceDefs, locationDefs)
+
+    expect(result.runtimeVars).toEqual({ 'src-morale': { variableName: 'morale', v: 7 } })
+  })
+
+  it.each([
+    ['there are no source definitions', undefined, targetDefs],
+    ['there are no target definitions', sourceDefs, undefined],
+  ])('returns the metadata untouched when %s', (_label, source, target) => {
+    const metadata = metadataWith({ 'src-morale': { variableName: 'morale', v: 7 } })
+    expect(remapRuntimeVars(metadata, 'character', source, target)).toBe(metadata)
+  })
+
+  it('returns the metadata untouched when the entity holds no values', () => {
+    const metadata = { runtimeVars: {} }
+    expect(remapRuntimeVars(metadata, 'character', sourceDefs, targetDefs)).toBe(metadata)
+    expect(remapRuntimeVars(null, 'character', sourceDefs, targetDefs)).toBeNull()
+  })
+
+  it('returns the metadata untouched when nothing in it matches', () => {
+    const metadata = metadataWith({ 'src-secret': { variableName: 'secret', v: 'hidden' } })
+    expect(remapRuntimeVars(metadata, 'character', sourceDefs, targetDefs)).toBe(metadata)
+  })
+})

--- a/src/lib/services/packs/binding.test.ts
+++ b/src/lib/services/packs/binding.test.ts
@@ -66,13 +66,13 @@ describe('matchPack', () => {
     expect(match.confidence).toBe('name-only')
   })
 
-  it('treats a null author and an empty one as the same value', async () => {
+  it('does not silently bind a source pack with no author', async () => {
     db.packs = [pack({ id: 'local-1', author: null })]
     await expect(matchPack({ name: 'Grimdark', author: '' })).resolves.toMatchObject({
-      confidence: 'exact',
+      confidence: 'name-only',
     })
     await expect(matchPack({ name: 'Grimdark', author: null })).resolves.toMatchObject({
-      confidence: 'exact',
+      confidence: 'name-only',
     })
   })
 

--- a/src/lib/services/packs/binding.test.ts
+++ b/src/lib/services/packs/binding.test.ts
@@ -55,6 +55,17 @@ describe('matchPack', () => {
     expect(match.pack?.id).toBe('local-1')
   })
 
+  it('does not silently choose between duplicate normalized name-and-author matches', async () => {
+    db.packs = [
+      pack({ id: 'local-1', name: 'Grimdark', author: 'Ada' }),
+      pack({ id: 'local-2', name: ' grimdark ', author: 'ada' }),
+    ]
+
+    const match = await matchPack({ name: 'GRIMDARK', author: 'Ada' })
+
+    expect(match.confidence).toBe('name-only')
+  })
+
   it('treats a null author and an empty one as the same value', async () => {
     db.packs = [pack({ id: 'local-1', author: null })]
     await expect(matchPack({ name: 'Grimdark', author: '' })).resolves.toMatchObject({

--- a/src/lib/services/packs/binding.ts
+++ b/src/lib/services/packs/binding.ts
@@ -62,11 +62,14 @@ export async function matchPack(
   if (!name) return { pack: null, confidence: 'none' }
 
   const candidates = packs ?? (await database.getAllPacks())
-  const byName = candidates.find((p) => normalize(p.name) === name)
-  if (!byName) return { pack: null, confidence: 'none' }
+  const byName = candidates.filter((p) => normalize(p.name) === name)
+  if (byName.length === 0) return { pack: null, confidence: 'none' }
 
-  const authorMatches = normalize(byName.author) === normalize(identity?.author)
-  return { pack: byName, confidence: authorMatches ? 'exact' : 'name-only' }
+  const author = normalize(identity?.author)
+  const authorMatches = byName.filter((p) => normalize(p.author) === author)
+  // One candidate on name *and* author is the only unambiguous reading.
+  if (authorMatches.length === 1) return { pack: authorMatches[0], confidence: 'exact' }
+  return { pack: byName[0], confidence: 'name-only' }
 }
 
 /** The subset of a runtime variable definition that matching needs, from either side. */

--- a/src/lib/services/packs/binding.ts
+++ b/src/lib/services/packs/binding.ts
@@ -1,0 +1,153 @@
+/**
+ * Binding a story to a prompt pack.
+ *
+ * A pack's id is assigned locally -- `crypto.randomUUID()` when it is created and again when a
+ * `.prompt.json` is imported -- so the same pack installed on two devices has two different ids.
+ * Nothing that crosses a device boundary can therefore match on id; identity is the pack's name
+ * and author, and the values a story holds are re-keyed to the local definitions by name.
+ *
+ * One implementation, two callers: file import and sync, both of which put a dialog in front of
+ * the user when the match is anything short of certain.
+ *
+ * Re-binding a story that already exists is a pending capability and deliberately absent here —
+ * the service call it will need is better written against that change's requirements than
+ * guessed at now.
+ */
+
+import { database } from '$lib/services/database'
+import type { PresetPack, RuntimeVarsMap, RuntimeEntityType } from './types'
+
+/**
+ * The built-in pack. `preset_packs` always contains it (`PackService.initialize` recreates it if
+ * it is missing), so it is the one binding that is always available to fall back to.
+ */
+export const DEFAULT_PACK_ID = 'default-pack'
+
+/** How a pack recorded in a story file is named. `author` is optional on a pack. */
+export interface PackIdentity {
+  name: string
+  author: string | null
+}
+
+/**
+ * How sure we are that a local pack is *the* pack a story was written with.
+ *
+ * `name-only` exists because `preset_packs` has `UNIQUE(name)`: a name lookup returns at most
+ * one candidate, which guarantees the match is unambiguous, not that it is right. Two people can
+ * both publish a pack called "Grimdark". So a name-only hit is a suggestion to show the user,
+ * never something to bind on silently.
+ */
+export type MatchConfidence = 'exact' | 'name-only' | 'none'
+
+export interface PackMatch {
+  pack: PresetPack | null
+  confidence: MatchConfidence
+}
+
+/** Trim and case-fold for comparison; a missing author is the same value as an empty one. */
+function normalize(value: string | null | undefined): string {
+  return (value ?? '').trim().toLowerCase()
+}
+
+/**
+ * Find the local pack a story file's pack identity refers to.
+ *
+ * Pass `packs` when the list is already loaded (the dialog has it); it is fetched otherwise.
+ */
+export async function matchPack(
+  identity: PackIdentity | null | undefined,
+  packs?: PresetPack[],
+): Promise<PackMatch> {
+  const name = normalize(identity?.name)
+  if (!name) return { pack: null, confidence: 'none' }
+
+  const candidates = packs ?? (await database.getAllPacks())
+  const byName = candidates.find((p) => normalize(p.name) === name)
+  if (!byName) return { pack: null, confidence: 'none' }
+
+  const authorMatches = normalize(byName.author) === normalize(identity?.author)
+  return { pack: byName, confidence: authorMatches ? 'exact' : 'name-only' }
+}
+
+/** The subset of a runtime variable definition that matching needs, from either side. */
+export interface RuntimeVarDef {
+  entityType: RuntimeEntityType
+  variableName: string
+}
+
+/** A local runtime variable definition, which additionally carries the key to write. */
+export interface LocalRuntimeVarDef extends RuntimeVarDef {
+  id: string
+}
+
+/**
+ * Which local definition each source variable name maps to, for one entity type.
+ *
+ * The source definitions travel without ids, so they cannot be looked up by the key the stored
+ * values use. What they establish is that the source pack *defined* this name for this entity
+ * type -- the pairing the spec describes -- while the value's own `variableName`, written
+ * alongside every stored value, is what carries the name across.
+ */
+function pairByName(
+  entityType: RuntimeEntityType,
+  sourceDefs: RuntimeVarDef[],
+  targetDefs: LocalRuntimeVarDef[],
+): Map<string, string> {
+  const sourceNames = new Set(
+    sourceDefs.filter((d) => d.entityType === entityType).map((d) => normalize(d.variableName)),
+  )
+  const pairs = new Map<string, string>()
+  for (const def of targetDefs) {
+    if (def.entityType !== entityType) continue
+    const name = normalize(def.variableName)
+    if (sourceNames.has(name)) pairs.set(name, def.id)
+  }
+  return pairs
+}
+
+/**
+ * Re-key one entity's stored runtime variable values for a different pack's definitions.
+ *
+ * `metadata.runtimeVars` is keyed by the *definition's* id, which makes renaming a variable free
+ * on one device and makes every value unreadable on any other. This finds the local definition
+ * with the same `(entityType, variableName)` as a source one and writes the value under the local
+ * id as well.
+ *
+ * `entityType` is a parameter rather than something read off `metadata`, because metadata does
+ * not record what it is attached to and a pack may define the same variable name for characters
+ * and for locations. Without it, a character's value could be re-keyed onto a location's
+ * definition.
+ *
+ * Additive on purpose: the source key is left in place. Keys are UUIDs and cannot collide, an
+ * unused entry costs a short `{variableName, v}` pair, and keeping it is what makes a re-binding
+ * reversible -- bind the story back to the original pack and the original values are readable
+ * again rather than gone. Pruning would destroy exactly the data this exists to protect.
+ *
+ * Returns `metadata` untouched (same reference) when there is nothing to remap, so callers can
+ * hand it straight back to the row they were going to write anyway.
+ */
+export function remapRuntimeVars<T extends Record<string, unknown> | null | undefined>(
+  metadata: T,
+  entityType: RuntimeEntityType,
+  sourceDefs: RuntimeVarDef[] | undefined,
+  targetDefs: LocalRuntimeVarDef[] | undefined,
+): T {
+  if (!metadata || !sourceDefs?.length || !targetDefs?.length) return metadata
+
+  const existing = metadata.runtimeVars as RuntimeVarsMap | undefined
+  if (!existing || Object.keys(existing).length === 0) return metadata
+
+  const pairs = pairByName(entityType, sourceDefs, targetDefs)
+  if (pairs.size === 0) return metadata
+
+  const added: RuntimeVarsMap = {}
+  for (const [defId, value] of Object.entries(existing)) {
+    if (!value || typeof value.variableName !== 'string') continue
+    const targetId = pairs.get(normalize(value.variableName))
+    if (!targetId || targetId === defId) continue
+    added[targetId] = { variableName: value.variableName, v: value.v }
+  }
+
+  if (Object.keys(added).length === 0) return metadata
+  return { ...metadata, runtimeVars: { ...existing, ...added } }
+}

--- a/src/lib/services/packs/binding.ts
+++ b/src/lib/services/packs/binding.ts
@@ -66,6 +66,7 @@ export async function matchPack(
   if (byName.length === 0) return { pack: null, confidence: 'none' }
 
   const author = normalize(identity?.author)
+  if (!author) return { pack: byName[0], confidence: 'name-only' }
   const authorMatches = byName.filter((p) => normalize(p.author) === author)
   // One candidate on name *and* author is the only unambiguous reading.
   if (authorMatches.length === 1) return { pack: authorMatches[0], confidence: 'exact' }

--- a/src/lib/services/packs/index.ts
+++ b/src/lib/services/packs/index.ts
@@ -1,0 +1,14 @@
+/** Public prompt-pack service contracts. */
+export * from './binding'
+export type {
+  CustomVariable,
+  CustomVariableType,
+  EnumOption,
+  FullPack,
+  PackTemplate,
+  PresetPack,
+  RuntimeEntityType,
+  RuntimeVariable,
+  RuntimeVariableType,
+  RuntimeVarsMap,
+} from './types'

--- a/src/lib/services/packs/roundTrip.test.ts
+++ b/src/lib/services/packs/roundTrip.test.ts
@@ -108,7 +108,7 @@ vi.mock('$lib/services/database', () => ({
   },
 }))
 
-const { gatherStoryData } = await import('../export/ExportCoordinationService')
+const { gatherStoryData } = await import('$lib/services/export')
 const { exportService } = await import('../export')
 const { runImport } = await import('../import')
 const { remapRuntimeVars } = await import('./binding')

--- a/src/lib/services/packs/roundTrip.test.ts
+++ b/src/lib/services/packs/roundTrip.test.ts
@@ -1,0 +1,220 @@
+/**
+ * The whole point of the change, end to end: a story written on a custom pack, exported, and
+ * imported onto a device where "the same pack" is a different row with a different id.
+ *
+ * The unit tests either side of this one each pin half of it. What they cannot show is that the
+ * two halves agree — that what the exporter chose to record is exactly what the importer needs,
+ * and that a value written on one device is readable on the other without anything in between
+ * knowing an id.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { PresetPack, RuntimeVariable, RuntimeVarsMap } from './types'
+
+const invoke = vi.fn(async (_cmd: string, _args: { storyJson: string }) => 'ok')
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (cmd: string, args: { storyJson: string }) => invoke(cmd, args),
+}))
+vi.mock('@tauri-apps/plugin-dialog', () => ({ open: vi.fn() }))
+vi.mock('@tauri-apps/plugin-fs', () => ({ writeTextFile: vi.fn(), readTextFile: vi.fn() }))
+vi.mock('$lib/services/import/native', () => ({ importFromFile: vi.fn() }))
+vi.mock('$lib/services/exportTarget', () => ({
+  resolveSaveTarget: vi.fn(async () => ({ destPath: '/tmp/out.avt' })),
+}))
+
+/** Definitions for one pack, differing only in the ids — which is the entire problem. */
+function runtimeVar(id: string, packId: string): RuntimeVariable {
+  return {
+    id,
+    packId,
+    entityType: 'character',
+    variableName: 'morale',
+    displayName: 'Morale',
+    variableType: 'number',
+    color: '#fff',
+    pinned: false,
+    sortOrder: 0,
+    createdAt: 0,
+  }
+}
+
+function pack(id: string, name: string, author: string | null): PresetPack {
+  return {
+    id,
+    name,
+    description: null,
+    author,
+    isDefault: id === 'default-pack',
+    createdAt: 0,
+    updatedAt: 0,
+  }
+}
+
+/** The source device: one custom pack, one story bound to it, one character with a value. */
+const SOURCE = {
+  packId: 'source-side-uuid',
+  runtimeVars: [runtimeVar('source-morale-uuid', 'source-side-uuid')],
+}
+
+/** The receiving device: the same pack by name and author, every id different. */
+const local = {
+  packs: [] as PresetPack[],
+  runtimeVarsByPack: new Map<string, RuntimeVariable[]>(),
+}
+
+const written = {
+  stories: [] as any[],
+  characters: [] as any[],
+}
+
+vi.mock('$lib/services/database', () => ({
+  database: {
+    // --- export side ---
+    getStoryEntries: vi.fn(async () => []),
+    getCharacters: vi.fn(async () => []),
+    getLocations: vi.fn(async () => []),
+    getItems: vi.fn(async () => []),
+    getStoryBeats: vi.fn(async () => []),
+    getEntries: vi.fn(async () => []),
+    getEmbeddedImageMetaForStory: vi.fn(async () => []),
+    getCheckpoints: vi.fn(async () => []),
+    getBranches: vi.fn(async () => []),
+    getChapters: vi.fn(async () => []),
+    getStoryPackId: vi.fn(async () => SOURCE.packId),
+    getPack: vi.fn(async () => pack(SOURCE.packId, 'Grimdark', 'Ada')),
+    getPackVariables: vi.fn(async () => []),
+    getStoryCustomVariables: vi.fn(async () => ({ writing_style: 'terse' })),
+    // --- import side ---
+    getAllPacks: vi.fn(async () => local.packs),
+    getRuntimeVariables: vi.fn(async (packId: string) => {
+      // Called for the source pack during export, and for the target pack during import.
+      if (packId === SOURCE.packId) return SOURCE.runtimeVars
+      return local.runtimeVarsByPack.get(packId) ?? []
+    }),
+    createStory: vi.fn(async (s: any) => void written.stories.push(s)),
+    addStoryEntry: vi.fn(async () => {}),
+    addCharacter: vi.fn(async (c: any) => void written.characters.push(c)),
+    addLocation: vi.fn(async () => {}),
+    addItem: vi.fn(async () => {}),
+    addStoryBeat: vi.fn(async () => {}),
+    addEntry: vi.fn(async () => {}),
+    addChapter: vi.fn(async () => {}),
+    addBranch: vi.fn(async () => {}),
+    createCheckpoint: vi.fn(async () => {}),
+    createEmbeddedImage: vi.fn(async () => {}),
+    updateBranch: vi.fn(async () => {}),
+    setStoryCurrentBranch: vi.fn(async () => {}),
+    deleteStory: vi.fn(async () => {}),
+  },
+}))
+
+const { gatherStoryData } = await import('../export/ExportCoordinationService')
+const { exportService } = await import('../export')
+const { runImport } = await import('../import')
+const { remapRuntimeVars } = await import('./binding')
+
+beforeEach(() => {
+  invoke.mockClear()
+  written.stories.length = 0
+  written.characters.length = 0
+  local.packs = [pack('default-pack', 'Default', 'Aventuras')]
+  local.runtimeVarsByPack = new Map()
+})
+
+/** Export a story carrying one character with a morale value, and return the file's JSON. */
+async function exportStory() {
+  const data = await gatherStoryData('story-1')
+  await exportService.exportToAventura(
+    { id: 'story-1', title: 'Yuka', styleReviewState: null, settings: {} } as never,
+    [{ id: 'entry-1', type: 'narration', content: 'c', parentId: null, position: 0 }] as never,
+    [
+      {
+        id: 'char-1',
+        name: 'Yuka',
+        metadata: { runtimeVars: { 'source-morale-uuid': { variableName: 'morale', v: 7 } } },
+      },
+    ] as never,
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    null,
+    data.packBinding,
+  )
+  return JSON.parse(invoke.mock.calls[0][1].storyJson)
+}
+
+describe('export -> import against the same pack under a different id', () => {
+  it('binds the story and makes the character values readable under the local definition', async () => {
+    // The receiving device installed the same pack from the same .prompt.json, so it matches by
+    // name and author and by nothing else — its ids were minted locally.
+    local.packs.push(pack('target-side-uuid', 'Grimdark', 'Ada'))
+    local.runtimeVarsByPack.set('target-side-uuid', [
+      runtimeVar('target-morale-uuid', 'target-side-uuid'),
+    ])
+
+    const file = await exportStory()
+    const result = await runImport(file)
+
+    expect(result.success).toBe(true)
+    expect(written.stories[0]).toMatchObject({
+      packId: 'target-side-uuid',
+      customVariableValues: { writing_style: 'terse' },
+    })
+
+    // What the world panels and ContextBuilder read: the local definition's id.
+    const runtimeVars = written.characters[0].metadata.runtimeVars as RuntimeVarsMap
+    expect(runtimeVars['target-morale-uuid']).toEqual({ variableName: 'morale', v: 7 })
+  })
+
+  it('carries no template content across', async () => {
+    local.packs.push(pack('target-side-uuid', 'Grimdark', 'Ada'))
+    const file = await exportStory()
+    // The receiving device's own pack narrates. Nothing in the file can change that, because
+    // there is nothing in it to change it with.
+    expect(JSON.stringify(file.packBinding)).not.toMatch(/content|template/i)
+  })
+})
+
+describe('the retention that makes a later re-binding possible', () => {
+  it('keeps every key, so binding to another pack loses no earlier values', async () => {
+    local.packs.push(pack('target-side-uuid', 'Grimdark', 'Ada'))
+    local.runtimeVarsByPack.set('target-side-uuid', [
+      runtimeVar('target-morale-uuid', 'target-side-uuid'),
+    ])
+
+    const file = await exportStory()
+    await runImport(file)
+    const imported = written.characters[0].metadata
+
+    // Re-bind to a third pack that also defines "morale" for characters...
+    const other = [runtimeVar('other-morale-uuid', 'other-pack')]
+    const onOther = remapRuntimeVars(
+      imported,
+      'character',
+      file.packBinding.runtimeVariables,
+      other,
+    )
+    expect((onOther.runtimeVars as RuntimeVarsMap)['other-morale-uuid']).toEqual({
+      variableName: 'morale',
+      v: 7,
+    })
+
+    // ...and back. The key the story was readable under before the detour is still there, which
+    // is what "no earlier value is destroyed" actually means in storage terms.
+    const backHome = remapRuntimeVars(
+      onOther,
+      'character',
+      file.packBinding.runtimeVariables,
+      local.runtimeVarsByPack.get('target-side-uuid')!,
+    )
+    const finalVars = backHome.runtimeVars as RuntimeVarsMap
+    expect(finalVars['target-morale-uuid']).toEqual({ variableName: 'morale', v: 7 })
+    expect(finalVars['other-morale-uuid']).toEqual({ variableName: 'morale', v: 7 })
+    expect(finalVars['source-morale-uuid']).toEqual({ variableName: 'morale', v: 7 })
+  })
+})

--- a/src/lib/services/sync.test.ts
+++ b/src/lib/services/sync.test.ts
@@ -1,0 +1,191 @@
+/**
+ * What the sync sender puts on the wire.
+ *
+ * Scoped deliberately to the pack binding. The section itself comes from the `.avt` exporter's
+ * `gatherPackBinding`, but sync still assembles the payload around it (see the TECH DEBT note on
+ * `exportStoryToJson`), so these assert on what ends up on the wire rather than on which module
+ * produced it — folding the two exporters together later should not rewrite them.
+ *
+ * Two known divergences from the `.avt` path are asserted as-is rather than fixed, so that
+ * closing them is a deliberate act with a failing test to update, not a silent drift: the
+ * version stamp is pinned at `1.7.0`, and background images are not carried at all.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// Module-scope Tauri and store imports that must merely resolve under Node.
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))
+vi.mock('$lib/stores/story.svelte', () => ({
+  story: { currentStory: null, loadStory: vi.fn(), createCheckpoint: vi.fn() },
+}))
+
+const db = {
+  getStory: vi.fn(),
+  getStoryEntries: vi.fn(),
+  getCharacters: vi.fn(),
+  getLocations: vi.fn(),
+  getItems: vi.fn(),
+  getStoryBeats: vi.fn(),
+  getEntries: vi.fn(),
+  getEmbeddedImagesForStory: vi.fn(),
+  getCheckpoints: vi.fn(),
+  getBranches: vi.fn(),
+  getChapters: vi.fn(),
+  getStoryPackId: vi.fn(),
+  getPack: vi.fn(),
+  getPackVariables: vi.fn(),
+  getRuntimeVariables: vi.fn(),
+  getStoryCustomVariables: vi.fn(),
+  getBackgroundForBranch: vi.fn(),
+}
+vi.mock('./database', () => ({ database: db }))
+
+const { syncService } = await import('./sync')
+
+/** A story with no pack and nothing optional set — the baseline each test varies from. */
+function baseline() {
+  db.getStory.mockResolvedValue({
+    id: 's1',
+    title: 'Yuka',
+    settings: {},
+    styleReviewState: null,
+    currentBgImage: null,
+  })
+  db.getStoryEntries.mockResolvedValue([{ id: 'e1', type: 'narration', content: 'once' }])
+  db.getCharacters.mockResolvedValue([])
+  db.getLocations.mockResolvedValue([])
+  db.getItems.mockResolvedValue([])
+  db.getStoryBeats.mockResolvedValue([])
+  db.getEntries.mockResolvedValue([])
+  db.getEmbeddedImagesForStory.mockResolvedValue([])
+  db.getCheckpoints.mockResolvedValue([])
+  db.getBranches.mockResolvedValue([])
+  db.getChapters.mockResolvedValue([])
+  db.getStoryPackId.mockResolvedValue(null)
+  db.getPack.mockResolvedValue(null)
+  db.getPackVariables.mockResolvedValue([])
+  db.getRuntimeVariables.mockResolvedValue([])
+  db.getStoryCustomVariables.mockResolvedValue(null)
+}
+
+/** Give the story a custom pack, with one variable of each kind. */
+function withPack() {
+  db.getStoryPackId.mockResolvedValue('pack-local-uuid')
+  db.getPack.mockResolvedValue({
+    id: 'pack-local-uuid',
+    name: 'Grimdark',
+    author: 'Kolya',
+    description: 'grim',
+    isDefault: false,
+  })
+  db.getPackVariables.mockResolvedValue([
+    {
+      id: 'v1',
+      packId: 'pack-local-uuid',
+      variableName: 'writing_style',
+      displayName: 'Writing Style',
+      variableType: 'text',
+      isRequired: true,
+      sortOrder: 0,
+    },
+  ])
+  db.getRuntimeVariables.mockResolvedValue([
+    {
+      id: 'rv1',
+      packId: 'pack-local-uuid',
+      entityType: 'character',
+      variableName: 'morale',
+      displayName: 'Morale',
+      variableType: 'number',
+      minValue: 0,
+      maxValue: 100,
+      color: '#6366f1',
+      pinned: false,
+      sortOrder: 0,
+    },
+  ])
+  db.getStoryCustomVariables.mockResolvedValue({ writing_style: 'terse' })
+}
+
+async function payload() {
+  return JSON.parse(await syncService.exportStoryToJson('s1'))
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  baseline()
+})
+
+describe('exportStoryToJson — pack binding', () => {
+  it('carries the pack identity and the story’s answers', async () => {
+    withPack()
+    const { packBinding } = await payload()
+
+    expect(packBinding.pack).toEqual({ name: 'Grimdark', author: 'Kolya' })
+    expect(packBinding.customVariableValues).toEqual({ writing_style: 'terse' })
+  })
+
+  it('carries variable definitions without device-local ids', async () => {
+    withPack()
+    const { packBinding } = await payload()
+
+    expect(packBinding.variables[0]).toMatchObject({
+      variableName: 'writing_style',
+      variableType: 'text',
+      isRequired: true,
+    })
+    expect(packBinding.runtimeVariables[0]).toMatchObject({
+      entityType: 'character',
+      variableName: 'morale',
+      minValue: 0,
+      maxValue: 100,
+    })
+    // Ids are minted per device; sending them would invite a receiver to match on them.
+    expect(packBinding.variables[0]).not.toHaveProperty('id')
+    expect(packBinding.variables[0]).not.toHaveProperty('packId')
+    expect(packBinding.runtimeVariables[0]).not.toHaveProperty('id')
+    expect(packBinding.runtimeVariables[0]).not.toHaveProperty('packId')
+  })
+
+  it('never sends template content', async () => {
+    withPack()
+    const raw = await syncService.exportStoryToJson('s1')
+
+    expect(db.getPackVariables).toHaveBeenCalledWith('pack-local-uuid')
+    expect(raw).not.toContain('templates')
+    expect(raw).not.toContain('content_hash')
+  })
+
+  it('omits packBinding entirely for a story with no pack', async () => {
+    expect('packBinding' in (await payload())).toBe(false)
+  })
+
+  it('omits packBinding when the story points at a pack that no longer exists', async () => {
+    db.getStoryPackId.mockResolvedValue('deleted-pack')
+    db.getPack.mockResolvedValue(null)
+
+    expect('packBinding' in (await payload())).toBe(false)
+  })
+})
+
+describe('exportStoryToJson — known divergences from the .avt path', () => {
+  it('still stamps 1.7.0, which the shape-driven importer ignores', async () => {
+    // Not an endorsement: pinned so that correcting it is deliberate. The importer never
+    // compares this value, which is why the binding above is honoured despite it.
+    withPack()
+    const p = await payload()
+
+    expect(p.version).toBe('1.7.0')
+    expect(p.packBinding).toBeDefined()
+  })
+
+  it('does not claim to carry a background image', async () => {
+    // The real value lives in `background_images` behind `getBackgroundForBranch`; `getStory`
+    // hardcodes `currentBgImage: null`. Mocking a value in here would pass against a shape the
+    // production query cannot produce and make the payload look richer than it is.
+    const p = await payload()
+
+    expect(p.currentBgImage ?? null).toBeNull()
+    expect(db.getBackgroundForBranch).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/services/sync.ts
+++ b/src/lib/services/sync.ts
@@ -1,10 +1,9 @@
 import { invoke } from '@tauri-apps/api/core'
 import type { SyncServerInfo, SyncStoryPreview, SyncConnectionData } from '$lib/types/sync'
 import type { AventuraExport } from './export'
-// The one piece of the `.avt` exporter sync shares. Imported from its own module rather than the
-// `./export` barrel, which pulls in the Tauri dialog/fs plugins at module scope that sync has no
-// use for. See the note on `exportStoryToJson` for what is deliberately *not* shared.
-import { gatherPackBinding } from './export/ExportCoordinationService'
+// The one piece of the `.avt` exporter sync shares. See the note on `exportStoryToJson` for what
+// is deliberately *not* shared.
+import { gatherPackBinding } from './export'
 import { database } from './database'
 import { story } from '$lib/stores/story.svelte'
 

--- a/src/lib/services/sync.ts
+++ b/src/lib/services/sync.ts
@@ -1,6 +1,10 @@
 import { invoke } from '@tauri-apps/api/core'
 import type { SyncServerInfo, SyncStoryPreview, SyncConnectionData } from '$lib/types/sync'
 import type { AventuraExport } from './export'
+// The one piece of the `.avt` exporter sync shares. Imported from its own module rather than the
+// `./export` barrel, which pulls in the Tauri dialog/fs plugins at module scope that sync has no
+// use for. See the note on `exportStoryToJson` for what is deliberately *not* shared.
+import { gatherPackBinding } from './export/ExportCoordinationService'
 import { database } from './database'
 import { story } from '$lib/stores/story.svelte'
 
@@ -87,7 +91,18 @@ class SyncService {
   }
 
   /**
-   * Export a story to JSON string in Aventura format
+   * Export a story to JSON string in Aventura format.
+   *
+   * The pack section comes from the `.avt` exporter's own `gatherPackBinding`, so the two agree
+   * on what a binding is by construction. The surrounding payload is still assembled here rather
+   * than through `gatherStoryData`.
+   *
+   * TECH DEBT: that split means a field added to the format reaches `.avt` and not sync unless
+   * both are edited, which is how the payload below came to stamp `1.7.0` and omit
+   * `currentBgImage` — the `.avt` path has carried both since v1.8.0. Merging the two is the
+   * fix and is out of scope here: sync loads image payloads inline, where the `.avt` path takes
+   * metadata only and lets Rust stream the bytes into SQLite, so they cannot merge without
+   * first deciding whether sync should stream natively too.
    */
   async exportStoryToJson(storyId: string): Promise<string> {
     // Get all story data from database
@@ -107,6 +122,7 @@ class SyncService {
       checkpoints,
       branches,
       chapters,
+      packBinding,
     ] = await Promise.all([
       database.getStoryEntries(storyId),
       database.getCharacters(storyId),
@@ -118,9 +134,14 @@ class SyncService {
       database.getCheckpoints(storyId),
       database.getBranches(storyId),
       database.getChapters(storyId),
+      gatherPackBinding(storyId),
     ])
 
     const exportData: AventuraExport = {
+      // Left at 1.7.0 on purpose. The receiving importer is shape-driven — it reads whichever
+      // sections are present and never compares this number — so `packBinding` below is honoured
+      // regardless. Correcting the stamp belongs with the wider fix noted on this method, not
+      // here, where it would only change what gets logged.
       version: '1.7.0',
       exportedAt: Date.now(),
       story: storyData,
@@ -135,6 +156,9 @@ class SyncService {
       checkpoints,
       branches,
       chapters,
+      // Omitted rather than written as null, so a story with no pack keeps the shape that takes
+      // the legacy import path — matching what `exportToAventura` produces.
+      ...(packBinding ? { packBinding } : {}),
     }
 
     return JSON.stringify(exportData)

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -913,6 +913,7 @@ export function getDefaultExperimentalFeatures(): ExperimentalFeatures {
     backgroundGeneration: false,
     generationNotifications: false,
     notificationPreview: false,
+    legacyImportPackMapping: false,
   }
 }
 

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -859,6 +859,15 @@ export interface ExperimentalFeatures {
   generationNotifications: boolean
   /** Android: Include preview of generated text in the completion notification */
   notificationPreview: boolean
+  /**
+   * Ask which prompt pack to use when importing a story file that records no pack.
+   *
+   * Off by default on purpose: files predating the pack section are every file in existence, and
+   * they already import bound to the built-in pack. Only consulted on the interactive file-import
+   * path, and only when the device has more than one pack — sync never prompts, and a device with
+   * one pack has nothing to choose.
+   */
+  legacyImportPackMapping: boolean
 }
 
 // ===== World State Delta Tracking (Phase 1) =====


### PR DESCRIPTION
## Why

A story's prompt pack was a foreign key and nothing more. `AventuraExport` had no pack field and `createStory` never wrote the column, so every imported story landed with `pack_id` NULL and was silently narrated by templates its author never chose. The story's answers to that pack's variables went with it, and per-entity runtime values survived the transfer keyed by the *source device's* definition UUIDs — sitting intact in the database, unreadable by anything on the receiving one.

Pack ids are minted per device, so carrying `pack_id` in the file would not have helped. Identity is the pack's name and author; values are re-keyed to the local definitions by name.

## What changes

- **`.avt` gains `packBinding`** — pack identity, the story's variable answers, and the *definitions* of the pack's variables and runtime variables. Never the template content: a shared story must not fork the recipient's packs. Format version `1.9.0`; files without the section import exactly as before.
- **Import and sync both settle the binding before anything is written.** A name+author match binds without asking. A name-only match, a missing pack, or a required variable the story has no answer for opens a dialog. Cancelling costs nothing because it runs ahead of the first write.
- **Sync resolves ahead of the backup-and-delete** it performs when replacing a story. It previously deleted first, so a failed download — or now a cancelled pack choice — would have left the user with neither copy.
- **Runtime values are re-keyed additively** by `(entityType, variableName)`. Source-device keys stay, so binding a story back to a pack it was once on makes the original values readable again rather than resurrecting nothing.
- **Labs toggle** (off by default) extends the pack step to pre-1.9.0 files that record no pack. Interactive path only, and only with more than one pack installed.
- **Story Settings names the pack** a story narrates through. Nothing else in the app showed it.

No migration — `pack_id` and `custom_variable_values` already existed (030/031/032), `createStory` simply never wrote them. No Rust changes.

## Design notes worth a reviewer's eye

- **A confident match does not prompt.** The wizard always sets `pack_id`, so every file written from 1.9.0 on records a pack; a confirm-on-match rule would put a modal in front of every import forever, including re-importing your own export. A prompt whose only sensible answer is "yes" teaches people to dismiss prompts.
- **A name-only match never binds silently.** `preset_packs` has `UNIQUE(name)`, which guarantees one candidate, not the right one — two people can both ship a pack called "Grimdark".
- **There is no "unresolved binding" state.** An earlier iteration recorded one so the app could offer to fix it later; since every path now settles the binding before the story exists, that state became unreachable and the flag was removed rather than maintained.
- **Sync asks because it is user-driven** — the payload is already downloaded and no remote party is waiting. That assumption is written into the design doc, because a background sync would need a different policy.

## Known limitation

A forwarded story carries the pack it *landed on*, not the one it was written with: `packBinding` is gathered from `stories.pack_id`. Passing a story on to a third device cannot re-establish the original binding. Accepted — every scenario here is a single hop, and sync produces standalone copies rather than one story living on several devices.

## Testing

1033 tests pass, `svelte-check` clean, lint clean, `vite build` succeeds. New coverage: pack matching and confidence, additive re-keying and its round trip, the prompt decision (confident / uncertain / absent / missing required value), export shape including the absence of template text, and the import pipeline's abort-before-write.

**Still unverified manually** — draft for this reason:

1. A pre-1.9.0 `.avt` imported with the toggle off.
2. The `fill-values` dialog rendered, which needs a local pack defining a required, default-less variable the imported story has no answer for.
3. A cancelled replacing sync — the ordering fix touches destructive code and only unit tests cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stories now preserve prompt-pack selections, custom values, and variable settings during export, import, and sync.
  * Added guided pack selection for imports when packs are missing, mismatched, or require additional values.
  * Added an experimental option for choosing prompt packs when importing older story files.
  * Story settings now show the selected prompt pack and author.
* **Bug Fixes**
  * Improved compatibility when transferring stories between devices with different prompt-pack identifiers.
  * Legacy files without pack information continue to import using the built-in pack.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->