### PR TITLE
Fix discovery provider imports and contract coverage

### DIFF
--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -20,15 +20,14 @@ The discovery provider unit tests mock `corsFetch` with representative upstream 
 CI contract for request construction, result mapping, and card downloads; they do not depend on remote
 services remaining available or preserving their current catalog.
 
-An opt-in smoke suite exercises public search and download paths against Character Tavern, Chub,
-MLPChag, QuillGen, and Wyvern:
+An opt-in smoke suite exercises public search and download paths against every registered discovery
+provider:
 
 ```powershell
 $env:AVENTURAS_LIVE_DISCOVERY='1'; npx vitest run src/lib/services/discovery/providers/providers.live.test.ts
 ```
 
-It is skipped unless `AVENTURAS_LIVE_DISCOVERY=1` and must not be enabled in required CI. JannyAI is
-excluded because token discovery and card downloads can be challenged by Cloudflare. Backyard,
-Pygmalion, and RisuRealm use volatile application protocols whose availability is not a stable health
-signal for this repository. Their deterministic provider tests still cover the complete request,
-mapping, and download contracts.
+It is skipped unless `AVENTURAS_LIVE_DISCOVERY=1` and must not be enabled in required CI. The suite is
+intentionally comprehensive: failures from Cloudflare, volatile application protocols, upstream
+catalog changes, or provider outages are useful signals during an explicit live run, but would make
+required CI flaky.

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -13,3 +13,22 @@ callers, not test scaffolding.
 There is also no DOM environment (`environment: 'node'`), so components are not rendered by any test. A
 Svelte-level mistake — a `bind:` to an undefined value, for instance — passes `check`, `lint` and the
 whole suite, and only fails when the app runs.
+
+## Discovery provider tests
+
+The discovery provider unit tests mock `corsFetch` with representative upstream payloads. They are the
+CI contract for request construction, result mapping, and card downloads; they do not depend on remote
+services remaining available or preserving their current catalog.
+
+An opt-in smoke suite exercises public search and download paths against Character Tavern, Chub,
+MLPChag, QuillGen, and Wyvern:
+
+```powershell
+$env:AVENTURAS_LIVE_DISCOVERY='1'; npx vitest run src/lib/services/discovery/providers/providers.live.test.ts
+```
+
+It is skipped unless `AVENTURAS_LIVE_DISCOVERY=1` and must not be enabled in required CI. JannyAI is
+excluded because token discovery and card downloads can be challenged by Cloudflare. Backyard,
+Pygmalion, and RisuRealm use volatile application protocols whose availability is not a stable health
+signal for this repository. Their deterministic provider tests still cover the complete request,
+mapping, and download contracts.

--- a/src/lib/services/discovery/index.test.ts
+++ b/src/lib/services/discovery/index.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest'
+import { DiscoveryService } from './index'
+import type { DiscoveryProvider, SearchOptions } from './types'
+
+function providerWithSearch(search: DiscoveryProvider['search']): DiscoveryProvider {
+  return {
+    id: 'fixture',
+    name: 'Fixture',
+    supports: ['character'],
+    search,
+    getDownloadUrl: vi.fn(),
+    downloadCard: vi.fn(),
+    getTags: vi.fn(),
+  }
+}
+
+describe('DiscoveryService all-provider pagination', () => {
+  it('preserves sensitivity, sorting, and tags when loading the next page', async () => {
+    const search = vi
+      .fn<DiscoveryProvider['search']>()
+      .mockResolvedValueOnce({ cards: [], hasMore: true, nextPage: 7 })
+      .mockResolvedValueOnce({ cards: [], hasMore: false })
+    const service = new DiscoveryService([providerWithSearch(search)])
+    const options: SearchOptions = {
+      query: 'guide',
+      page: 4,
+      limit: 12,
+      sort: 'new',
+      nsfw: true,
+      tags: ['Fantasy'],
+    }
+
+    await service.searchAll(options, 'character')
+    await service.loadMoreAll('character', 24)
+
+    expect(search).toHaveBeenNthCalledWith(1, { ...options, page: 1 }, 'character')
+    expect(search).toHaveBeenNthCalledWith(
+      2,
+      {
+        query: 'guide',
+        tags: ['Fantasy'],
+        sort: 'new',
+        nsfw: true,
+        page: 7,
+        limit: 24,
+      },
+      'character',
+    )
+  })
+})

--- a/src/lib/services/discovery/index.ts
+++ b/src/lib/services/discovery/index.ts
@@ -17,25 +17,29 @@ interface ProviderPaginationState {
   hasMore: boolean
 }
 
-class DiscoveryService {
+export class DiscoveryService {
   private providers: Map<string, DiscoveryProvider> = new Map()
   private allModeState: Map<string, ProviderPaginationState> = new Map()
-  private lastAllModeOptions: {
-    query: string
-    tags?: string[]
-    type: 'character' | 'lorebook' | 'scenario'
-  } | null = null
+  private lastAllModeOptions:
+    | (Omit<SearchOptions, 'page' | 'limit'> & {
+        type: 'character' | 'lorebook' | 'scenario'
+      })
+    | null = null
 
-  constructor() {
-    this.registerProvider(new ChubProvider())
-    this.registerProvider(new JannyProvider())
-    this.registerProvider(new BackyardProvider())
-    this.registerProvider(new CharacterTavernProvider())
-    this.registerProvider(new RisuRealmProvider())
-    this.registerProvider(new WyvernProvider())
-    this.registerProvider(new PygmalionProvider())
-    this.registerProvider(new MlpchagProvider())
-    this.registerProvider(new QuillGenProvider())
+  constructor(
+    providers: DiscoveryProvider[] = [
+      new ChubProvider(),
+      new JannyProvider(),
+      new BackyardProvider(),
+      new CharacterTavernProvider(),
+      new RisuRealmProvider(),
+      new WyvernProvider(),
+      new PygmalionProvider(),
+      new MlpchagProvider(),
+      new QuillGenProvider(),
+    ],
+  ) {
+    for (const provider of providers) this.registerProvider(provider)
   }
 
   registerProvider(provider: DiscoveryProvider): void {
@@ -80,7 +84,8 @@ class DiscoveryService {
 
     // Reset pagination state for new search
     this.allModeState.clear()
-    this.lastAllModeOptions = { query: options.query, tags: options.tags, type }
+    const { page: _page, limit: _limit, ...stableOptions } = options
+    this.lastAllModeOptions = { ...stableOptions, type }
 
     // Search all providers in parallel
     const results = await Promise.allSettled(
@@ -157,6 +162,8 @@ class DiscoveryService {
           {
             query: this.lastAllModeOptions!.query,
             tags: this.lastAllModeOptions!.tags,
+            sort: this.lastAllModeOptions!.sort,
+            nsfw: this.lastAllModeOptions!.nsfw,
             page: state.nextPage,
             limit,
           },

--- a/src/lib/services/discovery/index.ts
+++ b/src/lib/services/discovery/index.ts
@@ -10,6 +10,7 @@ import { MlpchagProvider } from './providers/mlpchag'
 import { QuillGenProvider } from './providers/quillgen'
 
 export type { DiscoveryProvider, DiscoveryCard, SearchOptions, SearchResult }
+export { METADATA_ONLY_CHARACTER_MIME } from './types'
 
 // Track pagination state per provider for "Search All" mode
 interface ProviderPaginationState {

--- a/src/lib/services/discovery/providers/backyard.test.ts
+++ b/src/lib/services/discovery/providers/backyard.test.ts
@@ -54,6 +54,11 @@ describe('BackyardProvider', () => {
                         },
                       ],
                     },
+                    {
+                      id: 'group-nsfw',
+                      isNSFW: true,
+                      CharacterConfigs: [{ id: 'config-nsfw', displayName: 'Filtered Character' }],
+                    },
                   ],
                 },
               },
@@ -86,7 +91,7 @@ describe('BackyardProvider', () => {
     expect(decodeTrpcInput(requestUrl)).toEqual({
       tagNames: ['Mystery'],
       sortBy: { type: 'New', direction: 'desc' },
-      type: 'sfw',
+      type: 'all',
       direction: 'forward',
       search: 'Iris',
     })

--- a/src/lib/services/discovery/providers/backyard.test.ts
+++ b/src/lib/services/discovery/providers/backyard.test.ts
@@ -1,0 +1,230 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { corsFetchMock } = vi.hoisted(() => ({
+  corsFetchMock: vi.fn(),
+}))
+
+vi.mock('../utils', () => ({
+  corsFetch: corsFetchMock,
+}))
+
+import { BackyardProvider } from './backyard'
+
+function jsonResponse(value: unknown): Response {
+  return {
+    ok: true,
+    json: vi.fn().mockResolvedValue(value),
+  } as unknown as Response
+}
+
+function decodeTrpcInput(requestUrl: string): Record<string, unknown> {
+  const encodedInput = new URL(requestUrl).searchParams.get('input')
+  expect(encodedInput).not.toBeNull()
+  const batch = JSON.parse(encodedInput!) as { '0': { json: Record<string, unknown> } }
+  return batch['0'].json
+}
+
+describe('BackyardProvider', () => {
+  beforeEach(() => {
+    corsFetchMock.mockReset()
+  })
+
+  it('searches the tRPC endpoint, maps a character, and reuses its cursor', async () => {
+    corsFetchMock
+      .mockResolvedValueOnce(
+        jsonResponse([
+          {
+            result: {
+              data: {
+                json: {
+                  nextCursor: 'cursor-2',
+                  hubGroupConfigs: [
+                    {
+                      id: 'group-7',
+                      tagline: 'A patient investigator.',
+                      downloadCount: 42,
+                      isNSFW: false,
+                      Author: { username: 'garden-author' },
+                      Tags: [{ name: 'Mystery' }, { name: 'Detective' }],
+                      CharacterConfigs: [
+                        {
+                          id: 'config-9',
+                          displayName: 'Iris Vale',
+                          Images: [{ imageUrl: 'https://cdn.example/upload/iris.png' }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse([{ result: { data: { json: { hubGroupConfigs: [] } } } }]),
+      )
+
+    const provider = new BackyardProvider()
+    const result = await provider.search(
+      {
+        query: '  Iris  ',
+        page: 1,
+        sort: 'new',
+        nsfw: false,
+        tags: ['Mystery'],
+      },
+      'character',
+    )
+
+    const [requestUrl, init] = corsFetchMock.mock.calls[0] as [string, RequestInit]
+    const url = new URL(requestUrl)
+    expect(`${url.origin}${url.pathname}`).toBe(
+      'https://backyard.ai/api/trpc/hub.browse.getHubGroupConfigsForTag',
+    )
+    expect(url.searchParams.get('batch')).toBe('1')
+    expect(decodeTrpcInput(requestUrl)).toEqual({
+      tagNames: ['Mystery'],
+      sortBy: { type: 'New', direction: 'desc' },
+      type: 'sfw',
+      direction: 'forward',
+      search: 'Iris',
+    })
+    expect(init).toEqual({
+      method: 'GET',
+      headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+    })
+    expect(init.body).toBeUndefined()
+
+    expect(result).toEqual({
+      cards: [
+        {
+          id: 'config-9',
+          name: 'Iris Vale',
+          creator: 'garden-author',
+          description: 'A patient investigator.',
+          avatarUrl: 'https://cdn.example/upload/w_300,c_fill,g_north,f_auto,q_auto/iris.png',
+          imageUrl: 'https://backyard.ai/hub/character/group-7',
+          tags: ['Mystery', 'Detective'],
+          stats: { downloads: 42 },
+          source: 'backyard',
+          type: 'character',
+          nsfw: false,
+          raw: {
+            id: 'group-7',
+            tagline: 'A patient investigator.',
+            downloadCount: 42,
+            isNSFW: false,
+            Author: { username: 'garden-author' },
+            Tags: [{ name: 'Mystery' }, { name: 'Detective' }],
+            CharacterConfigs: [
+              {
+                id: 'config-9',
+                displayName: 'Iris Vale',
+                Images: [{ imageUrl: 'https://cdn.example/upload/iris.png' }],
+              },
+            ],
+            groupId: 'group-7',
+          },
+        },
+      ],
+      hasMore: true,
+      nextPage: 2,
+    })
+
+    await provider.search({ query: 'Iris', page: 2 }, 'character')
+    const [secondUrl] = corsFetchMock.mock.calls[1] as [string, RequestInit]
+    expect(decodeTrpcInput(secondUrl)).toEqual(
+      expect.objectContaining({ search: 'Iris', cursor: 'cursor-2' }),
+    )
+  })
+
+  it('builds a stable page URL and downloads full character data as JSON', async () => {
+    const provider = new BackyardProvider()
+    const card = {
+      id: 'config-9',
+      name: 'Iris Vale',
+      creator: 'garden-author',
+      description: 'A patient investigator.',
+      avatarUrl: '',
+      tags: ['Mystery'],
+      source: 'backyard',
+      type: 'character' as const,
+      nsfw: false,
+      raw: { groupId: 'group-7' },
+    }
+
+    expect(await provider.getDownloadUrl(card)).toBe('https://backyard.ai/hub/character/group-7')
+
+    corsFetchMock.mockResolvedValueOnce(
+      jsonResponse([
+        {
+          result: {
+            data: {
+              json: {
+                id: 'config-9',
+                displayName: 'Iris Vale',
+                persona: 'Observant and methodical.',
+                creatorNotes: 'Original card notes.',
+                Author: { username: 'garden-author' },
+                Tags: [{ name: 'Mystery' }],
+                standaloneGroupConfig: {
+                  id: 'group-7',
+                  PrimaryChat: {
+                    context: 'A locked-room mystery.',
+                    HubGreetingMessages: [{ text: 'The door was locked.' }, { text: 'Again?' }],
+                    HubExampleMessages: [{ characterName: 'Iris', text: 'Check the hinges.' }],
+                  },
+                },
+                LorebookItems: [{ key: 'Manor', value: 'An isolated old house.' }],
+              },
+            },
+          },
+        },
+      ]),
+    )
+
+    const blob = await provider.downloadCard(card)
+    const [requestUrl, init] = corsFetchMock.mock.calls[0] as [string, RequestInit | undefined]
+    expect(requestUrl).toContain('/hub.browse.getHubCharacterConfigById?batch=1&input=')
+    expect(decodeTrpcInput(requestUrl)).toEqual({
+      hubCharacterConfigId: 'config-9',
+      includeStandaloneGroupConfig: true,
+    })
+    expect(init).toBeUndefined()
+    expect(blob.type).toBe('application/json')
+    expect(JSON.parse(await blob.text())).toEqual({
+      name: 'Iris Vale',
+      description: 'Observant and methodical.',
+      personality: '',
+      scenario: 'A locked-room mystery.',
+      first_mes: 'The door was locked.',
+      mes_example: '<START>\nIris: Check the hinges.',
+      creator_notes: 'Original card notes.',
+      system_prompt: '',
+      post_history_instructions: '',
+      alternate_greetings: ['Again?'],
+      character_book: {
+        name: 'Iris Vale Lorebook',
+        entries: [
+          {
+            id: 1,
+            keys: ['Manor'],
+            secondary_keys: [],
+            content: 'An isolated old house.',
+            comment: 'Manor',
+            enabled: true,
+            constant: false,
+            selective: false,
+            insertion_order: 100,
+            position: 'before_char',
+          },
+        ],
+      },
+      tags: ['Mystery'],
+      creator: 'garden-author',
+      character_version: '1.0',
+      extensions: { backyard: { id: 'config-9', groupId: 'group-7' } },
+    })
+  })
+})

--- a/src/lib/services/discovery/providers/backyard.test.ts
+++ b/src/lib/services/discovery/providers/backyard.test.ts
@@ -171,6 +171,62 @@ describe('BackyardProvider', () => {
     expect(result.cards[0].nsfw).toBe(true)
   })
 
+  it('advances past filtered-only pages without hiding later safe results', async () => {
+    corsFetchMock
+      .mockResolvedValueOnce(
+        jsonResponse([
+          {
+            result: {
+              data: {
+                json: {
+                  nextCursor: 'safe-page',
+                  hubGroupConfigs: [
+                    {
+                      id: 'group-nsfw',
+                      isNSFW: true,
+                      CharacterConfigs: [{ id: 'config-nsfw', displayName: 'Filtered Character' }],
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse([
+          {
+            result: {
+              data: {
+                json: {
+                  nextCursor: 'cursor-3',
+                  hubGroupConfigs: [
+                    {
+                      id: 'group-safe',
+                      isNSFW: false,
+                      CharacterConfigs: [{ id: 'config-safe', displayName: 'Safe Character' }],
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        ]),
+      )
+
+    const result = await new BackyardProvider().search(
+      { query: 'adventure', page: 1, nsfw: false },
+      'character',
+    )
+
+    expect(corsFetchMock).toHaveBeenCalledTimes(2)
+    expect(decodeTrpcInput(corsFetchMock.mock.calls[1][0])).toEqual(
+      expect.objectContaining({ search: 'adventure', cursor: 'safe-page' }),
+    )
+    expect(result.cards.map((card) => card.id)).toEqual(['config-safe'])
+    expect(result).toEqual(expect.objectContaining({ hasMore: true, nextPage: 2 }))
+  })
+
   it('builds a stable page URL and downloads full character data as JSON', async () => {
     const provider = new BackyardProvider()
     const card = {

--- a/src/lib/services/discovery/providers/backyard.test.ts
+++ b/src/lib/services/discovery/providers/backyard.test.ts
@@ -144,6 +144,33 @@ describe('BackyardProvider', () => {
     )
   })
 
+  it('keeps NSFW groups when NSFW results are requested', async () => {
+    corsFetchMock.mockResolvedValueOnce(
+      jsonResponse([
+        {
+          result: {
+            data: {
+              json: {
+                hubGroupConfigs: [
+                  {
+                    id: 'group-nsfw',
+                    isNSFW: true,
+                    CharacterConfigs: [{ id: 'config-nsfw', displayName: 'Unfiltered Character' }],
+                  },
+                ],
+              },
+            },
+          },
+        },
+      ]),
+    )
+
+    const result = await new BackyardProvider().search({ query: '', nsfw: true }, 'character')
+
+    expect(result.cards.map((card) => card.id)).toEqual(['config-nsfw'])
+    expect(result.cards[0].nsfw).toBe(true)
+  })
+
   it('builds a stable page URL and downloads full character data as JSON', async () => {
     const provider = new BackyardProvider()
     const card = {

--- a/src/lib/services/discovery/providers/backyard.ts
+++ b/src/lib/services/discovery/providers/backyard.ts
@@ -33,7 +33,8 @@ export class BackyardProvider implements DiscoveryProvider {
         type: sortMap[options.sort || 'popular'] || 'Popularity',
         direction: 'desc',
       },
-      type: options.nsfw ? 'all' : 'sfw',
+      // Backyard now uses this field for chat topology, not content sensitivity.
+      type: 'all',
       direction: 'forward',
     }
 
@@ -95,7 +96,11 @@ export class BackyardProvider implements DiscoveryProvider {
       this.lastCursor = undefined
     }
 
-    const configs = data.hubGroupConfigs || []
+    const configs = (data.hubGroupConfigs || []).filter(
+      (config: any) =>
+        options.nsfw ||
+        !(config.isNSFW || config.CharacterConfigs?.some((character: any) => character.isNSFW)),
+    )
     const cards = configs.map((c: any) => this.transformCard(c))
 
     return {

--- a/src/lib/services/discovery/providers/backyard.ts
+++ b/src/lib/services/discovery/providers/backyard.ts
@@ -2,6 +2,9 @@ import type { DiscoveryCard, DiscoveryProvider, SearchOptions, SearchResult } fr
 import { corsFetch } from '../utils'
 
 const BACKYARD_API_BASE = 'https://backyard.ai/api/trpc'
+// Avoid making a safe search appear stuck when an upstream page contains only filtered cards.
+// A cap keeps one user action from walking an unexpectedly long provider feed.
+const MAX_FILTERED_PAGE_HOPS = 5
 
 export class BackyardProvider implements DiscoveryProvider {
   id = 'backyard'
@@ -66,48 +69,53 @@ export class BackyardProvider implements DiscoveryProvider {
       input.cursor = this.lastCursor
     }
 
-    const url = this.buildTrpcUrl('hub.browse.getHubGroupConfigsForTag', input)
-    console.log('[Backyard] Searching:', url)
+    for (let hop = 0; hop < MAX_FILTERED_PAGE_HOPS; hop++) {
+      const url = this.buildTrpcUrl('hub.browse.getHubGroupConfigsForTag', input)
+      console.log('[Backyard] Searching:', url)
 
-    const response = await corsFetch(url, {
-      method: 'GET',
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-      },
-    })
+      const response = await corsFetch(url, {
+        method: 'GET',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+      })
 
-    if (!response.ok) {
-      throw new Error(`Backyard API error: ${response.status}`)
+      if (!response.ok) {
+        throw new Error(`Backyard API error: ${response.status}`)
+      }
+
+      const json = await response.json()
+      // tRPC batch response: [{ result: { data: { json: ... } } }]
+      const data = json[0]?.result?.data?.json
+
+      if (!data) {
+        this.lastCursor = undefined
+        return { cards: [], hasMore: false }
+      }
+
+      this.lastCursor = data.nextCursor || undefined
+
+      const configs = (data.hubGroupConfigs || []).filter(
+        (config: any) =>
+          options.nsfw ||
+          !(config.isNSFW || config.CharacterConfigs?.some((character: any) => character.isNSFW)),
+      )
+      const cards = configs.map((c: any) => this.transformCard(c))
+      const hasMore = !!data.nextCursor
+
+      if (cards.length > 0 || !hasMore || options.nsfw || hop === MAX_FILTERED_PAGE_HOPS - 1) {
+        return {
+          cards,
+          hasMore,
+          nextPage: hasMore ? (options.page || 1) + 1 : undefined,
+        }
+      }
+
+      input.cursor = data.nextCursor
     }
 
-    const json = await response.json()
-    // tRPC batch response: [{ result: { data: { json: ... } } }]
-    const data = json[0]?.result?.data?.json
-
-    if (!data) {
-      return { cards: [], hasMore: false }
-    }
-
-    // Update cursor for next page
-    if (data.nextCursor) {
-      this.lastCursor = data.nextCursor
-    } else {
-      this.lastCursor = undefined
-    }
-
-    const configs = (data.hubGroupConfigs || []).filter(
-      (config: any) =>
-        options.nsfw ||
-        !(config.isNSFW || config.CharacterConfigs?.some((character: any) => character.isNSFW)),
-    )
-    const cards = configs.map((c: any) => this.transformCard(c))
-
-    return {
-      cards,
-      hasMore: !!data.nextCursor,
-      nextPage: data.nextCursor ? (options.page || 1) + 1 : undefined,
-    }
+    return { cards: [], hasMore: false }
   }
 
   private lastCursor?: string

--- a/src/lib/services/discovery/providers/characterTavern.test.ts
+++ b/src/lib/services/discovery/providers/characterTavern.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { corsFetchMock } = vi.hoisted(() => ({
+  corsFetchMock: vi.fn(),
+}))
+
+vi.mock('../utils', () => ({
+  corsFetch: corsFetchMock,
+}))
+
+import { CharacterTavernProvider } from './characterTavern'
+
+describe('CharacterTavernProvider', () => {
+  beforeEach(() => {
+    corsFetchMock.mockReset()
+  })
+
+  it('searches with the requested filters and maps safe results', async () => {
+    const safeHit = {
+      id: 'ct-17',
+      name: 'Captain Rowan',
+      inChatName: 'Rowan',
+      author: 'tavern-keeper',
+      tagline: 'An airship captain looking for a crew.',
+      path: 'tavern-keeper/captain-rowan',
+      tags: ['Adventure', 'Steampunk'],
+      downloads: 70,
+      views: 120,
+      likes: 11,
+      isNSFW: false,
+      characterDefinition: 'A seasoned captain.',
+      characterPersonality: 'Decisive and warm.',
+      characterScenario: 'The airship leaves at dawn.',
+      characterFirstMessage: 'Welcome aboard.',
+      characterExampleMessages: '<START>\nRowan: Cast off.',
+      characterPostHistoryPrompt: 'Keep the voyage moving.',
+      alternativeFirstMessage: ['You made it.'],
+    }
+    const unsafeHit = {
+      id: 'ct-18',
+      name: 'Filtered Result',
+      tags: ['NSFW'],
+      isNSFW: false,
+    }
+    corsFetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        hits: [safeHit, unsafeHit],
+        totalPages: 4,
+        page: 2,
+      }),
+    } as unknown as Response)
+
+    const provider = new CharacterTavernProvider()
+    const result = await provider.search(
+      {
+        query: 'airship captain',
+        limit: 12,
+        page: 2,
+        tags: ['Adventure', 'Steampunk'],
+        nsfw: false,
+      },
+      'character',
+    )
+
+    const [requestUrl, init] = corsFetchMock.mock.calls[0] as [string, RequestInit]
+    const url = new URL(requestUrl)
+    expect(`${url.origin}${url.pathname}`).toBe('https://character-tavern.com/api/search/cards')
+    expect(Object.fromEntries(url.searchParams)).toEqual({
+      query: 'airship captain',
+      limit: '12',
+      page: '2',
+      tags: 'Adventure,Steampunk',
+    })
+    expect(init).toEqual({ headers: { Accept: 'application/json' } })
+    expect(init.method).toBeUndefined()
+    expect(init.body).toBeUndefined()
+
+    expect(result).toEqual({
+      cards: [
+        {
+          id: 'ct-17',
+          name: 'Captain Rowan',
+          creator: 'tavern-keeper',
+          description: 'An airship captain looking for a crew.',
+          avatarUrl: 'https://cards.character-tavern.com/tavern-keeper/captain-rowan.png',
+          imageUrl: 'https://cards.character-tavern.com/tavern-keeper/captain-rowan.png',
+          tags: ['Adventure', 'Steampunk'],
+          stats: { downloads: 70, views: 120, rating: 11 },
+          source: 'character_tavern',
+          type: 'character',
+          nsfw: false,
+          raw: safeHit,
+        },
+      ],
+      hasMore: true,
+      nextPage: 3,
+    })
+  })
+
+  it('returns the card image URL and serializes the complete Tavern payload', async () => {
+    const provider = new CharacterTavernProvider()
+    const raw = {
+      path: 'tavern-keeper/captain-rowan',
+      tagline: 'An airship captain looking for a crew.',
+      characterDefinition: 'A seasoned captain.',
+      characterPersonality: 'Decisive and warm.',
+      characterScenario: 'The airship leaves at dawn.',
+      characterFirstMessage: 'Welcome aboard.',
+      characterExampleMessages: '<START>\nRowan: Cast off.',
+      characterPostHistoryPrompt: 'Keep the voyage moving.',
+      alternativeFirstMessage: ['You made it.'],
+    }
+    const card = {
+      id: 'ct-17',
+      name: 'Captain Rowan',
+      creator: 'tavern-keeper',
+      description: 'An airship captain looking for a crew.',
+      avatarUrl: 'https://cards.character-tavern.com/tavern-keeper/captain-rowan.png',
+      imageUrl: 'https://cards.character-tavern.com/tavern-keeper/captain-rowan.png',
+      tags: ['Adventure', 'Steampunk'],
+      source: 'character_tavern',
+      type: 'character' as const,
+      nsfw: false,
+      raw,
+    }
+
+    expect(await provider.getDownloadUrl(card)).toBe(card.imageUrl)
+    const blob = await provider.downloadCard(card)
+
+    expect(corsFetchMock).not.toHaveBeenCalled()
+    expect(blob.type).toBe('application/json')
+    expect(JSON.parse(await blob.text())).toEqual({
+      name: 'Captain Rowan',
+      description: 'A seasoned captain.',
+      personality: 'Decisive and warm.',
+      scenario: 'The airship leaves at dawn.',
+      first_mes: 'Welcome aboard.',
+      mes_example: '<START>\nRowan: Cast off.',
+      creator_notes: 'An airship captain looking for a crew.',
+      system_prompt: 'Keep the voyage moving.',
+      post_history_instructions: 'Keep the voyage moving.',
+      alternate_greetings: ['You made it.'],
+      tags: ['Adventure', 'Steampunk'],
+      creator: 'tavern-keeper',
+      character_version: '',
+      extensions: {
+        character_tavern: { id: 'ct-17', path: 'tavern-keeper/captain-rowan' },
+      },
+    })
+  })
+})

--- a/src/lib/services/discovery/providers/chub.test.ts
+++ b/src/lib/services/discovery/providers/chub.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { corsFetchMock } = vi.hoisted(() => ({
+  corsFetchMock: vi.fn(),
+}))
+
+vi.mock('../utils', () => ({
+  corsFetch: corsFetchMock,
+}))
+
+import { ChubProvider } from './chub'
+
+describe('ChubProvider', () => {
+  beforeEach(() => {
+    corsFetchMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('searches the character API with filters and maps its node contract', async () => {
+    const node = {
+      id: 'node-3',
+      fullPath: 'maker/clockwork-guide',
+      name: 'Clockwork Guide',
+      tagline: 'A guide to the brass city.',
+      topics: ['Adventure', 'Clockwork'],
+      nChats: 96,
+      starCount: 14,
+      nsfw: false,
+    }
+    corsFetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ data: { nodes: [node] } }),
+    } as unknown as Response)
+
+    const provider = new ChubProvider()
+    const result = await provider.search(
+      {
+        query: 'brass city',
+        limit: 1,
+        page: 3,
+        sort: 'name',
+        nsfw: false,
+        tags: ['Adventure', 'Clockwork'],
+      },
+      'character',
+    )
+
+    const [requestUrl, init] = corsFetchMock.mock.calls[0] as [string, RequestInit]
+    const url = new URL(requestUrl)
+    expect(`${url.origin}${url.pathname}`).toBe('https://api.chub.ai/search')
+    expect(Object.fromEntries(url.searchParams)).toEqual({
+      search: 'brass city',
+      first: '1',
+      page: '3',
+      sort: 'name',
+      asc: 'false',
+      nsfw: 'false',
+      nsfl: 'false',
+      topics: 'Adventure,Clockwork',
+    })
+    expect(init).toEqual({ method: 'GET', headers: { Accept: 'application/json' } })
+    expect(init.body).toBeUndefined()
+    expect(result).toEqual({
+      cards: [
+        {
+          id: 'maker/clockwork-guide',
+          name: 'Clockwork Guide',
+          creator: 'maker',
+          description: 'A guide to the brass city.',
+          avatarUrl: 'https://avatars.charhub.io/avatars/maker/clockwork-guide/chara_card_v2.png',
+          imageUrl: 'https://avatars.charhub.io/avatars/maker/clockwork-guide/chara_card_v2.png',
+          tags: ['Adventure', 'Clockwork'],
+          stats: { downloads: 96, rating: 14 },
+          source: 'chub',
+          type: 'character',
+          nsfw: false,
+          raw: { ...node, pageUrl: 'https://chub.ai/characters/maker/clockwork-guide' },
+        },
+      ],
+      hasMore: true,
+      nextPage: 4,
+    })
+  })
+
+  it('uses the lorebook gateway contract and maps lorebook identity', async () => {
+    const node = {
+      id: 'project-88',
+      fullPath: 'lorebooks/archivist/brass-city',
+      name: 'Brass City',
+      description: 'Places and factions of the brass city.',
+      topics: ['Setting', 'NSFW'],
+      downloadCount: 12,
+      starCount: 5,
+    }
+    corsFetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ nodes: [node] }),
+    } as unknown as Response)
+
+    const provider = new ChubProvider()
+    const result = await provider.search({ query: 'brass', limit: 48 }, 'lorebook')
+
+    const [requestUrl, init] = corsFetchMock.mock.calls[0] as [string, RequestInit]
+    const url = new URL(requestUrl)
+    expect(`${url.origin}${url.pathname}`).toBe('https://gateway.chub.ai/search')
+    expect(url.searchParams.get('namespace')).toBe('lorebooks')
+    expect(url.searchParams.get('include_forks')).toBe('true')
+    expect(url.searchParams.get('search')).toBe('brass')
+    expect(init).toEqual({ method: 'POST', headers: { Accept: 'application/json' } })
+    expect(init.body).toBeUndefined()
+    expect(result.cards[0]).toEqual({
+      id: 'archivist/brass-city',
+      name: 'Brass City',
+      creator: 'archivist',
+      description: 'Places and factions of the brass city.',
+      avatarUrl: 'https://avatars.charhub.io/avatars/lorebooks/archivist/brass-city/avatar.webp',
+      imageUrl: 'https://avatars.charhub.io/avatars/lorebooks/archivist/brass-city/avatar.webp',
+      tags: ['Setting', 'NSFW'],
+      stats: { downloads: 12, rating: 5 },
+      source: 'chub',
+      type: 'lorebook',
+      nsfw: true,
+      raw: { ...node, pageUrl: 'https://chub.ai/lorebooks/archivist/brass-city' },
+    })
+  })
+
+  it('downloads character PNG data with the provider-specific accept header', async () => {
+    const provider = new ChubProvider()
+    const card = {
+      id: 'maker/clockwork-guide',
+      name: 'Clockwork Guide',
+      creator: 'maker',
+      description: 'A guide.',
+      avatarUrl: '',
+      tags: [],
+      source: 'chub',
+      type: 'character' as const,
+      nsfw: false,
+    }
+    const downloaded = new Blob([new Uint8Array([137, 80, 78, 71])], { type: 'image/png' })
+    corsFetchMock.mockResolvedValueOnce({
+      ok: true,
+      blob: vi.fn().mockResolvedValue(downloaded),
+    } as unknown as Response)
+
+    const expectedUrl = 'https://avatars.charhub.io/avatars/maker/clockwork-guide/chara_card_v2.png'
+    expect(await provider.getDownloadUrl(card)).toBe(expectedUrl)
+    const blob = await provider.downloadCard(card)
+
+    expect(corsFetchMock).toHaveBeenCalledWith(expectedUrl, {
+      headers: { Accept: 'image/png' },
+    })
+    expect(blob.type).toBe('image/png')
+    expect([...new Uint8Array(await blob.arrayBuffer())]).toEqual([137, 80, 78, 71])
+  })
+
+  it('builds and downloads the raw SillyTavern lorebook URL', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.123456)
+    const provider = new ChubProvider()
+    const card = {
+      id: 'archivist/brass-city',
+      name: 'Brass City',
+      creator: 'archivist',
+      description: 'A setting book.',
+      avatarUrl: '',
+      tags: ['Setting'],
+      source: 'chub',
+      type: 'lorebook' as const,
+      nsfw: false,
+      raw: { id: 'project-88' },
+    }
+    const downloaded = new Blob(['{"entries":[]}'], { type: 'application/json' })
+    corsFetchMock.mockResolvedValueOnce({
+      ok: true,
+      blob: vi.fn().mockResolvedValue(downloaded),
+    } as unknown as Response)
+
+    const expectedUrl =
+      'https://gateway.chub.ai/api/v4/projects/project-88/repository/files/raw%252Fsillytavern_raw.json/raw?ref=main&response_type=blob&nocache=0.123456'
+    expect(await provider.getDownloadUrl(card)).toBe(expectedUrl)
+    const blob = await provider.downloadCard(card)
+
+    expect(corsFetchMock).toHaveBeenCalledWith(expectedUrl, {
+      headers: { Accept: 'application/json' },
+    })
+    expect(blob.type).toBe('application/json')
+    expect(await blob.text()).toBe('{"entries":[]}')
+  })
+})

--- a/src/lib/services/discovery/providers/janny.test.ts
+++ b/src/lib/services/discovery/providers/janny.test.ts
@@ -184,6 +184,40 @@ describe('JannyProvider', () => {
     expect(await blob.text()).toBe('png-card-payload')
   })
 
+  it.each([
+    ['malformed', 'not a URL'],
+    ['non-HTTPS', 'http://cdn.jannyai.com/cards/astra.png'],
+    ['nonstandard port', 'https://cdn.jannyai.com:444/cards/astra.png'],
+    ['lookalike host', 'https://cdn.jannyai.com.evil.example/cards/astra.png'],
+    ['untrusted subdomain', 'https://evil.jannyai.com/cards/astra.png'],
+  ])('rejects a %s download URL', async (_case, downloadUrl) => {
+    mockCorsFetch.mockResolvedValueOnce(jsonResponse({ status: 'ok', downloadUrl }))
+
+    const { JannyProvider } = await import('./janny')
+    await expect(new JannyProvider().downloadCard(discoveryCard())).rejects.toThrow(
+      'JannyAI did not return a character download',
+    )
+    expect(mockCorsFetch).toHaveBeenCalledOnce()
+  })
+
+  it('rejects a download payload without a usable URL', async () => {
+    mockCorsFetch.mockResolvedValueOnce(jsonResponse({ status: 'error' }))
+
+    const { JannyProvider } = await import('./janny')
+    await expect(new JannyProvider().downloadCard(discoveryCard())).rejects.toThrow(
+      'JannyAI did not return a character download',
+    )
+  })
+
+  it('throws for non-403 download failures', async () => {
+    mockCorsFetch.mockResolvedValueOnce(new Response('Unavailable', { status: 500 }))
+
+    const { JannyProvider } = await import('./janny')
+    await expect(new JannyProvider().downloadCard(discoveryCard())).rejects.toThrow(
+      'Failed to fetch JannyAI character: 500',
+    )
+  })
+
   it('returns an explicit metadata-only V2 card when Cloudflare blocks downloads', async () => {
     const card = discoveryCard()
     mockCorsFetch.mockResolvedValueOnce(new Response('Forbidden', { status: 403 }))
@@ -206,7 +240,9 @@ describe('JannyProvider', () => {
       data: expect.objectContaining({
         name: 'Astra & Co.',
         description: 'A spacefaring guide.',
-        scenario: 'A spacefaring guide.',
+        scenario: '',
+        creator_notes:
+          'Imported from JannyAI search metadata only. Full card unavailable. https://jannyai.com/characters/character-42_character-astra-co',
         tags: ['NSFW', 'Fantasy'],
         extensions: {
           jannyai: {

--- a/src/lib/services/discovery/providers/janny.test.ts
+++ b/src/lib/services/discovery/providers/janny.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { METADATA_ONLY_CHARACTER_MIME } from '../types'
 import type { DiscoveryCard } from '../types'
 
 const { mockCorsFetch } = vi.hoisted(() => ({
@@ -218,9 +219,23 @@ describe('JannyProvider', () => {
     )
   })
 
+  it('does not treat an unrelated 403 as a Cloudflare challenge', async () => {
+    mockCorsFetch.mockResolvedValueOnce(new Response('Forbidden', { status: 403 }))
+
+    const { JannyProvider } = await import('./janny')
+    await expect(new JannyProvider().downloadCard(discoveryCard())).rejects.toThrow(
+      'Failed to fetch JannyAI character: 403',
+    )
+  })
+
   it('returns an explicit metadata-only V2 card when Cloudflare blocks downloads', async () => {
     const card = discoveryCard()
-    mockCorsFetch.mockResolvedValueOnce(new Response('Forbidden', { status: 403 }))
+    mockCorsFetch.mockResolvedValueOnce(
+      new Response('Cloudflare challenge', {
+        status: 403,
+        headers: { Server: 'cloudflare', 'CF-Ray': 'fixture-ray' },
+      }),
+    )
 
     const { JannyProvider } = await import('./janny')
     const blob = await new JannyProvider().downloadCard(card)
@@ -233,7 +248,7 @@ describe('JannyProvider', () => {
         body: JSON.stringify({ characterId: 'character-42' }),
       }),
     )
-    expect(blob.type).toBe('application/json')
+    expect(blob.type).toBe(METADATA_ONLY_CHARACTER_MIME)
     expect(payload).toEqual({
       spec: 'chara_card_v2',
       spec_version: '2.0',
@@ -253,5 +268,24 @@ describe('JannyProvider', () => {
         },
       }),
     })
+  })
+
+  it('uses the metadata-only fallback when Cloudflare blocks the card CDN', async () => {
+    mockCorsFetch
+      .mockResolvedValueOnce(
+        jsonResponse({ status: 'ok', downloadUrl: 'https://cdn.jannyai.com/cards/astra.png' }),
+      )
+      .mockResolvedValueOnce(
+        new Response('Cloudflare challenge', {
+          status: 403,
+          headers: { 'CF-Mitigated': 'challenge' },
+        }),
+      )
+
+    const { JannyProvider } = await import('./janny')
+    const blob = await new JannyProvider().downloadCard(discoveryCard())
+
+    expect(blob.type).toBe(METADATA_ONLY_CHARACTER_MIME)
+    expect(JSON.parse(await blob.text()).data.extensions.jannyai.metadataOnly).toBe(true)
   })
 })

--- a/src/lib/services/discovery/providers/janny.test.ts
+++ b/src/lib/services/discovery/providers/janny.test.ts
@@ -1,0 +1,221 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DiscoveryCard } from '../types'
+
+const { mockCorsFetch } = vi.hoisted(() => ({
+  mockCorsFetch: vi.fn(),
+}))
+
+vi.mock('../utils', () => ({
+  corsFetch: mockCorsFetch,
+  GENERIC_ICON: 'generic-icon',
+}))
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+    ...init,
+  })
+}
+
+function discoveryCard(): DiscoveryCard {
+  return {
+    id: 'character-42',
+    name: 'Astra & Co.',
+    creator: '',
+    description: 'A spacefaring guide.',
+    avatarUrl: 'https://image.jannyai.com/bot-avatars/astra.webp',
+    imageUrl: 'https://image.jannyai.com/bot-avatars/astra.webp',
+    tags: ['NSFW', 'Fantasy'],
+    stats: { downloads: 73 },
+    source: 'janny',
+    type: 'character',
+    nsfw: true,
+    raw: {
+      slug: 'astra-co',
+      pageUrl: 'https://jannyai.com/characters/character-42_character-astra-co',
+    },
+  }
+}
+
+describe('JannyProvider', () => {
+  beforeEach(() => {
+    mockCorsFetch.mockReset()
+    vi.resetModules()
+  })
+
+  it('searches Meilisearch with the discovered token and maps a scenario hit', async () => {
+    const token = 'a'.repeat(64)
+    mockCorsFetch
+      .mockResolvedValueOnce(
+        new Response('<script src="client-config.fixture.js"></script>', {
+          status: 200,
+          headers: { 'Content-Type': 'text/html' },
+        }),
+      )
+      .mockResolvedValueOnce(new Response(`window.config = "${token}"`, { status: 200 }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          results: [
+            {
+              hits: [
+                {
+                  id: 'character-42',
+                  name: 'Astra & Co.',
+                  description: '<p>A spacefaring&nbsp;guide &amp; pilot.</p>',
+                  avatar: 'astra.webp',
+                  tagIds: [53, 999],
+                  isNsfw: true,
+                  stats: { chatCount: 73 },
+                },
+              ],
+            },
+          ],
+        }),
+      )
+
+    const { JannyProvider } = await import('./janny')
+    const provider = new JannyProvider()
+    const result = await provider.search(
+      {
+        query: 'space guide',
+        page: 2,
+        limit: 1,
+        sort: 'name',
+        nsfw: false,
+      },
+      'scenario',
+    )
+
+    expect(mockCorsFetch).toHaveBeenNthCalledWith(
+      1,
+      'https://jannyai.com/characters/search',
+      expect.objectContaining({ headers: { Accept: 'text/html' } }),
+    )
+    expect(mockCorsFetch).toHaveBeenNthCalledWith(
+      2,
+      'https://jannyai.com/_astro/client-config.fixture.js',
+    )
+
+    const [searchUrl, searchInit] = mockCorsFetch.mock.calls[2] as [string, RequestInit]
+    expect(searchUrl).toBe('https://search.jannyai.com/multi-search')
+    expect(searchInit.method).toBe('POST')
+    expect(searchInit.headers).toMatchObject({
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      Origin: 'https://jannyai.com',
+    })
+    expect(JSON.parse(String(searchInit.body))).toEqual({
+      queries: [
+        expect.objectContaining({
+          indexUid: 'janny-characters',
+          q: 'space guide',
+          hitsPerPage: 1,
+          page: 2,
+          sort: ['name:asc'],
+          filter: ['totalToken <= 4101 AND totalToken >= 29', '(isNsfw = false)'],
+        }),
+      ],
+    })
+
+    expect(result).toEqual({
+      cards: [
+        expect.objectContaining({
+          id: 'character-42',
+          name: 'Astra & Co.',
+          creator: '',
+          description: 'A spacefaring guide & pilot.',
+          avatarUrl: 'https://image.jannyai.com/bot-avatars/astra.webp',
+          imageUrl: 'https://image.jannyai.com/bot-avatars/astra.webp',
+          tags: ['NSFW', 'Fantasy', 'Tag 999'],
+          stats: { downloads: 73 },
+          source: 'janny',
+          type: 'character',
+          nsfw: true,
+          raw: expect.objectContaining({
+            id: 'character-42',
+            slug: 'astra-co',
+            pageUrl: 'https://jannyai.com/characters/character-42_character-astra-co',
+          }),
+        }),
+      ],
+      hasMore: true,
+      nextPage: 3,
+    })
+  })
+
+  it('uses the first-party download API and returns the downloaded card blob', async () => {
+    const card = discoveryCard()
+    mockCorsFetch
+      .mockResolvedValueOnce(
+        jsonResponse({ status: 'ok', downloadUrl: 'https://cdn.jannyai.com/cards/astra.png' }),
+      )
+      .mockResolvedValueOnce(
+        new Response('png-card-payload', {
+          status: 200,
+          headers: { 'Content-Type': 'image/png' },
+        }),
+      )
+
+    const { JannyProvider } = await import('./janny')
+    const provider = new JannyProvider()
+
+    expect(await provider.getDownloadUrl(card)).toBe(
+      'https://jannyai.com/characters/character-42_character-astra-co',
+    )
+
+    const blob = await provider.downloadCard(card)
+
+    expect(mockCorsFetch).toHaveBeenNthCalledWith(
+      1,
+      'https://api.jannyai.com/api/v1/download',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          Origin: 'https://jannyai.com',
+        }),
+        body: JSON.stringify({ characterId: 'character-42' }),
+      }),
+    )
+    expect(mockCorsFetch).toHaveBeenNthCalledWith(2, 'https://cdn.jannyai.com/cards/astra.png')
+    expect(blob.type).toBe('image/png')
+    expect(await blob.text()).toBe('png-card-payload')
+  })
+
+  it('returns an explicit metadata-only V2 card when Cloudflare blocks downloads', async () => {
+    const card = discoveryCard()
+    mockCorsFetch.mockResolvedValueOnce(new Response('Forbidden', { status: 403 }))
+
+    const { JannyProvider } = await import('./janny')
+    const blob = await new JannyProvider().downloadCard(card)
+    const payload = JSON.parse(await blob.text())
+
+    expect(mockCorsFetch).toHaveBeenCalledWith(
+      'https://api.jannyai.com/api/v1/download',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ characterId: 'character-42' }),
+      }),
+    )
+    expect(blob.type).toBe('application/json')
+    expect(payload).toEqual({
+      spec: 'chara_card_v2',
+      spec_version: '2.0',
+      data: expect.objectContaining({
+        name: 'Astra & Co.',
+        description: 'A spacefaring guide.',
+        scenario: 'A spacefaring guide.',
+        tags: ['NSFW', 'Fantasy'],
+        extensions: {
+          jannyai: {
+            id: 'character-42',
+            pageUrl: 'https://jannyai.com/characters/character-42_character-astra-co',
+            metadataOnly: true,
+          },
+        },
+      }),
+    })
+  })
+})

--- a/src/lib/services/discovery/providers/janny.ts
+++ b/src/lib/services/discovery/providers/janny.ts
@@ -2,6 +2,7 @@ import type { DiscoveryProvider, DiscoveryCard, SearchOptions, SearchResult } fr
 import { corsFetch, GENERIC_ICON } from '../utils'
 
 const JANNY_SEARCH_URL = 'https://search.jannyai.com/multi-search'
+const JANNY_DOWNLOAD_URL = 'https://api.jannyai.com/api/v1/download'
 const JANNY_IMAGE_BASE = 'https://image.jannyai.com/bot-avatars/'
 
 // Cached token
@@ -226,97 +227,70 @@ export class JannyProvider implements DiscoveryProvider {
   }
 
   async getDownloadUrl(card: DiscoveryCard): Promise<string> {
-    // JannyAI cards need to be fetched from the character page and parsed
-    // We return the page URL - downloadCard will handle the scraping
     const slug = card.raw?.slug || 'character'
-    return `https://jannyai.com/characters/${card.id}_${slug}`
+    return card.raw?.pageUrl || `https://jannyai.com/characters/${card.id}_character-${slug}`
   }
 
   async downloadCard(card: DiscoveryCard): Promise<Blob> {
-    // For JannyAI, we need to scrape the character page to get full data
-    const url = await this.getDownloadUrl(card)
-    console.log('[Janny] Fetching character page:', url)
-
-    const response = await corsFetch(url, {
-      headers: { Accept: 'text/html' },
+    const response = await corsFetch(JANNY_DOWNLOAD_URL, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        Origin: 'https://jannyai.com',
+        Referer: 'https://jannyai.com/',
+      },
+      body: JSON.stringify({ characterId: card.id }),
     })
 
-    if (!response.ok) {
+    if (response.ok) {
+      const result = await response.json()
+      if (result?.status !== 'ok' || typeof result.downloadUrl !== 'string') {
+        throw new Error('JannyAI did not return a character download')
+      }
+
+      const cardResponse = await corsFetch(result.downloadUrl)
+      if (!cardResponse.ok) {
+        throw new Error(`Failed to download JannyAI character: ${cardResponse.status}`)
+      }
+
+      return cardResponse.blob()
+    }
+
+    if (response.status !== 403) {
       throw new Error(`Failed to fetch JannyAI character: ${response.status}`)
     }
 
-    const html = await response.text()
-    const characterData = this.parseAstroProps(html)
-
-    // Convert to SillyTavern-compatible JSON format
-    const stCard = this.convertToSTFormat(characterData)
+    console.warn('[Janny] Download blocked by Cloudflare; importing search metadata only')
+    const stCard = this.convertSearchResultToSTFormat(card)
     const jsonString = JSON.stringify(stCard, null, 2)
 
     return new Blob([jsonString], { type: 'application/json' })
   }
 
-  private parseAstroProps(html: string): any {
-    const astroMatch = html.match(
-      /astro-island[^>]*component-export="CharacterButtons"[^>]*props="([^"]+)"/,
-    )
-    if (!astroMatch) {
-      throw new Error('Could not find character data in JannyAI page')
-    }
-
-    const propsEncoded = astroMatch[1]
-    const propsDecoded = propsEncoded
-      .replace(/&quot;/g, '"')
-      .replace(/&amp;/g, '&')
-      .replace(/&lt;/g, '<')
-      .replace(/&gt;/g, '>')
-      .replace(/&#39;/g, "'")
-
-    const propsJson = JSON.parse(propsDecoded)
-    return this.decodeAstroValue(propsJson.character)
-  }
-
-  private decodeAstroValue(value: any): any {
-    if (!Array.isArray(value)) return value
-    const [type, data] = value
-    if (type === 0) {
-      if (typeof data === 'object' && data !== null && !Array.isArray(data)) {
-        const decoded: Record<string, any> = {}
-        for (const [key, val] of Object.entries(data)) {
-          decoded[key] = this.decodeAstroValue(val)
-        }
-        return decoded
-      }
-      return data
-    } else if (type === 1) {
-      return data.map((item: any) => this.decodeAstroValue(item))
-    }
-    return data
-  }
-
-  private convertToSTFormat(char: any): any {
-    const tags = (char.tagIds || []).map((id: number) => JANNYAI_TAGS[id] || `Tag ${id}`)
-
+  private convertSearchResultToSTFormat(card: DiscoveryCard): any {
     return {
       spec: 'chara_card_v2',
       spec_version: '2.0',
       data: {
-        name: char.name || 'Unnamed',
-        description: char.personality || '',
+        name: card.name || 'Unnamed',
+        description: card.description || '',
         personality: '',
-        scenario: char.scenario || '',
-        first_mes: char.firstMessage || '',
-        mes_example: char.exampleDialogs || '',
-        creator_notes: this.stripHtml(char.description || ''),
+        scenario: card.description || '',
+        first_mes: '',
+        mes_example: '',
+        creator_notes: card.description || '',
         system_prompt: '',
         post_history_instructions: '',
         alternate_greetings: [],
-        tags,
-        creator: '',
+        tags: card.tags,
+        creator: card.creator,
         character_version: '1.0',
         extensions: {
           jannyai: {
-            id: char.id,
-            creatorId: char.creatorId,
+            id: card.id,
+            pageUrl: card.raw?.pageUrl,
+            metadataOnly: true,
           },
         },
       },

--- a/src/lib/services/discovery/providers/janny.ts
+++ b/src/lib/services/discovery/providers/janny.ts
@@ -1,4 +1,10 @@
-import type { DiscoveryProvider, DiscoveryCard, SearchOptions, SearchResult } from '../types'
+import {
+  METADATA_ONLY_CHARACTER_MIME,
+  type DiscoveryProvider,
+  type DiscoveryCard,
+  type SearchOptions,
+  type SearchResult,
+} from '../types'
 import { corsFetch, GENERIC_ICON } from '../utils'
 
 const JANNY_SEARCH_URL = 'https://search.jannyai.com/multi-search'
@@ -6,6 +12,16 @@ const JANNY_DOWNLOAD_URL = 'https://api.jannyai.com/api/v1/download'
 const JANNY_IMAGE_BASE = 'https://image.jannyai.com/bot-avatars/'
 // The API controls the returned URL, so keep this exact to prevent Tauri HTTP from fetching arbitrary hosts.
 const JANNY_DOWNLOAD_HOSTS = new Set(['cdn.jannyai.com', 'image.jannyai.com'])
+
+function isCloudflareChallenge(response: Response): boolean {
+  if (response.status !== 403) return false
+
+  return (
+    response.headers.has('cf-ray') ||
+    response.headers.get('cf-mitigated')?.toLowerCase() === 'challenge' ||
+    response.headers.get('server')?.toLowerCase().includes('cloudflare') === true
+  )
+}
 
 // Cached token
 let cachedToken: string | null = null
@@ -268,21 +284,28 @@ export class JannyProvider implements DiscoveryProvider {
 
       const cardResponse = await corsFetch(downloadUrl.href)
       if (!cardResponse.ok) {
+        if (isCloudflareChallenge(cardResponse)) {
+          return this.createMetadataOnlyCard(card)
+        }
         throw new Error(`Failed to download JannyAI character: ${cardResponse.status}`)
       }
 
       return cardResponse.blob()
     }
 
-    if (response.status !== 403) {
+    if (!isCloudflareChallenge(response)) {
       throw new Error(`Failed to fetch JannyAI character: ${response.status}`)
     }
 
+    return this.createMetadataOnlyCard(card)
+  }
+
+  private createMetadataOnlyCard(card: DiscoveryCard): Blob {
     console.warn('[Janny] Download blocked by Cloudflare; importing search metadata only')
     const stCard = this.convertSearchResultToSTFormat(card)
     const jsonString = JSON.stringify(stCard, null, 2)
 
-    return new Blob([jsonString], { type: 'application/json' })
+    return new Blob([jsonString], { type: METADATA_ONLY_CHARACTER_MIME })
   }
 
   private convertSearchResultToSTFormat(card: DiscoveryCard): any {

--- a/src/lib/services/discovery/providers/janny.ts
+++ b/src/lib/services/discovery/providers/janny.ts
@@ -4,6 +4,8 @@ import { corsFetch, GENERIC_ICON } from '../utils'
 const JANNY_SEARCH_URL = 'https://search.jannyai.com/multi-search'
 const JANNY_DOWNLOAD_URL = 'https://api.jannyai.com/api/v1/download'
 const JANNY_IMAGE_BASE = 'https://image.jannyai.com/bot-avatars/'
+// The API controls the returned URL, so keep this exact to prevent Tauri HTTP from fetching arbitrary hosts.
+const JANNY_DOWNLOAD_HOSTS = new Set(['cdn.jannyai.com', 'image.jannyai.com'])
 
 // Cached token
 let cachedToken: string | null = null
@@ -249,7 +251,22 @@ export class JannyProvider implements DiscoveryProvider {
         throw new Error('JannyAI did not return a character download')
       }
 
-      const cardResponse = await corsFetch(result.downloadUrl)
+      let downloadUrl: URL
+      try {
+        downloadUrl = new URL(result.downloadUrl)
+      } catch {
+        throw new Error('JannyAI did not return a character download')
+      }
+
+      if (
+        downloadUrl.protocol !== 'https:' ||
+        downloadUrl.port !== '' ||
+        !JANNY_DOWNLOAD_HOSTS.has(downloadUrl.hostname)
+      ) {
+        throw new Error('JannyAI did not return a character download')
+      }
+
+      const cardResponse = await corsFetch(downloadUrl.href)
       if (!cardResponse.ok) {
         throw new Error(`Failed to download JannyAI character: ${cardResponse.status}`)
       }
@@ -276,10 +293,11 @@ export class JannyProvider implements DiscoveryProvider {
         name: card.name || 'Unnamed',
         description: card.description || '',
         personality: '',
-        scenario: card.description || '',
+        scenario: '',
         first_mes: '',
         mes_example: '',
-        creator_notes: card.description || '',
+        creator_notes:
+          `Imported from JannyAI search metadata only. Full card unavailable. ${card.raw?.pageUrl || ''}`.trim(),
         system_prompt: '',
         post_history_instructions: '',
         alternate_greetings: [],

--- a/src/lib/services/discovery/providers/mlpchag.test.ts
+++ b/src/lib/services/discovery/providers/mlpchag.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { corsFetchMock } = vi.hoisted(() => ({
+  corsFetchMock: vi.fn(),
+}))
+
+vi.mock('../utils', () => ({
+  corsFetch: corsFetchMock,
+  GENERIC_ICON: 'generic-icon',
+}))
+
+import { MlpchagProvider } from './mlpchag'
+
+describe('MlpchagProvider', () => {
+  beforeEach(() => {
+    corsFetchMock.mockReset()
+  })
+
+  it('loads the index, maps and filters a card, then serializes it for download', async () => {
+    const fixture = {
+      'Twilight Sparkle/Research Assistant.png': {
+        name: 'Research Assistant',
+        author: 'ArchiveAuthor',
+        description: 'A careful magical researcher.',
+        personality: 'Curious and precise.',
+        scenario: 'A newly opened archive.',
+        greetings: ['I catalogued the first shelf.', 'Ready for the next one?'],
+        examples: '<START>\nAssistant: Cross-reference that volume.',
+        creator_notes: 'Archive-compatible card.',
+        system_prompt: 'Stay methodical.',
+        post_history_instructions: 'Track discovered volumes.',
+        character_version: '2.1',
+        character_book: { name: 'Archive', entries: [] },
+        tags: ['Unicorn', 'Research'],
+        nsfw: false,
+        datecreate: '2026-01-02',
+      },
+      'Other/Guard.png': {
+        name: 'Night Guard',
+        tags: ['Pegasus'],
+      },
+    }
+    corsFetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: vi.fn().mockResolvedValue(fixture),
+    } as unknown as Response)
+
+    const provider = new MlpchagProvider()
+    const result = await provider.search(
+      {
+        query: 'archiveauthor',
+        page: 1,
+        limit: 10,
+        sort: 'new',
+        tags: ['Research'],
+      },
+      'character',
+    )
+
+    expect(corsFetchMock).toHaveBeenCalledWith('https://mlpchag.neocities.org/mares.json')
+    const expectedImageUrl =
+      'https://mlpchag.neocities.org/cards/Twilight%20Sparkle/Research%20Assistant.png'
+    expect(result).toEqual({
+      cards: [
+        {
+          id: 'mlpchag_Twilight Sparkle/Research Assistant.png',
+          name: 'Research Assistant',
+          creator: 'ArchiveAuthor',
+          description: 'A careful magical researcher.',
+          avatarUrl: expectedImageUrl,
+          imageUrl: expectedImageUrl,
+          tags: ['Unicorn', 'Research'],
+          stats: {},
+          source: 'mlpchag',
+          type: 'character',
+          nsfw: false,
+          raw: {
+            ...fixture['Twilight Sparkle/Research Assistant.png'],
+            _key: 'Twilight Sparkle/Research Assistant.png',
+          },
+        },
+      ],
+      hasMore: false,
+      nextPage: undefined,
+    })
+
+    const card = result.cards[0]
+    expect(await provider.getDownloadUrl(card)).toBe(expectedImageUrl)
+    const blob = await provider.downloadCard(card)
+
+    expect(blob.type).toBe('application/json')
+    expect(JSON.parse(await blob.text())).toEqual({
+      name: 'Research Assistant',
+      description: 'A careful magical researcher.',
+      personality: 'Curious and precise.',
+      scenario: 'A newly opened archive.',
+      first_mes: 'I catalogued the first shelf.',
+      mes_example: '<START>\nAssistant: Cross-reference that volume.',
+      creator_notes: 'Archive-compatible card.',
+      system_prompt: 'Stay methodical.',
+      post_history_instructions: 'Track discovered volumes.',
+      alternate_greetings: ['Ready for the next one?'],
+      tags: ['Unicorn', 'Research'],
+      creator: 'ArchiveAuthor',
+      character_version: '2.1',
+      character_book: { name: 'Archive', entries: [] },
+    })
+  })
+})

--- a/src/lib/services/discovery/providers/providers.live.test.ts
+++ b/src/lib/services/discovery/providers/providers.live.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest'
+import { CharacterTavernProvider } from './characterTavern'
+import { ChubProvider } from './chub'
+import { MlpchagProvider } from './mlpchag'
+import { QuillGenProvider } from './quillgen'
+import { WyvernProvider } from './wyvern'
+
+vi.mock('../utils', () => ({
+  // Provider production code uses Tauri HTTP; live Node tests use the platform fetch equivalent.
+  corsFetch: (url: string, options?: RequestInit) => globalThis.fetch(url, options),
+  GENERIC_ICON: 'generic-icon',
+}))
+
+const live = process.env.AVENTURAS_LIVE_DISCOVERY === '1'
+
+describe.skipIf(!live)('discovery providers live smoke', () => {
+  it.each([
+    ['Character Tavern', () => new CharacterTavernProvider()],
+    ['Chub', () => new ChubProvider()],
+    ['MLPChag', () => new MlpchagProvider()],
+    ['QuillGen', () => new QuillGenProvider()],
+    ['Wyvern', () => new WyvernProvider()],
+  ])(
+    '$s finds and downloads a public character',
+    async (_name, makeProvider) => {
+      const provider = makeProvider()
+      const result = await provider.search(
+        { query: '', page: 1, limit: 1, sort: 'popular', nsfw: false },
+        'character',
+      )
+      const card = result.cards[0]
+
+      expect(card, `${provider.name} returned no public characters`).toBeDefined()
+      expect(card.id).toBeTruthy()
+      expect(card.name).toBeTruthy()
+      expect(card.source).toBe(provider.id)
+      expect(await provider.getDownloadUrl(card)).toBeTruthy()
+
+      const blob = await provider.downloadCard(card)
+      expect(blob.size).toBeGreaterThan(0)
+      expect(blob.type).toBeTruthy()
+    },
+    30_000,
+  )
+})

--- a/src/lib/services/discovery/providers/providers.live.test.ts
+++ b/src/lib/services/discovery/providers/providers.live.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { CharacterTavernProvider } from './characterTavern'
-import { ChubProvider } from './chub'
-import { MlpchagProvider } from './mlpchag'
-import { QuillGenProvider } from './quillgen'
-import { WyvernProvider } from './wyvern'
+import { discoveryService } from '../index'
 
 vi.mock('../utils', () => ({
   // Provider production code uses Tauri HTTP; live Node tests use the platform fetch equivalent.
@@ -14,16 +10,14 @@ vi.mock('../utils', () => ({
 const live = process.env.AVENTURAS_LIVE_DISCOVERY === '1'
 
 describe.skipIf(!live)('discovery providers live smoke', () => {
-  it.each([
-    ['Character Tavern', () => new CharacterTavernProvider()],
-    ['Chub', () => new ChubProvider()],
-    ['MLPChag', () => new MlpchagProvider()],
-    ['QuillGen', () => new QuillGenProvider()],
-    ['Wyvern', () => new WyvernProvider()],
-  ])(
-    '$s finds and downloads a public character',
-    async (_name, makeProvider) => {
-      const provider = makeProvider()
+  // Build the matrix from the registry so adding a provider automatically adds a live contract.
+  it.each(
+    discoveryService
+      .getProviders('character')
+      .map((provider) => [provider.name, provider] as const),
+  )(
+    '%s finds and downloads a public character',
+    async (_name, provider) => {
       const result = await provider.search(
         { query: '', page: 1, limit: 1, sort: 'popular', nsfw: false },
         'character',

--- a/src/lib/services/discovery/providers/providers.live.test.ts
+++ b/src/lib/services/discovery/providers/providers.live.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
-import { discoveryService } from '../index'
+// The aggregate character-card API also loads its AI sanitizer and Svelte stores. Live provider
+// tests only need the production file reader/parser and run in a plain Node environment.
+// eslint-disable-next-line boundaries/dependencies
+import { parseJson } from '$lib/services/characterCardImport/parseJson'
+// eslint-disable-next-line boundaries/dependencies
+import { readFile } from '$lib/services/characterCardImport/readFile'
+import { discoveryService, METADATA_ONLY_CHARACTER_MIME } from '../index'
 
 vi.mock('../utils', () => ({
   // Provider production code uses Tauri HTTP; live Node tests use the platform fetch equivalent.
@@ -33,6 +39,19 @@ describe.skipIf(!live)('discovery providers live smoke', () => {
       const blob = await provider.downloadCard(card)
       expect(blob.size).toBeGreaterThan(0)
       expect(blob.type).toBeTruthy()
+
+      // Nonempty bytes are not sufficient: validate the payload through the same filename-based
+      // PNG/JSON reader and card parser used by Character Vault imports.
+      const extension = blob.type.includes('json') ? 'json' : 'png'
+      const file = new File([blob], `${card.name}.${extension}`, { type: blob.type })
+      const cardJson = await readFile(file)
+      const parsed = parseJson(cardJson)
+
+      expect(parsed, `${provider.name} returned an unusable character-card payload`).not.toBeNull()
+      expect(parsed?.name, `${provider.name} returned a card without a name`).toBeTruthy()
+
+      const mode = blob.type === METADATA_ONLY_CHARACTER_MIME ? 'metadata-only' : 'full-card'
+      console.info(`[Live discovery] ${provider.name}: ${mode}, ${blob.size} bytes`)
     },
     30_000,
   )

--- a/src/lib/services/discovery/providers/pygmalion.test.ts
+++ b/src/lib/services/discovery/providers/pygmalion.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { DiscoveryCard } from '../types'
+import { PygmalionProvider } from './pygmalion'
+
+const mocks = vi.hoisted(() => ({
+  corsFetch: vi.fn(),
+}))
+
+vi.mock('../utils', () => ({
+  corsFetch: mocks.corsFetch,
+  GENERIC_ICON: 'generic-icon',
+}))
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('PygmalionProvider', () => {
+  beforeEach(() => {
+    mocks.corsFetch.mockReset()
+  })
+
+  it('searches the Connect RPC endpoint and maps a character result', async () => {
+    const raw = {
+      id: 'pyg-42',
+      displayName: 'Aster Vale',
+      owner: { displayName: 'Mira', username: 'mira-fallback' },
+      description: 'An astronomer following a vanished constellation.',
+      avatarUrl: 'https://cdn.pygmalion.chat/aster.webp',
+      tags: ['astronomy', 'mystery'],
+      downloads: 321,
+      views: 654,
+      stars: 4.75,
+    }
+    mocks.corsFetch.mockResolvedValueOnce(jsonResponse({ characters: [raw] }))
+
+    const provider = new PygmalionProvider()
+    const result = await provider.search(
+      { query: 'Aster Vale', page: 2, limit: 25, sort: 'popular', nsfw: false },
+      'character',
+    )
+
+    expect(mocks.corsFetch).toHaveBeenCalledOnce()
+    expect(mocks.corsFetch).toHaveBeenCalledWith(
+      'https://server.pygmalion.chat/galatea.v1.PublicCharacterService/CharacterSearch',
+      {
+        method: 'POST',
+        headers: {
+          Accept: '*/*',
+          'Content-Type': 'application/json',
+          'Connect-Protocol-Version': '1',
+        },
+        body: JSON.stringify({
+          orderBy: 'downloads',
+          orderDescending: true,
+          includeSensitive: false,
+          pageSize: 25,
+          page: 1,
+          query: 'Aster Vale',
+        }),
+      },
+    )
+    expect(result).toEqual({
+      cards: [
+        {
+          id: 'pyg-42',
+          name: 'Aster Vale',
+          creator: 'Mira',
+          description: 'An astronomer following a vanished constellation.',
+          avatarUrl: 'https://cdn.pygmalion.chat/aster.webp',
+          imageUrl: 'https://cdn.pygmalion.chat/aster.webp',
+          tags: ['astronomy', 'mystery'],
+          stats: { downloads: 321, views: 654, rating: 4.75 },
+          source: 'pygmalion',
+          type: 'character',
+          nsfw: false,
+          raw,
+        },
+      ],
+      hasMore: false,
+      nextPage: undefined,
+    })
+  })
+
+  it('resolves its public page and downloads normalized character JSON', async () => {
+    const card = {
+      id: 'pyg-42',
+      name: 'Aster Vale',
+      creator: 'Mira',
+      description: 'Search description',
+      avatarUrl: '',
+      tags: [],
+      source: 'pygmalion',
+      type: 'character',
+      nsfw: false,
+    } satisfies DiscoveryCard
+    mocks.corsFetch.mockResolvedValueOnce(
+      jsonResponse({
+        character: {
+          id: 'pyg-42',
+          displayName: 'Aster Vale',
+          description: 'Creator notes',
+          tags: ['astronomy'],
+          owner: { displayName: 'Mira' },
+          versionLabel: '2.1',
+          personality: {
+            name: 'Aster',
+            persona: 'Patient, precise, and intensely curious.',
+            greeting: 'The observatory is usually quieter at this hour.',
+            creator: 'Mira Prime',
+          },
+        },
+      }),
+    )
+
+    const provider = new PygmalionProvider()
+    await expect(provider.getDownloadUrl(card)).resolves.toBe('https://pygmalion.chat/chat/pyg-42')
+    const blob = await provider.downloadCard(card)
+
+    expect(mocks.corsFetch).toHaveBeenCalledWith(
+      'https://server.pygmalion.chat/galatea.v1.PublicCharacterService/Character',
+      {
+        method: 'POST',
+        headers: {
+          Accept: '*/*',
+          'Content-Type': 'application/json',
+          'Connect-Protocol-Version': '1',
+        },
+        body: JSON.stringify({ characterMetaId: 'pyg-42' }),
+      },
+    )
+    expect(blob.type).toBe('application/json')
+    await expect(blob.text().then(JSON.parse)).resolves.toEqual({
+      name: 'Aster',
+      description: 'Patient, precise, and intensely curious.',
+      personality: '',
+      scenario: '',
+      first_mes: 'The observatory is usually quieter at this hour.',
+      mes_example: '',
+      creator_notes: 'Creator notes',
+      tags: ['astronomy'],
+      creator: 'Mira Prime',
+      character_version: '2.1',
+      extensions: { pygmalion: { id: 'pyg-42' } },
+    })
+  })
+})

--- a/src/lib/services/discovery/providers/quillgen.test.ts
+++ b/src/lib/services/discovery/providers/quillgen.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { DiscoveryCard } from '../types'
+
+const mocks = vi.hoisted(() => ({
+  corsFetch: vi.fn(),
+}))
+
+vi.mock('../utils', () => ({
+  corsFetch: mocks.corsFetch,
+}))
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('QuillGenProvider', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    mocks.corsFetch.mockReset()
+  })
+
+  it('loads the browse cache once and maps, filters, and paginates its cards', async () => {
+    const raw = {
+      id: 'quill-7',
+      public_id: 'public-fallback',
+      name: 'Clockwork Gardener',
+      creator: { name: 'Quillwright' },
+      description: 'A caretaker for impossible mechanical flowers.',
+      avatar_url: 'https://legacy.example/avatar.webp',
+      image_url: 'https://quillgen.app/cards/quill-7.png',
+      tags: ['clockwork', 'garden'],
+      downloads: 88,
+      nsfw: false,
+    }
+    mocks.corsFetch.mockResolvedValueOnce(jsonResponse({ cards: [raw] }))
+    const { QuillGenProvider } = await import('./quillgen')
+    const provider = new QuillGenProvider()
+
+    const first = await provider.search(
+      { query: 'GARDEN', page: 1, limit: 1, nsfw: false },
+      'character',
+    )
+    const cached = await provider.search({ query: '', page: 1, limit: 5 }, 'scenario')
+
+    expect(mocks.corsFetch).toHaveBeenCalledOnce()
+    expect(mocks.corsFetch).toHaveBeenCalledWith(
+      'https://quillgen.app/v1/public/api/browse/characters?limit=500',
+      { headers: { Accept: 'application/json' } },
+    )
+    const expectedCard = {
+      id: 'quill-7',
+      name: 'Clockwork Gardener',
+      creator: 'Quillwright',
+      description: 'A caretaker for impossible mechanical flowers.',
+      avatarUrl:
+        'https://quillgen.app/v1/public/api/browse/characters/quill-7/avatar?size=300&format=webp',
+      imageUrl:
+        'https://quillgen.app/v1/public/api/browse/characters/quill-7/avatar?size=300&format=webp',
+      tags: ['clockwork', 'garden'],
+      stats: { downloads: 88 },
+      source: 'quillgen',
+      type: 'character',
+      nsfw: false,
+      raw,
+    }
+    expect(first).toEqual({ cards: [expectedCard], hasMore: false, nextPage: undefined })
+    expect(cached).toEqual({ cards: [expectedCard], hasMore: false, nextPage: undefined })
+  })
+
+  it('uses the original card image URL as its downloadable artifact', async () => {
+    const card = {
+      id: 'quill-7',
+      name: 'Clockwork Gardener',
+      creator: 'Quillwright',
+      description: '',
+      avatarUrl: '',
+      tags: [],
+      source: 'quillgen',
+      type: 'character',
+      nsfw: false,
+      raw: { image_url: 'https://quillgen.app/cards/quill-7.png' },
+    } satisfies DiscoveryCard
+    const pngBytes = new Uint8Array([137, 80, 78, 71])
+    mocks.corsFetch.mockResolvedValueOnce(
+      new Response(pngBytes, { status: 200, headers: { 'Content-Type': 'image/png' } }),
+    )
+    const { QuillGenProvider } = await import('./quillgen')
+    const provider = new QuillGenProvider()
+
+    await expect(provider.getDownloadUrl(card)).resolves.toBe(
+      'https://quillgen.app/cards/quill-7.png',
+    )
+    const blob = await provider.downloadCard(card)
+
+    expect(mocks.corsFetch).toHaveBeenCalledWith('https://quillgen.app/cards/quill-7.png')
+    expect(blob.type).toBe('image/png')
+    expect(new Uint8Array(await blob.arrayBuffer())).toEqual(pngBytes)
+  })
+})

--- a/src/lib/services/discovery/providers/risuRealm.test.ts
+++ b/src/lib/services/discovery/providers/risuRealm.test.ts
@@ -116,7 +116,7 @@ describe('RisuRealmProvider', () => {
         creator_notes: 13,
       },
       'risu-9',
-      'Lantern Keeper',
+      null,
       'RealmScribe',
       'A guide through a city that dreams at night.',
       [7, 8],

--- a/src/lib/services/discovery/providers/risuRealm.test.ts
+++ b/src/lib/services/discovery/providers/risuRealm.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { DiscoveryCard } from '../types'
+import { RisuRealmProvider } from './risuRealm'
+
+const mocks = vi.hoisted(() => ({
+  corsFetch: vi.fn(),
+}))
+
+vi.mock('../utils', () => ({
+  corsFetch: mocks.corsFetch,
+}))
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('RisuRealmProvider', () => {
+  beforeEach(() => {
+    mocks.corsFetch.mockReset()
+    vi.restoreAllMocks()
+  })
+
+  it('requests SvelteKit data and resolves the devalue index graph into a card', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_712_345_678_901)
+    // Risu serializes object properties and arrays as indexes into this shared value table.
+    const devalueData = [
+      null,
+      [2],
+      { id: 3, name: 4, authorname: 5, desc: 6, img: 7, tags: 8, download: 9 },
+      'risu-9',
+      'Lantern Keeper',
+      'RealmScribe',
+      'A guide through a city that dreams at night.',
+      'lantern-keeper.webp',
+      [10, 11],
+      '1.25k',
+      'dreams',
+      'urban fantasy',
+    ]
+    mocks.corsFetch.mockResolvedValueOnce(jsonResponse({ nodes: [{}, { data: devalueData }] }))
+
+    const provider = new RisuRealmProvider()
+    const result = await provider.search(
+      { query: 'lantern keeper', page: 2, sort: 'popular', nsfw: false },
+      'character',
+    )
+
+    expect(mocks.corsFetch).toHaveBeenCalledWith(
+      'https://realm.risuai.net/__data.json?sort=download&page=2&q=lantern+keeper&nsfw=false&_t=1712345678901',
+      {
+        headers: {
+          Accept: 'application/json',
+          'Cache-Control': 'no-cache',
+        },
+      },
+    )
+    const raw = {
+      id: 'risu-9',
+      name: 'Lantern Keeper',
+      authorname: 'RealmScribe',
+      desc: 'A guide through a city that dreams at night.',
+      img: 'lantern-keeper.webp',
+      tags: ['dreams', 'urban fantasy'],
+      download: '1.25k',
+    }
+    expect(result).toEqual({
+      cards: [
+        {
+          id: 'risu-9',
+          name: 'Lantern Keeper',
+          creator: 'RealmScribe',
+          description: 'A guide through a city that dreams at night.',
+          avatarUrl: 'https://sv.risuai.xyz/resource/lantern-keeper.webp',
+          imageUrl: 'https://realm.risuai.net/character/risu-9',
+          tags: ['dreams', 'urban fantasy'],
+          stats: { downloads: 1250 },
+          source: 'risu_realm',
+          type: 'character',
+          nsfw: false,
+          raw,
+        },
+      ],
+      hasMore: false,
+      nextPage: undefined,
+    })
+  })
+
+  it('resolves its character page and downloads normalized JSON from devalue data', async () => {
+    const card = {
+      id: 'risu-9',
+      name: 'Lantern Keeper',
+      creator: 'RealmScribe',
+      description: '',
+      avatarUrl: '',
+      tags: [],
+      source: 'risu_realm',
+      type: 'character',
+      nsfw: false,
+    } satisfies DiscoveryCard
+    const devalueData = [
+      null,
+      { id: 2, name: 3, authorname: 4, desc: 5, tags: 6 },
+      'risu-9',
+      'Lantern Keeper',
+      'RealmScribe',
+      'A guide through a city that dreams at night.',
+      [7, 8],
+      'dreams',
+      'urban fantasy',
+    ]
+    mocks.corsFetch.mockResolvedValueOnce(jsonResponse({ nodes: [{}, { data: devalueData }] }))
+
+    const provider = new RisuRealmProvider()
+    await expect(provider.getDownloadUrl(card)).resolves.toBe(
+      'https://realm.risuai.net/character/risu-9',
+    )
+    const blob = await provider.downloadCard(card)
+
+    expect(mocks.corsFetch).toHaveBeenCalledWith(
+      'https://realm.risuai.net/character/risu-9/__data.json',
+    )
+    expect(blob.type).toBe('application/json')
+    await expect(blob.text().then(JSON.parse)).resolves.toEqual({
+      name: 'Lantern Keeper',
+      description: 'A guide through a city that dreams at night.',
+      personality: '',
+      scenario: '',
+      first_mes: '',
+      mes_example: '',
+      creator_notes: '',
+      tags: ['dreams', 'urban fantasy'],
+      creator: 'RealmScribe',
+      character_version: '1.0',
+      extensions: { risu_realm: { id: 'risu-9' } },
+    })
+  })
+})

--- a/src/lib/services/discovery/providers/risuRealm.test.ts
+++ b/src/lib/services/discovery/providers/risuRealm.test.ts
@@ -103,7 +103,18 @@ describe('RisuRealmProvider', () => {
     } satisfies DiscoveryCard
     const devalueData = [
       null,
-      { id: 2, name: 3, authorname: 4, desc: 5, tags: 6 },
+      {
+        id: 2,
+        name: 3,
+        authorname: 4,
+        desc: 5,
+        tags: 6,
+        personality: 9,
+        scenario: 10,
+        first_mes: 11,
+        mes_example: 12,
+        creator_notes: 13,
+      },
       'risu-9',
       'Lantern Keeper',
       'RealmScribe',
@@ -111,6 +122,11 @@ describe('RisuRealmProvider', () => {
       [7, 8],
       'dreams',
       'urban fantasy',
+      'Patient, watchful, and fond of riddles.',
+      'The city has begun dreaming while awake.',
+      'Keep your lantern close. The streets moved again.',
+      '<START>\n{{char}}: Do you remember this alley?',
+      'Keep the mystery gradual and atmospheric.',
     ]
     mocks.corsFetch.mockResolvedValueOnce(jsonResponse({ nodes: [{}, { data: devalueData }] }))
 
@@ -127,11 +143,11 @@ describe('RisuRealmProvider', () => {
     await expect(blob.text().then(JSON.parse)).resolves.toEqual({
       name: 'Lantern Keeper',
       description: 'A guide through a city that dreams at night.',
-      personality: '',
-      scenario: '',
-      first_mes: '',
-      mes_example: '',
-      creator_notes: '',
+      personality: 'Patient, watchful, and fond of riddles.',
+      scenario: 'The city has begun dreaming while awake.',
+      first_mes: 'Keep your lantern close. The streets moved again.',
+      mes_example: '<START>\n{{char}}: Do you remember this alley?',
+      creator_notes: 'Keep the mystery gradual and atmospheric.',
       tags: ['dreams', 'urban fantasy'],
       creator: 'RealmScribe',
       character_version: '1.0',

--- a/src/lib/services/discovery/providers/risuRealm.ts
+++ b/src/lib/services/discovery/providers/risuRealm.ts
@@ -205,7 +205,7 @@ export class RisuRealmProvider implements DiscoveryProvider {
     // Risu's decoded page data uses SillyTavern-compatible field names when the
     // author exposes them. Preserve those fields instead of reducing the card to metadata.
     const stCard = {
-      name: fullCard.name,
+      name: fullCard.name || card.name || 'Unnamed',
       description: fullCard.desc || '',
       personality: fullCard.personality || '',
       scenario: fullCard.scenario || '',

--- a/src/lib/services/discovery/providers/risuRealm.ts
+++ b/src/lib/services/discovery/providers/risuRealm.ts
@@ -202,25 +202,16 @@ export class RisuRealmProvider implements DiscoveryProvider {
       }
     }
 
-    // Convert to ST format
+    // Risu's decoded page data uses SillyTavern-compatible field names when the
+    // author exposes them. Preserve those fields instead of reducing the card to metadata.
     const stCard = {
       name: fullCard.name,
       description: fullCard.desc || '',
-      personality: '',
-      scenario: '',
-      first_mes: '', // RisuRealm might not expose first_mes in the public data? Bot Browser uses transformRisuRealmCard which doesn't seem to extract first_mes!
-      // Wait, Bot Browser's `transformFullRisuRealmCard` just wraps `transformRisuRealmCard` and adds `desc`.
-      // It seems RisuRealm public API might not expose all fields needed for a full card?
-      // Let's check if we can get more.
-      // The `__data.json` for a character page usually contains what's rendered.
-      // If RisuRealm hides first_mes, we might be out of luck or need another endpoint.
-      // However, usually these sites render the first message.
-      // Looking at `parseDevalueData` again, maybe I missed fields?
-      // `cardSchema` keys are dynamic.
-      // If `first_mes` isn't there, we can't get it.
-      // But for now, let's dump what we have.
-      mes_example: '',
-      creator_notes: '',
+      personality: fullCard.personality || '',
+      scenario: fullCard.scenario || '',
+      first_mes: fullCard.first_mes || '',
+      mes_example: fullCard.mes_example || '',
+      creator_notes: fullCard.creator_notes || '',
       tags: fullCard.tags || [],
       creator: fullCard.authorname,
       character_version: '1.0',
@@ -228,9 +219,6 @@ export class RisuRealmProvider implements DiscoveryProvider {
         risu_realm: { id: card.id },
       },
     }
-
-    // If RisuRealm exports a PNG, we might prefer that.
-    // But `__data.json` is what we have.
 
     const blob = new Blob([JSON.stringify(stCard, null, 2)], { type: 'application/json' })
     return blob

--- a/src/lib/services/discovery/providers/wyvern.test.ts
+++ b/src/lib/services/discovery/providers/wyvern.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { WyvernProvider } from './wyvern'
+
+const mocks = vi.hoisted(() => ({
+  corsFetch: vi.fn(),
+}))
+
+vi.mock('../utils', () => ({
+  corsFetch: mocks.corsFetch,
+  GENERIC_ICON: 'generic-icon',
+}))
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('WyvernProvider', () => {
+  beforeEach(() => {
+    mocks.corsFetch.mockReset()
+  })
+
+  it('searches and downloads a character directly from the result payload', async () => {
+    const raw = {
+      id: 'wyv-char-1',
+      name: 'Ash Cartographer',
+      creator: { displayName: 'MapMaker', vanityUrl: 'map-fallback' },
+      description: 'Maps roads that only appear after sunset.',
+      avatar: 'https://cdn.wyvern.chat/ash.webp',
+      tags: ['maps', 'fantasy'],
+      rating: 'mature',
+      statistics_record: { views: 400, likes: 37 },
+      personality: 'Methodical and dryly funny.',
+      scenario: 'A road has disappeared overnight.',
+      first_mes: 'That road was here yesterday.',
+      mes_example: '<START>\n{{char}}: Check the milestone again.',
+      creator_notes: 'Designed for mystery stories.',
+      pre_history_instructions: 'Keep discoveries internally consistent.',
+      post_history_instructions: 'Advance one clue at a time.',
+      alternate_greetings: ['You are late. The road is already moving.'],
+    }
+    mocks.corsFetch.mockResolvedValueOnce(jsonResponse({ results: [raw], hasMore: true, page: 3 }))
+
+    const provider = new WyvernProvider()
+    const result = await provider.search(
+      {
+        query: 'ash map',
+        page: 3,
+        limit: 12,
+        sort: 'name',
+        nsfw: false,
+        tags: ['maps', 'fantasy'],
+      },
+      'character',
+    )
+
+    expect(mocks.corsFetch).toHaveBeenCalledWith(
+      'https://api.wyvern.chat/exploreSearch/characters?q=ash+map&page=3&limit=12&sort=name&order=DESC&tags=maps%2Cfantasy&rating=none',
+      { headers: { Accept: 'application/json' } },
+    )
+    expect(result).toEqual({
+      cards: [
+        {
+          id: 'wyv-char-1',
+          name: 'Ash Cartographer',
+          creator: 'MapMaker',
+          description: 'Maps roads that only appear after sunset.',
+          avatarUrl: 'https://cdn.wyvern.chat/ash.webp',
+          imageUrl: 'https://cdn.wyvern.chat/ash.webp',
+          tags: ['maps', 'fantasy'],
+          stats: { views: 400, rating: 37 },
+          source: 'wyvern',
+          type: 'character',
+          nsfw: true,
+          raw,
+        },
+      ],
+      hasMore: true,
+      nextPage: 4,
+    })
+
+    const card = result.cards[0]
+    await expect(provider.getDownloadUrl(card)).resolves.toBe(
+      'https://wyvern.chat/characters/wyv-char-1',
+    )
+    const blob = await provider.downloadCard(card)
+
+    // Wyvern embeds complete card data in search results, so downloads require no second request.
+    expect(mocks.corsFetch).toHaveBeenCalledOnce()
+    expect(blob.type).toBe('application/json')
+    await expect(blob.text().then(JSON.parse)).resolves.toEqual({
+      name: 'Ash Cartographer',
+      description: 'Maps roads that only appear after sunset.',
+      personality: 'Methodical and dryly funny.',
+      scenario: 'A road has disappeared overnight.',
+      first_mes: 'That road was here yesterday.',
+      mes_example: '<START>\n{{char}}: Check the milestone again.',
+      creator_notes: 'Designed for mystery stories.',
+      system_prompt: 'Keep discoveries internally consistent.',
+      post_history_instructions: 'Advance one clue at a time.',
+      alternate_greetings: ['You are late. The road is already moving.'],
+      tags: ['maps', 'fantasy'],
+      creator: 'MapMaker',
+      character_version: '1.0',
+      extensions: { wyvern: { id: 'wyv-char-1' } },
+    })
+  })
+
+  it('searches and downloads a lorebook directly from the result payload', async () => {
+    const raw = {
+      _id: 'wyv-lore-3',
+      name: 'The Glass Archipelago',
+      creator: { vanityUrl: 'island-scribe' },
+      description: 'Locations and customs of the mirrored islands.',
+      photoURL: 'https://cdn.wyvern.chat/glass.webp',
+      tags: ['setting', 'islands'],
+      rating: 'none',
+      statistics_record: { views: 90, likes: 12 },
+      entries: [{ keys: ['Glassport'], content: 'A harbor built inside a crystal caldera.' }],
+      scan_depth: 4,
+      token_budget: 600,
+      recursive_scanning: true,
+    }
+    mocks.corsFetch.mockResolvedValueOnce(jsonResponse({ results: [raw], hasMore: false, page: 1 }))
+
+    const provider = new WyvernProvider()
+    const result = await provider.search(
+      { query: 'glass', page: 1, limit: 20, sort: 'new', nsfw: true },
+      'lorebook',
+    )
+
+    expect(mocks.corsFetch).toHaveBeenCalledWith(
+      'https://api.wyvern.chat/exploreSearch/lorebooks?q=glass&page=1&limit=20&sort=created_at&order=DESC',
+      { headers: { Accept: 'application/json' } },
+    )
+    expect(result).toEqual({
+      cards: [
+        {
+          id: 'wyv-lore-3',
+          name: 'The Glass Archipelago',
+          creator: 'island-scribe',
+          description: 'Locations and customs of the mirrored islands.',
+          avatarUrl: 'https://cdn.wyvern.chat/glass.webp',
+          imageUrl: 'https://cdn.wyvern.chat/glass.webp',
+          tags: ['setting', 'islands'],
+          stats: { views: 90, rating: 12 },
+          source: 'wyvern',
+          type: 'lorebook',
+          nsfw: false,
+          raw,
+        },
+      ],
+      hasMore: false,
+      nextPage: undefined,
+    })
+
+    const card = result.cards[0]
+    await expect(provider.getDownloadUrl(card)).resolves.toBe(
+      'https://wyvern.chat/lorebooks/wyv-lore-3',
+    )
+    const blob = await provider.downloadCard(card)
+
+    expect(mocks.corsFetch).toHaveBeenCalledOnce()
+    expect(blob.type).toBe('application/json')
+    await expect(blob.text().then(JSON.parse)).resolves.toEqual({
+      name: 'The Glass Archipelago',
+      description: 'Locations and customs of the mirrored islands.',
+      entries: [{ keys: ['Glassport'], content: 'A harbor built inside a crystal caldera.' }],
+      scan_depth: 4,
+      token_budget: 600,
+      recursive_scanning: true,
+      extensions: { wyvern: { id: 'wyv-lore-3' } },
+    })
+  })
+})

--- a/src/lib/services/discovery/types.ts
+++ b/src/lib/services/discovery/types.ts
@@ -32,6 +32,13 @@ export interface SearchResult {
   nextPage?: number
 }
 
+/**
+ * Marks a valid character-card payload assembled from discovery metadata because the source's
+ * full download was blocked. Keeping this distinct from ordinary JSON lets the Vault warn the
+ * user without coupling providers to UI state.
+ */
+export const METADATA_ONLY_CHARACTER_MIME = 'application/vnd.aventuras.character-metadata-only+json'
+
 export interface DiscoveryProvider {
   id: string
   name: string

--- a/src/lib/stores/characterVault.svelte.ts
+++ b/src/lib/stores/characterVault.svelte.ts
@@ -1,6 +1,10 @@
 import type { VaultCharacter, Character } from '$lib/types'
 import { database } from '$lib/services/database'
-import { discoveryService, type DiscoveryCard } from '$lib/services/discovery'
+import {
+  discoveryService,
+  METADATA_ONLY_CHARACTER_MIME,
+  type DiscoveryCard,
+} from '$lib/services/discovery'
 import { CharacterCardImport } from '$lib/services/characterCardImport'
 import { LorebookImportExport } from '$lib/services/lorebookImportExport'
 import { lorebookVault } from './lorebookVault.svelte'
@@ -279,14 +283,24 @@ class CharacterVaultStore {
 
   private async _processDiscoveryImport(tempId: string, card: DiscoveryCard): Promise<void> {
     const blob = await discoveryService.downloadCard(card)
+    const metadataOnly = blob.type === METADATA_ONLY_CHARACTER_MIME
     const file = new File([blob], `${card.name}.${blob.type.includes('json') ? 'json' : 'png'}`, {
       type: blob.type,
     })
 
     await this._processFileImport(tempId, file, {
       sourceUrl: card.imageUrl || card.avatarUrl,
-      tags: card.tags,
+      tags: metadataOnly ? [...new Set([...card.tags, 'metadata-only'])] : card.tags,
+      ...(metadataOnly ? { metadataOnly: true } : {}),
     })
+
+    if (metadataOnly) {
+      ui.showToast(
+        `${card.name} was imported from search metadata only because Cloudflare blocked the full card download.`,
+        'warning',
+        10000,
+      )
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

- use JannyAI's first-party download API with an explicit metadata-only fallback when Cloudflare blocks downloads
- add deterministic search, mapping, URL, and download contracts for all nine discovery providers
- preserve RisuRealm personality, scenario, greeting, examples, and creator notes when exposed
- update Backyard.ai's current tRPC browse contract while retaining safe-result filtering
- run the opt-in live smoke suite from the provider registry so every registered character provider is covered

## Verification

- `npm test -- --run` — 1,211 passed, 9 live tests skipped by default
- `npm run check` — 0 errors and 0 warnings
- `npm run lint` — 0 errors (203 existing boundary warnings)
- `$env:AVENTURAS_LIVE_DISCOVERY='1'; npx vitest run src/lib/services/discovery/providers/providers.live.test.ts` — 9/9 providers passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NSFW filtering in discovery searches.
  * Improved JannyAI downloads, including safer download handling and a fallback when direct downloads are unavailable.
  * Preserved additional character details in RisuRealm downloads.
  * Standardized search behavior, pagination, and download results across providers.

* **Tests**
  * Expanded automated and live coverage for searches, filtering, pagination, metadata, character and lorebook downloads, and serialized card content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->