### PR TITLE
Add branch-aware story landmark navigation

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -42,6 +42,12 @@ The story is an append-only list of `StoryEntry` rows (`user_action`, `narration
 - **Branches** fork at a `forkEntryId`. `story.entries` is the current branch's view, assembled
   from the branch's own rows plus everything inherited from its ancestors; `visibleEntries` is
   that list minus what has been folded into chapters.
+- **Entry numbers** are what a reader sees and types: `position + 1`, every entry type counted,
+  so the last entry's number equals the branch's entry count. Numbering is per branch view — a
+  branch continues its parent's positions from the fork, so shared history keeps its numbers and
+  sibling branches reuse them after the fork. `resolveEntryByNumber` (`utils/storyNavigation.ts`)
+  floors to the nearest lower entry, which is what makes a gap left by an import or a repair
+  navigable rather than a dead number.
 - **Chapters** cover a contiguous run of entries (`startEntryId`/`endEntryId`) and replace them
   in the prompt with a summary. Entries after the last chapter's end are the **un-chapterized
   tail** (`story.getUnchapterizedEntries()`) — the newest material, and the part chapter-oriented

--- a/src/lib/components/branch/BranchPanel.svelte
+++ b/src/lib/components/branch/BranchPanel.svelte
@@ -15,10 +15,41 @@
   } from '@lucide/svelte'
   import type { Branch, Checkpoint } from '$lib/types'
   import { SvelteSet } from 'svelte/reactivity'
+  import { untrack } from 'svelte'
   import { supportsHover } from '$lib/utils/platform'
 
   // Track expanded branches in tree view
   let expandedBranches = $state<Set<string>>(new Set(['main']))
+
+  /**
+   * Unfold the path down to the branch being read, so the tree never opens with the current
+   * branch hidden inside a collapsed ancestor.
+   *
+   * Only its ancestors are expanded — a node's own state controls its children, not whether
+   * its row is visible. Done once per branch, so a node collapsed afterwards stays collapsed.
+   */
+  let revealedFor: string | null | undefined = undefined
+
+  $effect(() => {
+    const branchId = story.currentStory?.currentBranchId ?? null
+    const branches = story.branches
+    if (branchId === revealedFor) return
+    // Branches load after the story, so wait for the one we are asked to reveal.
+    if (branchId && !branches.some((b) => b.id === branchId)) return
+    revealedFor = branchId
+
+    untrack(() => {
+      const next = new SvelteSet(expandedBranches)
+      next.add('main')
+      let current = branches.find((b) => b.id === branchId)
+      while (current?.parentBranchId) {
+        const parentId: string = current.parentBranchId
+        next.add(parentId)
+        current = branches.find((b) => b.id === parentId)
+      }
+      expandedBranches = next
+    })
+  })
 
   // Track which branch is being renamed
   let renamingBranchId = $state<string | null>(null)

--- a/src/lib/components/branch/BranchPanel.svelte
+++ b/src/lib/components/branch/BranchPanel.svelte
@@ -42,7 +42,9 @@
       const next = new SvelteSet(expandedBranches)
       next.add('main')
       let current = branches.find((b) => b.id === branchId)
-      while (current?.parentBranchId) {
+      const visited = new SvelteSet<string>()
+      while (current?.parentBranchId && !visited.has(current.id)) {
+        visited.add(current.id)
         const parentId: string = current.parentBranchId
         next.add(parentId)
         current = branches.find((b) => b.id === parentId)

--- a/src/lib/components/layout/AppShell.svelte
+++ b/src/lib/components/layout/AppShell.svelte
@@ -4,6 +4,7 @@
   import { story } from '$lib/stores/story.svelte'
   import { settings } from '$lib/stores/settings.svelte'
   import Sidebar from './Sidebar.svelte'
+  import StoryNavPanel from './StoryNavPanel.svelte'
   import Header from './Header.svelte'
   import ProfileWarningBanner from './ProfileWarningBanner.svelte'
   import StoryView from '$lib/components/story/StoryView.svelte'
@@ -225,27 +226,54 @@
       ></div>
     {/if}
 
+    <!-- Left edge swipe zone for opening the nav panel — a region-owning gesture, the mirror
+         of the right-edge zone above. Mounted only while neither panel is open, so a
+         right-swipe that belongs to the sidebar's tab strip or to dismissing a panel cannot
+         also open this one. -->
+    {#if !ui.sidebarOpen && !ui.navPanelOpen && story.currentStory}
+      <div
+        class="swipe-edge-zone swipe-edge-zone-left"
+        use:swipe={{ onSwipeRight: () => ui.toggleNavPanel(), threshold: 30 }}
+      ></div>
+    {/if}
+
     <!-- Main content area -->
     <div class="flex flex-1 flex-col overflow-hidden">
       <Header />
 
-      <main class="flex-1 overflow-hidden">
-        {#if ui.activePanel === 'story' && story.currentStory}
-          <StoryView />
-        {:else if ui.activePanel === 'gallery' && story.currentStory}
-          <GalleryTab />
-        {:else if ui.activePanel === 'lorebook' && story.currentStory}
-          <LorebookView />
-        {:else if ui.activePanel === 'memory' && story.currentStory}
-          <MemoryView />
-        {:else if ui.activePanel === 'vault'}
-          <VaultPanel />
-        {:else if ui.activePanel === 'library' || !story.currentStory}
-          <LibraryView />
-        {:else if children}
-          {@render children()}
+      <!-- `relative` so the navigation panel can overlay the content area without the header:
+           it must take no layout space, or opening it would narrow the story column and
+           reflow the text the reader is looking at. -->
+      <div class="relative min-h-0 flex-1">
+        {#if ui.navPanelOpen && story.currentStory}
+          <button
+            class="nav-panel-scrim"
+            onclick={() => ui.closeNavPanel()}
+            aria-label="Close story navigation"
+          ></button>
+          <div class="nav-panel-container">
+            <StoryNavPanel />
+          </div>
         {/if}
-      </main>
+
+        <main class="h-full overflow-hidden">
+          {#if ui.activePanel === 'story' && story.currentStory}
+            <StoryView />
+          {:else if ui.activePanel === 'gallery' && story.currentStory}
+            <GalleryTab />
+          {:else if ui.activePanel === 'lorebook' && story.currentStory}
+            <LorebookView />
+          {:else if ui.activePanel === 'memory' && story.currentStory}
+            <MemoryView />
+          {:else if ui.activePanel === 'vault'}
+            <VaultPanel />
+          {:else if ui.activePanel === 'library' || !story.currentStory}
+            <LibraryView />
+          {:else if children}
+            {@render children()}
+          {/if}
+        </main>
+      </div>
     </div>
 
     <!-- Sidebar (Right aligned) -->
@@ -395,6 +423,32 @@
     outline-offset: -2px;
   }
 
+  /*
+   * Story navigation panel — an overlay at every width, unlike the right sidebar. Taking
+   * layout space would narrow the story column and reflow its text, moving the reader's
+   * place before they have navigated anywhere.
+   */
+  .nav-panel-container {
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 16rem;
+    z-index: 45;
+  }
+
+  /* Desktop keeps the story visible and interactive behind the panel: the reader jumps,
+     looks at where they landed, and jumps again without reopening anything. */
+  .nav-panel-scrim {
+    display: none;
+    position: absolute;
+    inset: 0;
+    background-color: rgba(0, 0, 0, 0.5);
+    z-index: 44;
+    border: none;
+    cursor: pointer;
+  }
+
   /* Right edge swipe zone */
   .swipe-edge-zone {
     position: fixed;
@@ -403,6 +457,11 @@
     width: 20px;
     height: 100%;
     z-index: 30;
+  }
+
+  .swipe-edge-zone-left {
+    right: auto;
+    left: 0;
   }
 
   /* Mobile styles */
@@ -424,11 +483,30 @@
       width: 30px;
       top: max(var(--safe-top), 28px);
     }
+
+    .nav-panel-scrim {
+      display: block;
+    }
+
+    .nav-panel-container {
+      width: calc(100vw - 3rem);
+      max-width: 288px;
+      animation: slide-in-left 0.2s ease-out;
+    }
   }
 
   @keyframes slide-in {
     from {
       transform: translateX(100%);
+    }
+    to {
+      transform: translateX(0);
+    }
+  }
+
+  @keyframes slide-in-left {
+    from {
+      transform: translateX(-100%);
     }
     to {
       transform: translateX(0);

--- a/src/lib/components/layout/AppShell.svelte
+++ b/src/lib/components/layout/AppShell.svelte
@@ -276,7 +276,7 @@
                  nothing to resize. -->
             <button
               type="button"
-              class="resizer-handle nav-panel-resizer hidden h-full sm:block"
+              class="resizer-handle nav-panel-resizer h-full"
               onmousedown={(e) => startResizing('navPanel', e)}
               aria-label="Story Navigation Resizer"
             ></button>
@@ -511,6 +511,12 @@
 
     .nav-panel-scrim {
       display: block;
+    }
+
+    /* The panel overlays at a fixed width here, so there is nothing to drag. Tied to this
+       query rather than a utility class, so it cannot disagree with the overlay breakpoint. */
+    .nav-panel-resizer {
+      display: none;
     }
 
     .nav-panel-container {

--- a/src/lib/components/layout/AppShell.svelte
+++ b/src/lib/components/layout/AppShell.svelte
@@ -123,26 +123,37 @@
     clampDebugButtonToViewport()
   }
 
-  // Resizing logic
-  let isResizing = $state(false)
+  // Resizing logic — two panels, one drag at a time
+  let resizing = $state<'sidebar' | 'navPanel' | null>(null)
+  const isResizing = $derived(resizing !== null)
+  let navPanelEl = $state<HTMLDivElement | null>(null)
 
-  function startResizing(e: MouseEvent) {
-    isResizing = true
+  function startResizing(target: 'sidebar' | 'navPanel', e: MouseEvent) {
+    resizing = target
     e.preventDefault()
   }
 
   function stopResizing() {
-    if (!isResizing) return
-    isResizing = false
+    if (!resizing) return
+    const target = resizing
+    resizing = null
     // Persist the final width to the database now that resizing is complete.
-    settings.setSidebarWidth(settings.uiSettings.sidebarWidth)
+    if (target === 'sidebar') {
+      settings.setSidebarWidth(settings.uiSettings.sidebarWidth)
+    } else {
+      settings.setNavPanelWidth(settings.uiSettings.navPanelWidth)
+    }
   }
 
   function handleMouseMove(e: MouseEvent) {
-    if (!isResizing) return
+    if (!resizing) return
 
-    // Sidebar is on the right, so width is window.innerWidth - mouseX
-    const newWidth = window.innerWidth - e.clientX
+    // The sidebar is flush to the right edge; the nav panel starts wherever the content
+    // area does, which is not the window edge once a safe-area inset is in play.
+    const newWidth =
+      resizing === 'sidebar'
+        ? window.innerWidth - e.clientX
+        : e.clientX - (navPanelEl?.getBoundingClientRect().left ?? 0)
 
     // Constraints
     if (
@@ -150,7 +161,11 @@
       newWidth <= Math.min(MAX_SIDEBAR_WIDTH, window.innerWidth * MAX_SIDEBAR_RATIO)
     ) {
       // For performance, update the reactive state directly without saving to the database on every mouse movement.
-      settings.uiSettings.sidebarWidth = newWidth
+      if (resizing === 'sidebar') {
+        settings.uiSettings.sidebarWidth = newWidth
+      } else {
+        settings.uiSettings.navPanelWidth = newWidth
+      }
     }
   }
 
@@ -241,22 +256,34 @@
     <div class="flex flex-1 flex-col overflow-hidden">
       <Header />
 
-      <!-- `relative` so the navigation panel can overlay the content area without the header:
-           it must take no layout space, or opening it would narrow the story column and
-           reflow the text the reader is looking at. -->
-      <div class="relative min-h-0 flex-1">
+      <!-- The navigation panel is a flex sibling of the content, so on desktop it pushes.
+           `relative` is for the mobile case, where it overlays this area instead — below
+           the header, so the control that opened it stays reachable. -->
+      <div class="relative flex min-h-0 flex-1">
         {#if ui.navPanelOpen && story.currentStory}
           <button
             class="nav-panel-scrim"
             onclick={() => ui.closeNavPanel()}
             aria-label="Close story navigation"
           ></button>
-          <div class="nav-panel-container">
+          <div
+            bind:this={navPanelEl}
+            class="nav-panel-container relative flex"
+            style:width="{settings.uiSettings.navPanelWidth}px"
+          >
             <StoryNavPanel />
+            <!-- Desktop only: on mobile the panel overlays at a fixed width, so there is
+                 nothing to resize. -->
+            <button
+              type="button"
+              class="resizer-handle nav-panel-resizer hidden h-full sm:block"
+              onmousedown={(e) => startResizing('navPanel', e)}
+              aria-label="Story Navigation Resizer"
+            ></button>
           </div>
         {/if}
 
-        <main class="h-full overflow-hidden">
+        <main class="min-w-0 flex-1 overflow-hidden">
           {#if ui.activePanel === 'story' && story.currentStory}
             <StoryView />
           {:else if ui.activePanel === 'gallery' && story.currentStory}
@@ -283,7 +310,7 @@
         <button
           type="button"
           class="resizer-handle hidden h-full sm:block"
-          onmousedown={startResizing}
+          onmousedown={(e) => startResizing('sidebar', e)}
           aria-label="Sidebar Resizer"
         ></button>
         <Sidebar />
@@ -423,22 +450,20 @@
     outline-offset: -2px;
   }
 
-  /*
-   * Story navigation panel — an overlay at every width, unlike the right sidebar. Taking
-   * layout space would narrow the story column and reflow its text, moving the reader's
-   * place before they have navigated anywhere.
-   */
+  /* Story navigation panel — in flow on desktop, so it pushes the content the way the
+     right sidebar does. It overlays only on mobile, where there is no room to push. */
   .nav-panel-container {
-    position: absolute;
-    left: 0;
-    top: 0;
-    bottom: 0;
-    width: 16rem;
-    z-index: 45;
+    flex-shrink: 0;
   }
 
-  /* Desktop keeps the story visible and interactive behind the panel: the reader jumps,
-     looks at where they landed, and jumps again without reopening anything. */
+  /* The shared resizer sits on the panel's right edge, not its left. */
+  .nav-panel-resizer {
+    left: auto;
+    right: 0;
+  }
+
+  /* No scrim on desktop: the story stays visible and interactive beside the panel, so the
+     reader can jump, look at where they landed, and jump again. */
   .nav-panel-scrim {
     display: none;
     position: absolute;
@@ -489,7 +514,13 @@
     }
 
     .nav-panel-container {
-      width: calc(100vw - 3rem);
+      position: absolute;
+      left: 0;
+      top: 0;
+      bottom: 0;
+      z-index: 45;
+      /* Overrides the inline width the desktop resizer sets. */
+      width: calc(100vw - 3rem) !important;
       max-width: 288px;
       animation: slide-in-left 0.2s ease-out;
     }

--- a/src/lib/components/layout/Header.svelte
+++ b/src/lib/components/layout/Header.svelte
@@ -9,6 +9,7 @@
   import * as DropdownMenu from '$lib/components/ui/dropdown-menu'
   import {
     PanelRight,
+    PanelLeft,
     Settings,
     Library,
     ArrowUpDown,
@@ -318,6 +319,10 @@
           <DropdownMenu.Separator />
           <!-- The toolbar button beside this menu is desktop-only; on a narrow screen the
                menu is where it lives instead. -->
+          <DropdownMenu.Item class="sm:hidden" onclick={() => ui.toggleNavPanel()}>
+            <PanelLeft class="text-muted-foreground h-4 w-4" />
+            Go to an entry
+          </DropdownMenu.Item>
           <DropdownMenu.Item class="sm:hidden" onclick={() => ui.toggleLorebookDebug()}>
             <Bug class="text-muted-foreground h-4 w-4" />
             Active Context
@@ -389,6 +394,15 @@
     {@render settingsButton('hidden sm:block')}
 
     {#if story.currentStory}
+      <!-- Desktop-only, like the Active Context button above: on a narrow screen the mobile
+           menu carries it instead, and the swipe gesture reaches it without either. -->
+      <Button
+        icon={PanelLeft}
+        variant="text"
+        class="text-muted-foreground hover:text-primary hidden min-h-11 min-w-11 sm:flex"
+        onclick={() => ui.toggleNavPanel()}
+        title={ui.navPanelOpen ? 'Hide story navigation' : 'Go to an entry'}
+      />
       <Button
         icon={PanelRight}
         variant="text"

--- a/src/lib/components/layout/StoryNavPanel.svelte
+++ b/src/lib/components/layout/StoryNavPanel.svelte
@@ -1,0 +1,129 @@
+<script lang="ts">
+  import { story } from '$lib/stores/story.svelte'
+  import { ui } from '$lib/stores/ui.svelte'
+  import { buildLandmarks, entryNumber, resolveEntryByNumber } from '$lib/utils/storyNavigation'
+  import { supportsHover } from '$lib/utils/platform'
+  import { Button } from '$lib/components/ui/button'
+  import { Input } from '$lib/components/ui/input'
+  import EmptyState from '$lib/components/ui/empty-state/empty-state.svelte'
+  import { swipe } from '$lib/utils/swipe'
+  import { Bookmark, CornerDownLeft, GitBranch, Milestone, X } from '@lucide/svelte'
+
+  let numberInput = $state('')
+
+  const activeBranch = $derived.by(() => {
+    const branchId = story.currentStory?.currentBranchId ?? null
+    if (!branchId) return null
+    return story.branches.find((b) => b.id === branchId) ?? null
+  })
+
+  const landmarks = $derived(buildLandmarks(story.entries, story.checkpoints, activeBranch))
+
+  const lastNumber = $derived(
+    story.entries.length > 0 ? entryNumber(story.entries[story.entries.length - 1]) : 0,
+  )
+
+  // Fork points live in the story panel, which may not be the one that is up — and while it
+  // isn't, StoryView is destroyed rather than hidden. The request is left on the ui store for
+  // it to pick up on mount, the same way the Branches panel jumps to a fork point.
+  function goTo(entryId: string, confirmation: string) {
+    ui.requestEntryScroll(entryId)
+    ui.setActivePanel('story')
+    ui.closeNavPanelOnMobile()
+
+    // Where the platform can't hover the panel may have just closed over the result, so the
+    // jump confirms itself the way the fork-point jump does.
+    if (!supportsHover()) {
+      ui.showToast(confirmation, 'info', 2000)
+    }
+  }
+
+  function goToNumber() {
+    const entry = resolveEntryByNumber(story.entries, numberInput)
+    if (!entry) return
+    goTo(entry.id, `Jumped to entry ${entryNumber(entry)}`)
+  }
+</script>
+
+<aside
+  class="border-border bg-card/95 flex h-full w-full flex-col border-r backdrop-blur-[2px]"
+  aria-label="Story navigation"
+  use:swipe={{ onSwipeLeft: () => ui.closeNavPanel(), threshold: 50 }}
+>
+  <div class="border-border flex items-center justify-between border-b px-3 py-2">
+    <h3 class="text-surface-200 font-medium">Go to</h3>
+    <Button
+      variant="text"
+      size="icon"
+      class="text-muted-foreground hover:text-foreground h-10 w-10 sm:h-7 sm:w-7"
+      onclick={() => ui.closeNavPanel()}
+      title="Close"
+      aria-label="Close story navigation"
+    >
+      <X class="h-4 w-4" />
+    </Button>
+  </div>
+
+  <div class="min-h-0 flex-1 overflow-y-auto p-3">
+    <div class="flex items-end gap-2">
+      <Input
+        type="text"
+        inputmode="numeric"
+        label="Entry number"
+        placeholder={lastNumber > 0 ? `1 – ${lastNumber}` : ''}
+        bind:value={numberInput}
+        onkeydown={(e: KeyboardEvent) => e.key === 'Enter' && goToNumber()}
+      />
+      <Button
+        variant="secondary"
+        class="shrink-0"
+        onclick={goToNumber}
+        disabled={numberInput.trim() === ''}
+        title="Go to this entry"
+      >
+        <CornerDownLeft class="h-4 w-4" />
+      </Button>
+    </div>
+
+    <h4 class="text-muted-foreground mt-5 mb-2 text-xs font-medium tracking-wider uppercase">
+      Landmarks
+    </h4>
+
+    {#if landmarks.length === 0}
+      <EmptyState
+        icon={Milestone}
+        size="sm"
+        title="No landmarks"
+        description="This branch has no starting point or checkpoints to jump to. Checkpoints are saved at chapter boundaries."
+        class="py-6"
+      />
+    {:else}
+      <div class="space-y-1">
+        {#each landmarks as landmark (landmark.entryId)}
+          <button
+            class="hover:bg-surface-700/50 flex min-h-[40px] w-full items-start gap-2 rounded-lg p-2 text-left transition-colors sm:min-h-0"
+            onclick={() => goTo(landmark.entryId, `Jumped to entry ${landmark.number}`)}
+            title="Go to entry {landmark.number}"
+          >
+            {#if landmark.kind === 'origin'}
+              <GitBranch class="text-muted-foreground mt-0.5 h-4 w-4 shrink-0" />
+            {:else}
+              <Bookmark class="text-muted-foreground mt-0.5 h-4 w-4 shrink-0" />
+            {/if}
+            <span class="text-surface-500 mt-0.5 shrink-0 font-mono text-xs tabular-nums">
+              {landmark.number}
+            </span>
+            <span class="min-w-0 flex-1">
+              <span class="text-surface-200 block truncate text-sm">
+                {landmark.kind === 'origin' ? `${landmark.label} starts here` : landmark.label}
+              </span>
+              {#if landmark.preview}
+                <span class="text-surface-500 block truncate text-xs">{landmark.preview}</span>
+              {/if}
+            </span>
+          </button>
+        {/each}
+      </div>
+    {/if}
+  </div>
+</aside>

--- a/src/lib/components/layout/StoryNavPanel.svelte
+++ b/src/lib/components/layout/StoryNavPanel.svelte
@@ -7,9 +7,11 @@
   import { Input } from '$lib/components/ui/input'
   import EmptyState from '$lib/components/ui/empty-state/empty-state.svelte'
   import { swipe } from '$lib/utils/swipe'
-  import { Bookmark, CornerDownLeft, GitBranch, Milestone, X } from '@lucide/svelte'
+  import { Bookmark, Check, CornerDownLeft, Edit2, GitBranch, Milestone, X } from '@lucide/svelte'
 
   let numberInput = $state('')
+  let renamingCheckpointId = $state<string | null>(null)
+  let renameValue = $state('')
 
   const activeBranch = $derived.by(() => {
     const branchId = story.currentStory?.currentBranchId ?? null
@@ -44,6 +46,28 @@
     const entry = resolveEntryByNumber(story.entries, numberInput)
     if (!entry) return
     goTo(entry.id, `Jumped to entry ${entryNumber(entry)}`)
+  }
+
+  function startRename(checkpointId: string, name: string) {
+    renamingCheckpointId = checkpointId
+    renameValue = name
+  }
+
+  async function confirmRename() {
+    if (renamingCheckpointId && renameValue.trim()) {
+      try {
+        await story.renameCheckpoint(renamingCheckpointId, renameValue.trim())
+      } catch (error) {
+        console.error('Failed to rename checkpoint:', error)
+      }
+    }
+    renamingCheckpointId = null
+    renameValue = ''
+  }
+
+  function cancelRename() {
+    renamingCheckpointId = null
+    renameValue = ''
   }
 </script>
 
@@ -101,10 +125,14 @@
       />
     {:else}
       <div class="space-y-1">
-        {#each landmarks as landmark (landmark.entryId)}
-          <button
-            class="hover:bg-surface-700/50 flex min-h-[40px] w-full items-start gap-2 rounded-lg p-2 text-left transition-colors sm:min-h-0"
+        {#each landmarks as landmark (landmark.checkpointId ?? `origin:${landmark.entryId}`)}
+          <div
+            class="group hover:bg-surface-700/50 flex min-h-[40px] w-full cursor-pointer items-start gap-2 rounded-lg p-2 text-left transition-colors sm:min-h-0"
             onclick={() => goTo(landmark.entryId, `Jumped to entry ${landmark.number}`)}
+            onkeydown={(e) =>
+              e.key === 'Enter' && goTo(landmark.entryId, `Jumped to entry ${landmark.number}`)}
+            role="button"
+            tabindex="0"
             title="Go to entry {landmark.number}:&#10;{landmark.label}"
           >
             {#if landmark.kind === 'origin'}
@@ -115,14 +143,63 @@
             <span class="text-surface-500 mt-0.5 shrink-0 font-mono text-xs tabular-nums">
               {landmark.number}
             </span>
-            <span class="min-w-0 flex-1">
-              <!-- Wrapped rather than truncated: a name the reader chose is the only thing
-                   telling these rows apart, and a touch device has no tooltip to fall back
-                   on. The list is a handful of rows, so the vertical space is affordable. -->
-              <span class="text-surface-200 block text-sm break-words">{landmark.label}</span>
-              <span class="text-surface-500 block truncate text-xs">{landmark.branchName}</span>
-            </span>
-          </button>
+            {#if landmark.checkpointId && renamingCheckpointId === landmark.checkpointId}
+              <input
+                type="text"
+                class="input min-w-0 flex-1 px-1 py-0.5 text-sm"
+                bind:value={renameValue}
+                onclick={(e) => e.stopPropagation()}
+                onkeydown={(e) => {
+                  e.stopPropagation()
+                  if (e.key === 'Enter') confirmRename()
+                  if (e.key === 'Escape') cancelRename()
+                }}
+              />
+              <button
+                class="flex min-h-[32px] min-w-[32px] items-center justify-center p-1 text-green-400 hover:text-green-300 sm:min-h-0 sm:min-w-0 sm:p-0.5"
+                onclick={(e) => {
+                  e.stopPropagation()
+                  confirmRename()
+                }}
+                title="Save checkpoint name"
+                aria-label="Save checkpoint name"
+              >
+                <Check class="h-4 w-4 sm:h-3.5 sm:w-3.5" />
+              </button>
+              <button
+                class="text-surface-400 hover:text-surface-200 flex min-h-[32px] min-w-[32px] items-center justify-center p-1 sm:min-h-0 sm:min-w-0 sm:p-0.5"
+                onclick={(e) => {
+                  e.stopPropagation()
+                  cancelRename()
+                }}
+                title="Cancel rename"
+                aria-label="Cancel checkpoint rename"
+              >
+                <X class="h-4 w-4 sm:h-3.5 sm:w-3.5" />
+              </button>
+            {:else}
+              <span class="min-w-0 flex-1">
+                <!-- Wrapped rather than truncated: a name the reader chose is the only thing
+                     telling these rows apart, and a touch device has no tooltip to fall back
+                     on. The list is a handful of rows, so the vertical space is affordable. -->
+                <span class="text-surface-200 block text-sm break-words">{landmark.label}</span>
+                <span class="text-surface-500 block truncate text-xs">{landmark.branchName}</span>
+              </span>
+              {#if landmark.checkpointId}
+                <button
+                  class="text-surface-500 hover:text-surface-200 flex min-h-[32px] min-w-[32px] items-center justify-center p-1 transition-opacity sm:min-h-0 sm:min-w-0 sm:p-0.5 sm:opacity-0 sm:group-hover:opacity-100"
+                  onclick={(e) => {
+                    e.stopPropagation()
+                    startRename(landmark.checkpointId!, landmark.label)
+                  }}
+                  title="Rename"
+                  aria-label="Rename checkpoint"
+                >
+                  <Edit2 class="h-4 w-4 sm:h-3 sm:w-3" />
+                </button>
+              {/if}
+            {/if}
+          </div>
         {/each}
       </div>
     {/if}

--- a/src/lib/components/layout/StoryNavPanel.svelte
+++ b/src/lib/components/layout/StoryNavPanel.svelte
@@ -51,8 +51,15 @@
   }
 
   function goToNumber() {
+    if (!numberInput.trim()) return
     const entry = resolveEntryByNumber(story.entries, numberInput)
-    if (!entry) return
+    if (!entry) {
+      ui.showToast(
+        story.entries.length === 0 ? 'This branch has no entries' : 'Enter a valid entry number',
+        'error',
+      )
+      return
+    }
     goTo(entry.id, `Jumped to entry ${entryNumber(entry)}`)
   }
 
@@ -88,6 +95,8 @@
         await story.renameCheckpoint(renamingCheckpointId, renameValue.trim())
       } catch (error) {
         console.error('Failed to rename checkpoint:', error)
+        ui.showToast('Failed to rename checkpoint', 'error')
+        return
       }
     }
     renamingCheckpointId = null
@@ -156,72 +165,71 @@
       <div class="space-y-1">
         {#each landmarks as landmark (landmark.checkpointId ?? `origin:${landmark.entryId}`)}
           <div
-            class="group hover:bg-surface-700/50 flex min-h-[40px] w-full cursor-pointer items-start gap-2 rounded-lg p-2 text-left transition-colors sm:min-h-0"
-            onclick={() => void goToLandmark(landmark)}
-            onkeydown={(e) => {
-              if (e.key === 'Enter') void goToLandmark(landmark)
-            }}
-            role="button"
-            tabindex="0"
-            title="Go to entry {landmark.number}:&#10;{landmark.label}"
+            class="group hover:bg-surface-700/50 relative min-h-[40px] rounded-lg transition-colors sm:min-h-0"
           >
-            {#if landmark.kind === 'origin'}
-              <GitBranch class="text-muted-foreground mt-0.5 h-4 w-4 shrink-0" />
-            {:else}
-              <Bookmark class="text-muted-foreground mt-0.5 h-4 w-4 shrink-0" />
-            {/if}
-            <span class="text-surface-500 mt-0.5 shrink-0 font-mono text-xs tabular-nums">
-              {landmark.number}
-            </span>
             {#if landmark.checkpointId && renamingCheckpointId === landmark.checkpointId}
-              <input
-                type="text"
-                class="input min-w-0 flex-1 px-1 py-0.5 text-sm"
-                bind:value={renameValue}
-                onclick={(e) => e.stopPropagation()}
-                onkeydown={(e) => {
-                  e.stopPropagation()
-                  if (e.key === 'Enter') confirmRename()
-                  if (e.key === 'Escape') cancelRename()
-                }}
-              />
-              <button
-                class="flex min-h-[32px] min-w-[32px] items-center justify-center p-1 text-green-400 hover:text-green-300 sm:min-h-0 sm:min-w-0 sm:p-0.5"
-                onclick={(e) => {
-                  e.stopPropagation()
-                  confirmRename()
-                }}
-                title="Save checkpoint name"
-                aria-label="Save checkpoint name"
-              >
-                <Check class="h-4 w-4 sm:h-3.5 sm:w-3.5" />
-              </button>
-              <button
-                class="text-surface-400 hover:text-surface-200 flex min-h-[32px] min-w-[32px] items-center justify-center p-1 sm:min-h-0 sm:min-w-0 sm:p-0.5"
-                onclick={(e) => {
-                  e.stopPropagation()
-                  cancelRename()
-                }}
-                title="Cancel rename"
-                aria-label="Cancel checkpoint rename"
-              >
-                <X class="h-4 w-4 sm:h-3.5 sm:w-3.5" />
-              </button>
+              <div class="flex items-start gap-2 p-2 text-left">
+                {#if landmark.kind === 'origin'}
+                  <GitBranch class="text-muted-foreground mt-0.5 h-4 w-4 shrink-0" />
+                {:else}
+                  <Bookmark class="text-muted-foreground mt-0.5 h-4 w-4 shrink-0" />
+                {/if}
+                <span class="text-surface-500 mt-0.5 shrink-0 font-mono text-xs tabular-nums">
+                  {landmark.number}
+                </span>
+                <input
+                  type="text"
+                  class="input min-w-0 flex-1 px-1 py-0.5 text-sm"
+                  bind:value={renameValue}
+                  onkeydown={(e) => {
+                    if (e.key === 'Enter') confirmRename()
+                    if (e.key === 'Escape') cancelRename()
+                  }}
+                />
+                <button
+                  class="flex min-h-[32px] min-w-[32px] items-center justify-center p-1 text-green-400 hover:text-green-300 sm:min-h-0 sm:min-w-0 sm:p-0.5"
+                  onclick={confirmRename}
+                  title="Save checkpoint name"
+                  aria-label="Save checkpoint name"
+                >
+                  <Check class="h-4 w-4 sm:h-3.5 sm:w-3.5" />
+                </button>
+                <button
+                  class="text-surface-400 hover:text-surface-200 flex min-h-[32px] min-w-[32px] items-center justify-center p-1 sm:min-h-0 sm:min-w-0 sm:p-0.5"
+                  onclick={cancelRename}
+                  title="Cancel rename"
+                  aria-label="Cancel checkpoint rename"
+                >
+                  <X class="h-4 w-4 sm:h-3.5 sm:w-3.5" />
+                </button>
+              </div>
             {:else}
-              <span class="min-w-0 flex-1">
-                <!-- Wrapped rather than truncated: a name the reader chose is the only thing
-                     telling these rows apart, and a touch device has no tooltip to fall back
-                     on. The list is a handful of rows, so the vertical space is affordable. -->
-                <span class="text-surface-200 block text-sm break-words">{landmark.label}</span>
-                <span class="text-surface-500 block truncate text-xs">{landmark.branchName}</span>
-              </span>
+              <button
+                type="button"
+                class="flex min-h-[40px] w-full items-start gap-2 rounded-lg p-2 pr-10 text-left sm:min-h-0"
+                onclick={() => void goToLandmark(landmark)}
+                title="Go to entry {landmark.number}:&#10;{landmark.label}"
+              >
+                {#if landmark.kind === 'origin'}
+                  <GitBranch class="text-muted-foreground mt-0.5 h-4 w-4 shrink-0" />
+                {:else}
+                  <Bookmark class="text-muted-foreground mt-0.5 h-4 w-4 shrink-0" />
+                {/if}
+                <span class="text-surface-500 mt-0.5 shrink-0 font-mono text-xs tabular-nums">
+                  {landmark.number}
+                </span>
+                <span class="min-w-0 flex-1">
+                  <!-- Wrapped rather than truncated: a name the reader chose is the only thing
+                       telling these rows apart, and a touch device has no tooltip to fall back
+                       on. The list is a handful of rows, so the vertical space is affordable. -->
+                  <span class="text-surface-200 block text-sm break-words">{landmark.label}</span>
+                  <span class="text-surface-500 block truncate text-xs">{landmark.branchName}</span>
+                </span>
+              </button>
               {#if landmark.checkpointId}
                 <button
-                  class="text-surface-500 hover:text-surface-200 flex min-h-[32px] min-w-[32px] items-center justify-center p-1 transition-opacity sm:min-h-0 sm:min-w-0 sm:p-0.5 sm:opacity-0 sm:group-hover:opacity-100"
-                  onclick={(e) => {
-                    e.stopPropagation()
-                    startRename(landmark.checkpointId!, landmark.label)
-                  }}
+                  class="text-surface-500 hover:text-surface-200 absolute top-1 right-1 flex min-h-[32px] min-w-[32px] items-center justify-center p-1 transition-opacity sm:min-h-0 sm:min-w-0 sm:p-0.5 sm:opacity-0 sm:group-hover:opacity-100"
+                  onclick={() => startRename(landmark.checkpointId!, landmark.label)}
                   title="Rename"
                   aria-label="Rename checkpoint"
                 >

--- a/src/lib/components/layout/StoryNavPanel.svelte
+++ b/src/lib/components/layout/StoryNavPanel.svelte
@@ -39,6 +39,9 @@
   // isn't, StoryView is destroyed rather than hidden. The request is left on the ui store for
   // it to pick up on mount, the same way the Branches panel jumps to a fork point.
   function goTo(entryId: string, confirmation: string) {
+    // The story view can only scroll to an entry it can render. Checked here as well so the
+    // confirmation below reports what will actually happen rather than asserting success.
+    const willLand = story.entries.some((e) => e.id === entryId)
     ui.requestEntryScroll(entryId)
     ui.setActivePanel('story')
     ui.closeNavPanelOnMobile()
@@ -46,7 +49,11 @@
     // Where the platform can't hover the panel may have just closed over the result, so the
     // jump confirms itself the way the fork-point jump does.
     if (!supportsHover()) {
-      ui.showToast(confirmation, 'info', 2000)
+      if (willLand) {
+        ui.showToast(confirmation, 'info', 2000)
+      } else {
+        ui.showToast('That entry is not in this branch', 'error', 2000)
+      }
     }
   }
 
@@ -72,12 +79,19 @@
   async function goToLandmark(landmark: Landmark) {
     const currentBranchId = story.currentStory?.currentBranchId ?? null
     if (landmarkNavigationMode === 'checkpoint-branch' && currentBranchId !== landmark.branchId) {
+      // Claimed before the switch, because the event that triggers the story view's own
+      // end-of-branch landing is emitted inside it.
+      ui.claimBranchLanding()
       try {
         await story.switchBranch(landmark.branchId)
       } catch (error) {
         console.error('Failed to switch to landmark branch:', error)
         ui.showToast(error instanceof Error ? error.message : 'Failed to switch branch', 'error')
         return
+      } finally {
+        // Only a mounted story view consumes the claim, and it is unmounted whenever another
+        // panel is up — so drop it either way rather than let it suppress a later switch.
+        ui.consumeBranchLandingClaim()
       }
     }
 

--- a/src/lib/components/layout/StoryNavPanel.svelte
+++ b/src/lib/components/layout/StoryNavPanel.svelte
@@ -194,6 +194,7 @@
                 <input
                   type="text"
                   class="input min-w-0 flex-1 px-1 py-0.5 text-sm"
+                  aria-label="Checkpoint name"
                   bind:value={renameValue}
                   onkeydown={(e) => {
                     if (e.key === 'Enter') confirmRename()
@@ -242,7 +243,7 @@
               </button>
               {#if landmark.checkpointId}
                 <button
-                  class="text-surface-500 hover:text-surface-200 absolute top-1 right-1 flex min-h-[32px] min-w-[32px] items-center justify-center p-1 transition-opacity sm:min-h-0 sm:min-w-0 sm:p-0.5 sm:opacity-0 sm:group-hover:opacity-100"
+                  class="text-surface-500 hover:text-surface-200 absolute top-1 right-1 flex min-h-[32px] min-w-[32px] items-center justify-center p-1 transition-opacity sm:min-h-0 sm:min-w-0 sm:p-0.5 sm:opacity-0 sm:group-hover:opacity-100 sm:focus-visible:opacity-100"
                   onclick={() => startRename(landmark.checkpointId!, landmark.label)}
                   title="Rename"
                   aria-label="Rename checkpoint"

--- a/src/lib/components/layout/StoryNavPanel.svelte
+++ b/src/lib/components/layout/StoryNavPanel.svelte
@@ -103,7 +103,7 @@
           <button
             class="hover:bg-surface-700/50 flex min-h-[40px] w-full items-start gap-2 rounded-lg p-2 text-left transition-colors sm:min-h-0"
             onclick={() => goTo(landmark.entryId, `Jumped to entry ${landmark.number}`)}
-            title="Go to entry {landmark.number}"
+            title="Go to entry {landmark.number}:&#10;{landmark.label}"
           >
             {#if landmark.kind === 'origin'}
               <GitBranch class="text-muted-foreground mt-0.5 h-4 w-4 shrink-0" />
@@ -114,9 +114,10 @@
               {landmark.number}
             </span>
             <span class="min-w-0 flex-1">
-              <span class="text-surface-200 block truncate text-sm">
-                {landmark.kind === 'origin' ? `${landmark.label} starts here` : landmark.label}
-              </span>
+              <!-- Wrapped rather than truncated: a name the reader chose is the only thing
+                   telling these rows apart, and a touch device has no tooltip to fall back
+                   on. The list is a handful of rows, so the vertical space is affordable. -->
+              <span class="text-surface-200 block text-sm break-words">{landmark.label}</span>
               {#if landmark.preview}
                 <span class="text-surface-500 block truncate text-xs">{landmark.preview}</span>
               {/if}

--- a/src/lib/components/layout/StoryNavPanel.svelte
+++ b/src/lib/components/layout/StoryNavPanel.svelte
@@ -17,7 +17,9 @@
     return story.branches.find((b) => b.id === branchId) ?? null
   })
 
-  const landmarks = $derived(buildLandmarks(story.entries, story.checkpoints, activeBranch))
+  const landmarks = $derived(
+    buildLandmarks(story.entries, story.checkpoints, story.branches, activeBranch),
+  )
 
   const lastNumber = $derived(
     story.entries.length > 0 ? entryNumber(story.entries[story.entries.length - 1]) : 0,
@@ -118,9 +120,7 @@
                    telling these rows apart, and a touch device has no tooltip to fall back
                    on. The list is a handful of rows, so the vertical space is affordable. -->
               <span class="text-surface-200 block text-sm break-words">{landmark.label}</span>
-              {#if landmark.preview}
-                <span class="text-surface-500 block truncate text-xs">{landmark.preview}</span>
-              {/if}
+              <span class="text-surface-500 block truncate text-xs">{landmark.branchName}</span>
             </span>
           </button>
         {/each}

--- a/src/lib/components/layout/StoryNavPanel.svelte
+++ b/src/lib/components/layout/StoryNavPanel.svelte
@@ -1,10 +1,17 @@
 <script lang="ts">
   import { story } from '$lib/stores/story.svelte'
   import { ui } from '$lib/stores/ui.svelte'
-  import { buildLandmarks, entryNumber, resolveEntryByNumber } from '$lib/utils/storyNavigation'
+  import {
+    buildLandmarks,
+    entryNumber,
+    resolveEntryByNumber,
+    type Landmark,
+  } from '$lib/utils/storyNavigation'
   import { supportsHover } from '$lib/utils/platform'
   import { Button } from '$lib/components/ui/button'
   import { Input } from '$lib/components/ui/input'
+  import { Label } from '$lib/components/ui/label'
+  import { RadioGroup, RadioGroupItem } from '$lib/components/ui/radio-group'
   import EmptyState from '$lib/components/ui/empty-state/empty-state.svelte'
   import { swipe } from '$lib/utils/swipe'
   import { Bookmark, Check, CornerDownLeft, Edit2, GitBranch, Milestone, X } from '@lucide/svelte'
@@ -12,6 +19,7 @@
   let numberInput = $state('')
   let renamingCheckpointId = $state<string | null>(null)
   let renameValue = $state('')
+  let landmarkNavigationMode = $state<'current-branch' | 'checkpoint-branch'>('current-branch')
 
   const activeBranch = $derived.by(() => {
     const branchId = story.currentStory?.currentBranchId ?? null
@@ -46,6 +54,27 @@
     const entry = resolveEntryByNumber(story.entries, numberInput)
     if (!entry) return
     goTo(entry.id, `Jumped to entry ${entryNumber(entry)}`)
+  }
+
+  function setLandmarkNavigationMode(value: string) {
+    if (value === 'current-branch' || value === 'checkpoint-branch') {
+      landmarkNavigationMode = value
+    }
+  }
+
+  async function goToLandmark(landmark: Landmark) {
+    const currentBranchId = story.currentStory?.currentBranchId ?? null
+    if (landmarkNavigationMode === 'checkpoint-branch' && currentBranchId !== landmark.branchId) {
+      try {
+        await story.switchBranch(landmark.branchId)
+      } catch (error) {
+        console.error('Failed to switch to landmark branch:', error)
+        ui.showToast(error instanceof Error ? error.message : 'Failed to switch branch', 'error')
+        return
+      }
+    }
+
+    goTo(landmark.entryId, `Jumped to entry ${landmark.number}`)
   }
 
   function startRename(checkpointId: string, name: string) {
@@ -128,9 +157,10 @@
         {#each landmarks as landmark (landmark.checkpointId ?? `origin:${landmark.entryId}`)}
           <div
             class="group hover:bg-surface-700/50 flex min-h-[40px] w-full cursor-pointer items-start gap-2 rounded-lg p-2 text-left transition-colors sm:min-h-0"
-            onclick={() => goTo(landmark.entryId, `Jumped to entry ${landmark.number}`)}
-            onkeydown={(e) =>
-              e.key === 'Enter' && goTo(landmark.entryId, `Jumped to entry ${landmark.number}`)}
+            onclick={() => void goToLandmark(landmark)}
+            onkeydown={(e) => {
+              if (e.key === 'Enter') void goToLandmark(landmark)
+            }}
             role="button"
             tabindex="0"
             title="Go to entry {landmark.number}:&#10;{landmark.label}"
@@ -203,5 +233,30 @@
         {/each}
       </div>
     {/if}
+  </div>
+
+  <div class="border-border border-t p-3">
+    <p class="text-muted-foreground mb-2 text-xs font-medium tracking-wider uppercase">
+      Landmark navigation
+    </p>
+    <RadioGroup
+      value={landmarkNavigationMode}
+      onValueChange={setLandmarkNavigationMode}
+      class="gap-2"
+      aria-label="Landmark navigation behavior"
+    >
+      <div class="flex items-center gap-2">
+        <RadioGroupItem value="current-branch" id="landmark-current-branch" />
+        <Label for="landmark-current-branch" class="cursor-pointer text-xs font-normal">
+          Stay on current branch
+        </Label>
+      </div>
+      <div class="flex items-center gap-2">
+        <RadioGroupItem value="checkpoint-branch" id="landmark-checkpoint-branch" />
+        <Label for="landmark-checkpoint-branch" class="cursor-pointer text-xs font-normal">
+          Switch to checkpoint branch
+        </Label>
+      </div>
+    </RadioGroup>
   </div>
 </aside>

--- a/src/lib/components/layout/StoryNavPanel.svelte
+++ b/src/lib/components/layout/StoryNavPanel.svelte
@@ -81,7 +81,7 @@
     if (landmarkNavigationMode === 'checkpoint-branch' && currentBranchId !== landmark.branchId) {
       // Claimed before the switch, because the event that triggers the story view's own
       // end-of-branch landing is emitted inside it.
-      ui.claimBranchLanding()
+      ui.claimBranchLanding(landmark.branchId)
       try {
         await story.switchBranch(landmark.branchId)
       } catch (error) {
@@ -91,7 +91,7 @@
       } finally {
         // Only a mounted story view consumes the claim, and it is unmounted whenever another
         // panel is up — so drop it either way rather than let it suppress a later switch.
-        ui.consumeBranchLandingClaim()
+        ui.clearBranchLandingClaim()
       }
     }
 

--- a/src/lib/components/story/LibraryView.svelte
+++ b/src/lib/components/story/LibraryView.svelte
@@ -53,7 +53,12 @@
   async function openStory(storyId: string) {
     ui.resetScrollBreak()
     ui.setActivePanel('story')
-    await story.loadStory(storyId)
+    try {
+      await story.loadStory(storyId)
+    } catch (error) {
+      ui.setActivePanel('library')
+      ui.showToast(errMessage(error), 'error')
+    }
   }
 
   async function deleteStory(storyId: string, event: MouseEvent) {

--- a/src/lib/components/story/LibraryView.svelte
+++ b/src/lib/components/story/LibraryView.svelte
@@ -45,11 +45,7 @@
     showSTImportWizard = true
   }
 
-  // The panel is switched before the load, not after. `loadStory` publishes `currentStory`
-  // early and keeps working for the rest of its awaits, and the sidebars are gated on it — so
-  // switching afterwards mounted them over the library first and the story view a beat later,
-  // each pushing the layout in its own frame. Setting it first costs nothing (the library keeps
-  // rendering while `currentStory` is null) and lands everything in one pass.
+  // Switch before loading so the story view mounts with its sidebars in one pass.
   async function openStory(storyId: string) {
     ui.resetScrollBreak()
     ui.setActivePanel('story')
@@ -129,6 +125,7 @@
         ui.showToast(result.error, 'error')
       }
     } catch (error) {
+      ui.setActivePanel('library')
       ui.showToast(errMessage(error), 'error')
     } finally {
       isImporting = false

--- a/src/lib/components/story/LibraryView.svelte
+++ b/src/lib/components/story/LibraryView.svelte
@@ -45,10 +45,15 @@
     showSTImportWizard = true
   }
 
+  // The panel is switched before the load, not after. `loadStory` publishes `currentStory`
+  // early and keeps working for the rest of its awaits, and the sidebars are gated on it — so
+  // switching afterwards mounted them over the library first and the story view a beat later,
+  // each pushing the layout in its own frame. Setting it first costs nothing (the library keeps
+  // rendering while `currentStory` is null) and lands everything in one pass.
   async function openStory(storyId: string) {
     ui.resetScrollBreak()
-    await story.loadStory(storyId)
     ui.setActivePanel('story')
+    await story.loadStory(storyId)
   }
 
   async function deleteStory(storyId: string, event: MouseEvent) {
@@ -113,8 +118,8 @@
 
       if (result.success && result.storyId) {
         await story.loadAllStories()
-        await story.loadStory(result.storyId)
         ui.setActivePanel('story')
+        await story.loadStory(result.storyId)
       } else if (result.error) {
         ui.showToast(result.error, 'error')
       }

--- a/src/lib/components/story/StoryEntry.svelte
+++ b/src/lib/components/story/StoryEntry.svelte
@@ -1443,6 +1443,16 @@
             {/if}
           </dl>
         {/snippet}
+        {#snippet entryNumberRow()}
+          <!-- Where the entry sits in the story, not how it was generated — so it stays outside
+               the Response info block at both sizes rather than becoming a row in it. -->
+          <div class="flex justify-between gap-3">
+            <span class="text-muted-foreground shrink-0">Entry number</span>
+            <span class="text-foreground text-right font-medium tabular-nums"
+              >{entryNumber(entry)}</span
+            >
+          </div>
+        {/snippet}
         {#if showInfo}
           <Popover.Root>
             <Popover.Trigger>
@@ -1459,13 +1469,8 @@
               {/snippet}
             </Popover.Trigger>
             <Popover.Content class="w-64 p-3 text-xs" align="end">
-              <!-- Where the entry sits in the story, not how it was generated — so it is
-                   outside the Response info block rather than a row in it. -->
-              <div class="border-border mb-2 flex justify-between gap-3 border-b pb-2">
-                <span class="text-muted-foreground shrink-0">Entry number</span>
-                <span class="text-foreground text-right font-medium tabular-nums">
-                  {entryNumber(entry)}
-                </span>
+              <div class="border-border mb-2 border-b pb-2">
+                {@render entryNumberRow()}
               </div>
               <p class="text-foreground mb-2 text-sm font-medium">Response info</p>
               {@render responseInfoRows()}
@@ -1628,6 +1633,9 @@
                  menu, which would unmount any popover anchored to it. -->
             {#if showInfo}
               <DropdownMenu.Separator />
+              <div class="w-56 px-2 pb-1.5 text-xs">
+                {@render entryNumberRow()}
+              </div>
               <DropdownMenu.Group>
                 <DropdownMenu.GroupHeading class="px-2 py-1.5 text-sm font-medium">
                   Response info

--- a/src/lib/components/story/StoryEntry.svelte
+++ b/src/lib/components/story/StoryEntry.svelte
@@ -30,6 +30,7 @@
   } from '$lib/services/ai/utils/ttsText'
   import { parseMarkdown, parseStoryMarkdown } from '$lib/utils/markdown'
   import { findPrecedingUserAction } from '$lib/utils/storyEntries'
+  import { entryNumber } from '$lib/utils/storyNavigation'
   import { sanitizeTextForTTS } from '$lib/utils/htmlSanitize'
   import {
     processStoryContent,
@@ -1458,6 +1459,14 @@
               {/snippet}
             </Popover.Trigger>
             <Popover.Content class="w-64 p-3 text-xs" align="end">
+              <!-- Where the entry sits in the story, not how it was generated — so it is
+                   outside the Response info block rather than a row in it. -->
+              <div class="border-border mb-2 flex justify-between gap-3 border-b pb-2">
+                <span class="text-muted-foreground shrink-0">Entry number</span>
+                <span class="text-foreground text-right font-medium tabular-nums">
+                  {entryNumber(entry)}
+                </span>
+              </div>
               <p class="text-foreground mb-2 text-sm font-medium">Response info</p>
               {@render responseInfoRows()}
             </Popover.Content>

--- a/src/lib/components/story/StoryView.svelte
+++ b/src/lib/components/story/StoryView.svelte
@@ -301,6 +301,10 @@
   $effect(() => {
     // The payload is unread: landing resolves everything from the store when it runs
     return eventBus.subscribe<BranchSwitchedEvent>('BranchSwitched', () => {
+      // The switch is one step of a jump someone else is making: they position the view, and
+      // landing at the end of the branch here would race the entry they are about to request.
+      if (ui.consumeBranchLandingClaim()) return
+
       // Panel hidden: defer until the story panel comes back (see panel effect below)
       if (ui.activePanel !== 'story' || !storyContainer) {
         pendingBranchLanding = true

--- a/src/lib/components/story/StoryView.svelte
+++ b/src/lib/components/story/StoryView.svelte
@@ -300,10 +300,11 @@
   // No reactive reads in the effect bodies — subscribe once, unsubscribe on teardown
   $effect(() => {
     // The payload is unread: landing resolves everything from the store when it runs
-    return eventBus.subscribe<BranchSwitchedEvent>('BranchSwitched', () => {
+    return eventBus.subscribe<BranchSwitchedEvent>('BranchSwitched', (event) => {
       // The switch is one step of a jump someone else is making: they position the view, and
       // landing at the end of the branch here would race the entry they are about to request.
-      if (ui.consumeBranchLandingClaim()) return
+      // Matched on the branch, so a switch already in flight cannot spend someone else's claim.
+      if (ui.consumeBranchLandingClaim(event.branchId)) return
 
       // Panel hidden: defer until the story panel comes back (see panel effect below)
       if (ui.activePanel !== 'story' || !storyContainer) {

--- a/src/lib/services/database.ts
+++ b/src/lib/services/database.ts
@@ -1508,6 +1508,11 @@ class DatabaseService {
     )
   }
 
+  async renameCheckpoint(id: string, name: string): Promise<void> {
+    const db = await this.getDb()
+    await db.execute('UPDATE checkpoints SET name = ? WHERE id = ?', [name, id])
+  }
+
   async deleteCheckpoint(id: string): Promise<void> {
     const db = await this.getDb()
     await db.execute('DELETE FROM checkpoints WHERE id = ?', [id])

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -1194,6 +1194,7 @@ export function getDefaultUISettings(): UISettings {
     disableActionPrefixes: false,
     showReasoning: true,
     sidebarWidth: 288,
+    navPanelWidth: 256,
     autoScroll: true,
     showScrollToTop: false,
     showScrollToBottom: true,
@@ -1594,6 +1595,9 @@ class SettingsStore {
 
       const sidebarWidth = await database.getSetting('sidebar_width')
       if (sidebarWidth) this.uiSettings.sidebarWidth = parseInt(sidebarWidth, 10)
+
+      const navPanelWidth = await database.getSetting('nav_panel_width')
+      if (navPanelWidth) this.uiSettings.navPanelWidth = parseInt(navPanelWidth, 10)
 
       const sidebarOpen = await database.getSetting('sidebar_open')
       if (sidebarOpen !== null) ui.sidebarOpen = sidebarOpen === 'true'
@@ -2703,6 +2707,11 @@ class SettingsStore {
   async setSidebarWidth(width: number) {
     this.uiSettings.sidebarWidth = width
     await database.setSetting('sidebar_width', width.toString())
+  }
+
+  async setNavPanelWidth(width: number) {
+    this.uiSettings.navPanelWidth = width
+    await database.setSetting('nav_panel_width', width.toString())
   }
 
   async setDebugMode(enabled: boolean) {

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -1597,7 +1597,12 @@ class SettingsStore {
       if (sidebarWidth) this.uiSettings.sidebarWidth = parseInt(sidebarWidth, 10)
 
       const navPanelWidth = await database.getSetting('nav_panel_width')
-      if (navPanelWidth) this.uiSettings.navPanelWidth = parseInt(navPanelWidth, 10)
+      if (navPanelWidth) {
+        const parsedNavPanelWidth = parseInt(navPanelWidth, 10)
+        if (Number.isFinite(parsedNavPanelWidth)) {
+          this.uiSettings.navPanelWidth = parsedNavPanelWidth
+        }
+      }
 
       const sidebarOpen = await database.getSetting('sidebar_open')
       if (sidebarOpen !== null) ui.sidebarOpen = sidebarOpen === 'true'

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -1602,6 +1602,9 @@ class SettingsStore {
       const sidebarOpen = await database.getSetting('sidebar_open')
       if (sidebarOpen !== null) ui.sidebarOpen = sidebarOpen === 'true'
 
+      const navPanelOpen = await database.getSetting('nav_panel_open')
+      if (navPanelOpen !== null) ui.navPanelOpen = navPanelOpen === 'true'
+
       const manualMode = await database.getSetting('advanced_manual_mode')
       if (manualMode !== null) {
         this.advancedRequestSettings.manualMode = manualMode === 'true'

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -38,6 +38,7 @@ import {
 import { ui } from '$lib/stores/ui.svelte'
 import { getTheme } from '../../themes/themes'
 import { LLM_TIMEOUT_DEFAULT, LLM_TIMEOUT_MIN, LLM_TIMEOUT_MAX } from '$lib/constants/timeout'
+import { MAX_SIDEBAR_WIDTH, MIN_SIDEBAR_WIDTH } from '$lib/constants/layout'
 import { SvelteSet, SvelteMap } from 'svelte/reactivity'
 import { dedupeTextModels } from '$lib/utils/dedupeTextModels'
 import { applyIncognitoKeyboard } from '$lib/utils/platform'
@@ -1600,7 +1601,10 @@ class SettingsStore {
       if (navPanelWidth) {
         const parsedNavPanelWidth = parseInt(navPanelWidth, 10)
         if (Number.isFinite(parsedNavPanelWidth)) {
-          this.uiSettings.navPanelWidth = parsedNavPanelWidth
+          this.uiSettings.navPanelWidth = Math.min(
+            MAX_SIDEBAR_WIDTH,
+            Math.max(MIN_SIDEBAR_WIDTH, parsedNavPanelWidth),
+          )
         }
       }
 
@@ -2718,8 +2722,9 @@ class SettingsStore {
   }
 
   async setNavPanelWidth(width: number) {
-    this.uiSettings.navPanelWidth = width
-    await database.setSetting('nav_panel_width', width.toString())
+    const clampedWidth = Math.min(MAX_SIDEBAR_WIDTH, Math.max(MIN_SIDEBAR_WIDTH, width))
+    this.uiSettings.navPanelWidth = clampedWidth
+    await database.setSetting('nav_panel_width', clampedWidth.toString())
   }
 
   async setDebugMode(enabled: boolean) {
@@ -3101,6 +3106,8 @@ class SettingsStore {
 
     // Reset UI settings
     this.uiSettings = getDefaultUISettings()
+    await this.setNavPanelWidth(this.uiSettings.navPanelWidth)
+    await ui.setNavPanelOpen(false)
 
     // Reset font to default
     this.applyFontFamily('default', 'default')

--- a/src/lib/stores/story.svelte.ts
+++ b/src/lib/stores/story.svelte.ts
@@ -1113,10 +1113,17 @@ class StoryStore {
 
     // Legacy behavior: delete just this one entry (no world state changes)
     const droppedCheckpoints = this.checkpointsAnchoredTo(new Set([entryId]))
+    // Chapters hold foreign keys to the entries at their boundaries, with no ON DELETE
+    // behaviour, so a boundary entry cannot go without them — same as the cascade path.
+    const chaptersToDelete = this.chapters.filter(
+      (ch) => ch.startEntryId === entryId || ch.endEntryId === entryId,
+    )
     await database.deleteEntriesWithDependents({
       entryIds: [entryId],
+      chapterIds: chaptersToDelete.map((ch) => ch.id),
       checkpointIds: droppedCheckpoints.map((cp) => cp.id),
     })
+    this.chapters = this.chapters.filter((ch) => !chaptersToDelete.some((d) => d.id === ch.id))
     this.forgetCheckpoints(droppedCheckpoints)
     this.entries = this.entries.filter((e) => e.id !== entryId)
 

--- a/src/lib/stores/story.svelte.ts
+++ b/src/lib/stores/story.svelte.ts
@@ -577,6 +577,18 @@ class StoryStore {
   }
 
   private async performStoryLoad(storyId: string, seq: number): Promise<void> {
+    try {
+      await this.runStoryLoad(storyId, seq)
+    } catch (error) {
+      // A load the reader has already replaced must not report its failure. Its caller sends
+      // them back to the library on error, which would discard the story they switched to and
+      // explain it with the name of the one they left. The newer load speaks for itself.
+      if (seq !== this.storyLoadSeq) return
+      throw error
+    }
+  }
+
+  private async runStoryLoad(storyId: string, seq: number): Promise<void> {
     // Serialize loads and let the most recent request win. This prevents a slower
     // earlier selection from publishing after the story the reader selected last.
     if (seq !== this.storyLoadSeq) return

--- a/src/lib/stores/story.svelte.ts
+++ b/src/lib/stores/story.svelte.ts
@@ -534,9 +534,6 @@ class StoryStore {
     // Late `ImageReady` events from those generations clamp at zero rather than going
     // negative.
     ui.resetImageGenerationState()
-    // Every exit from a story runs through here, including the Android hardware back
-    // handler, so the panel cannot survive to spring open on the next story.
-    ui.closeNavPanel()
     log('Story closed')
   }
 

--- a/src/lib/stores/story.svelte.ts
+++ b/src/lib/stores/story.svelte.ts
@@ -559,6 +559,23 @@ class StoryStore {
     return run
   }
 
+  /**
+   * Whether a newer load — or a close — has taken over since this one published
+   * `currentStory`, in which case this load has to unpublish it too.
+   *
+   * Returning without that leaves the store naming the story it just published while
+   * `entries`, `branches` and the world state still belong to the previous one, which the
+   * story view and the navigation panel both render. Loads are serialised, so the load that
+   * superseded this one has not started yet and this cannot clear a story it already
+   * published; if that load then fails early, the reader gets the library rather than the
+   * mismatch.
+   */
+  private supersededAfterPublish(seq: number): boolean {
+    if (seq === this.storyLoadSeq) return false
+    this.currentStory = null
+    return true
+  }
+
   private async performStoryLoad(storyId: string, seq: number): Promise<void> {
     // Serialize loads and let the most recent request win. This prevents a slower
     // earlier selection from publishing after the story the reader selected last.
@@ -584,7 +601,7 @@ class StoryStore {
     ui.setMobileDefaults()
     this.currentStory = story
     const backgroundImage = await database.getBackgroundForBranch(storyId, story.currentBranchId)
-    if (seq !== this.storyLoadSeq) return
+    if (this.supersededAfterPublish(seq)) return
     this.currentBgImage = backgroundImage
 
     // Load branch-independent data first
@@ -598,7 +615,7 @@ class StoryStore {
         database.getEntries(storyId),
         database.getBranches(storyId),
       ])
-    if (seq !== this.storyLoadSeq) return
+    if (this.supersededAfterPublish(seq)) return
 
     this.characters = characters
     this.locations = locations
@@ -620,7 +637,7 @@ class StoryStore {
 
     // Load entries and chapters based on current branch
     await this.reloadEntriesForCurrentBranch()
-    if (seq !== this.storyLoadSeq) return
+    if (this.supersededAfterPublish(seq)) return
 
     // Reset all caches after loading
     this.invalidateWordCountCache()
@@ -639,7 +656,7 @@ class StoryStore {
 
     // Load persisted activation data for this story (stickiness tracking)
     await ui.loadActivationData(storyId)
-    if (seq !== this.storyLoadSeq) return
+    if (this.supersededAfterPublish(seq)) return
 
     // Clear stale lorebook retrieval from previous story to prevent cross-story contamination
     ui.setLastLorebookRetrieval(null)
@@ -657,18 +674,18 @@ class StoryStore {
 
     // Validate and repair chapter integrity (handles orphaned references)
     await this.validateChapterIntegrity()
-    if (seq !== this.storyLoadSeq) return
+    if (this.supersededAfterPublish(seq)) return
 
     // Load persisted action choices for adventure mode
     if (story.mode === 'adventure') {
       await ui.loadActionChoices(storyId)
-      if (seq !== this.storyLoadSeq) return
+      if (this.supersededAfterPublish(seq)) return
     }
 
     // Load persisted suggestions for creative-writing mode
     if (story.mode === 'creative-writing') {
       await ui.loadSuggestions(storyId)
-      if (seq !== this.storyLoadSeq) return
+      if (this.supersededAfterPublish(seq)) return
     }
 
     // The settings-keyed cache above is empty for a story that never generated choices in this

--- a/src/lib/stores/story.svelte.ts
+++ b/src/lib/stores/story.svelte.ts
@@ -534,6 +534,9 @@ class StoryStore {
     // Late `ImageReady` events from those generations clamp at zero rather than going
     // negative.
     ui.resetImageGenerationState()
+    // Every exit from a story runs through here, including the Android hardware back
+    // handler, so the panel cannot survive to spring open on the next story.
+    ui.closeNavPanel()
     log('Story closed')
   }
 

--- a/src/lib/stores/story.svelte.ts
+++ b/src/lib/stores/story.svelte.ts
@@ -95,6 +95,11 @@ function mergeRuntimeVars(
 
 // Story Store using Svelte 5 runes
 class StoryStore {
+  /** Tail of the story-load queue — see loadStory. */
+  private storyLoadChain: Promise<unknown> = Promise.resolve()
+  /** Sequence of the most recently requested story load. */
+  private storyLoadSeq = 0
+
   // Current active story
   currentStory = $state<Story | null>(null)
   entries = $state<StoryEntry[]>([])
@@ -526,6 +531,7 @@ class StoryStore {
 
   // Close the current story and reset state
   closeStory(): void {
+    this.storyLoadSeq++
     this.resetStoryState()
     this.currentBgImage = null
     this.branches = []
@@ -544,7 +550,22 @@ class StoryStore {
 
   // Load a specific story with all its data
   async loadStory(storyId: string): Promise<void> {
+    const seq = ++this.storyLoadSeq
+    const run = this.storyLoadChain.then(
+      () => this.performStoryLoad(storyId, seq),
+      () => this.performStoryLoad(storyId, seq),
+    )
+    this.storyLoadChain = run.catch(() => {})
+    return run
+  }
+
+  private async performStoryLoad(storyId: string, seq: number): Promise<void> {
+    // Serialize loads and let the most recent request win. This prevents a slower
+    // earlier selection from publishing after the story the reader selected last.
+    if (seq !== this.storyLoadSeq) return
+
     const story = await database.getStory(storyId)
+    if (seq !== this.storyLoadSeq) return
     if (!story) {
       throw new Error(`Story not found: ${storyId}`)
     }
@@ -552,6 +573,7 @@ class StoryStore {
     // Clean up any orphaned embedded_images before loading
     // (fixes FK constraint issues from older data)
     await database.cleanupOrphanedEmbeddedImages()
+    if (seq !== this.storyLoadSeq) return
 
     // Whatever the previous story left cached is about a pool this one does not have.
     clearTier3SelectionCache()
@@ -561,7 +583,9 @@ class StoryStore {
     // narrow display. Do this before publishing `currentStory`, which mounts those panels.
     ui.setMobileDefaults()
     this.currentStory = story
-    this.currentBgImage = await database.getBackgroundForBranch(storyId, story.currentBranchId)
+    const backgroundImage = await database.getBackgroundForBranch(storyId, story.currentBranchId)
+    if (seq !== this.storyLoadSeq) return
+    this.currentBgImage = backgroundImage
 
     // Load branch-independent data first
     const [characters, locations, items, storyBeats, checkpoints, lorebookEntries, branches] =
@@ -574,6 +598,7 @@ class StoryStore {
         database.getEntries(storyId),
         database.getBranches(storyId),
       ])
+    if (seq !== this.storyLoadSeq) return
 
     this.characters = characters
     this.locations = locations
@@ -595,6 +620,7 @@ class StoryStore {
 
     // Load entries and chapters based on current branch
     await this.reloadEntriesForCurrentBranch()
+    if (seq !== this.storyLoadSeq) return
 
     // Reset all caches after loading
     this.invalidateWordCountCache()
@@ -613,6 +639,7 @@ class StoryStore {
 
     // Load persisted activation data for this story (stickiness tracking)
     await ui.loadActivationData(storyId)
+    if (seq !== this.storyLoadSeq) return
 
     // Clear stale lorebook retrieval from previous story to prevent cross-story contamination
     ui.setLastLorebookRetrieval(null)
@@ -630,15 +657,18 @@ class StoryStore {
 
     // Validate and repair chapter integrity (handles orphaned references)
     await this.validateChapterIntegrity()
+    if (seq !== this.storyLoadSeq) return
 
     // Load persisted action choices for adventure mode
     if (story.mode === 'adventure') {
       await ui.loadActionChoices(storyId)
+      if (seq !== this.storyLoadSeq) return
     }
 
     // Load persisted suggestions for creative-writing mode
     if (story.mode === 'creative-writing') {
       await ui.loadSuggestions(storyId)
+      if (seq !== this.storyLoadSeq) return
     }
 
     // The settings-keyed cache above is empty for a story that never generated choices in this
@@ -2988,6 +3018,7 @@ class StoryStore {
 
   // Clear current story (when switching or closing)
   clearCurrentStory(): void {
+    this.storyLoadSeq++
     this.resetStoryState()
 
     // Clear current retry story ID (backups are kept per-story)

--- a/src/lib/stores/story.svelte.ts
+++ b/src/lib/stores/story.svelte.ts
@@ -3559,6 +3559,14 @@ class StoryStore {
     return checkpoint
   }
 
+  async renameCheckpoint(checkpointId: string, newName: string): Promise<void> {
+    await database.renameCheckpoint(checkpointId, newName)
+    this.checkpoints = this.checkpoints.map((checkpoint) =>
+      checkpoint.id === checkpointId ? { ...checkpoint, name: newName } : checkpoint,
+    )
+    log('Checkpoint renamed:', checkpointId, 'to', newName)
+  }
+
   /**
    * @deprecated Checkpoint restoration is no longer supported.
    * Use createBranchFromCheckpoint() instead to explore alternate timelines.

--- a/src/lib/stores/story.svelte.ts
+++ b/src/lib/stores/story.svelte.ts
@@ -557,6 +557,9 @@ class StoryStore {
     clearTier3SelectionCache()
     clearImageMarkerCache()
 
+    // A remembered desktop panel must not briefly cover a story as it starts loading on a
+    // narrow display. Do this before publishing `currentStory`, which mounts those panels.
+    ui.setMobileDefaults()
     this.currentStory = story
     this.currentBgImage = await database.getBackgroundForBranch(storyId, story.currentBranchId)
 
@@ -656,9 +659,6 @@ class StoryStore {
     if (!hasPersistedChoices && this.entries[this.entries.length - 1]?.type === 'narration') {
       this.restoreSuggestedActionsFromLastNarration()
     }
-
-    // Set mobile-friendly defaults (close sidebar, etc.)
-    ui.setMobileDefaults()
 
     // Emit event
     emitStoryLoaded(storyId, story.mode)

--- a/src/lib/stores/story.svelte.ts
+++ b/src/lib/stores/story.svelte.ts
@@ -584,6 +584,10 @@ class StoryStore {
       // them back to the library on error, which would discard the story they switched to and
       // explain it with the name of the one they left. The newer load speaks for itself.
       if (seq !== this.storyLoadSeq) return
+      // A load that failed *after* publishing leaves the store naming a story whose entries and
+      // world state it never loaded. The caller shows the library, so the mismatch is invisible
+      // but latent — tear it down rather than leave it for the next reader of the store.
+      if (this.currentStory?.id === storyId) this.closeStory()
       throw error
     }
   }
@@ -1112,18 +1116,31 @@ class StoryStore {
     }
 
     // Legacy behavior: delete just this one entry (no world state changes)
-    const droppedCheckpoints = this.checkpointsAnchoredTo(new Set([entryId]))
-    // Chapters hold foreign keys to the entries at their boundaries, with no ON DELETE
-    // behaviour, so a boundary entry cannot go without them — same as the cascade path.
-    const chaptersToDelete = this.chapters.filter(
+    //
+    // A chapter holds foreign keys to the entries at its boundaries. Deleting those rows along
+    // with the entry — which is what the cascade path does — is only safe there because that
+    // path removes a contiguous *suffix*, so the chapters it drops are trailing and the entries
+    // they covered go with them. One entry out of the middle is not that: it would delete a
+    // chapter and its generated summary while the entries around it survive, leaving a gap in
+    // the numbering. Refuse, naming what is in the way, rather than lose the summary silently.
+    const boundaryChapters = this.chapters.filter(
       (ch) => ch.startEntryId === entryId || ch.endEntryId === entryId,
     )
+    if (boundaryChapters.length > 0) {
+      const named = boundaryChapters
+        .map((ch) => (ch.title ? `${ch.number} ("${ch.title}")` : `${ch.number}`))
+        .join(', ')
+      throw new Error(
+        `Cannot delete this entry: it is the boundary of chapter ${named}, and deleting it ` +
+          `would discard that chapter's summary. Delete from this entry onward instead.`,
+      )
+    }
+
+    const droppedCheckpoints = this.checkpointsAnchoredTo(new Set([entryId]))
     await database.deleteEntriesWithDependents({
       entryIds: [entryId],
-      chapterIds: chaptersToDelete.map((ch) => ch.id),
       checkpointIds: droppedCheckpoints.map((cp) => cp.id),
     })
-    this.chapters = this.chapters.filter((ch) => !chaptersToDelete.some((d) => d.id === ch.id))
     this.forgetCheckpoints(droppedCheckpoints)
     this.entries = this.entries.filter((e) => e.id !== entryId)
 

--- a/src/lib/stores/ui.svelte.ts
+++ b/src/lib/stores/ui.svelte.ts
@@ -445,6 +445,31 @@ class UIStore {
    */
   pendingEntryScrollId = $state<string | null>(null)
 
+  /**
+   * A branch switch whose caller will position the view itself.
+   *
+   * The story view lands at the end of a branch on every switch. When the switch is one step
+   * of "go to this landmark on another branch", that landing and the entry the caller is
+   * about to request both run, computing different render windows and fighting over the
+   * scroll. The caller claims the landing so only its own jump happens.
+   *
+   * Not reactive: it is claimed and consumed synchronously around a single await, never read
+   * from a template. The claimer clears it unconditionally, because the only consumer is a
+   * mounted story view and it must not leak into an unrelated switch later.
+   */
+  private branchLandingClaimed = false
+
+  claimBranchLanding() {
+    this.branchLandingClaimed = true
+  }
+
+  /** Take the claim, if any, and clear it. */
+  consumeBranchLandingClaim(): boolean {
+    const claimed = this.branchLandingClaimed
+    this.branchLandingClaimed = false
+    return claimed
+  }
+
   requestEntryScroll(entryId: string) {
     this.pendingEntryScrollId = entryId
   }

--- a/src/lib/stores/ui.svelte.ts
+++ b/src/lib/stores/ui.svelte.ts
@@ -114,6 +114,9 @@ class UIStore {
   activePanel = $state<ActivePanel>('story')
   sidebarTab = $state<SidebarTab>('characters')
   sidebarOpen = $state(typeof window !== 'undefined' ? window.innerWidth >= 640 : false)
+  // Not persisted, unlike `sidebarOpen`: opened to make one jump and dismissed again, so a
+  // remembered state would only ever be stale. Cleared by `story.closeStory()`.
+  navPanelOpen = $state(false)
   settingsModalOpen = $state(false)
   isGenerating = $state(false)
   isRetryingLastMessage = $state(false) // Hide stop button during completed-message retries
@@ -399,6 +402,21 @@ class UIStore {
   closeSidebarOnMobile() {
     if (typeof window !== 'undefined' && window.innerWidth <= DESKTOP_BREAKPOINT) {
       this.sidebarOpen = false
+    }
+  }
+
+  toggleNavPanel() {
+    this.navPanelOpen = !this.navPanelOpen
+  }
+
+  closeNavPanel() {
+    this.navPanelOpen = false
+  }
+
+  /** The story navigation panel's twin of `closeSidebarOnMobile`, for the same reason. */
+  closeNavPanelOnMobile() {
+    if (typeof window !== 'undefined' && window.innerWidth <= DESKTOP_BREAKPOINT) {
+      this.navPanelOpen = false
     }
   }
 

--- a/src/lib/stores/ui.svelte.ts
+++ b/src/lib/stores/ui.svelte.ts
@@ -457,17 +457,27 @@ class UIStore {
    * from a template. The claimer clears it unconditionally, because the only consumer is a
    * mounted story view and it must not leak into an unrelated switch later.
    */
-  private branchLandingClaimed = false
+  private branchLandingClaim: { branchId: string | null } | null = null
 
-  claimBranchLanding() {
-    this.branchLandingClaimed = true
+  claimBranchLanding(branchId: string | null) {
+    this.branchLandingClaim = { branchId }
   }
 
-  /** Take the claim, if any, and clear it. */
-  consumeBranchLandingClaim(): boolean {
-    const claimed = this.branchLandingClaimed
-    this.branchLandingClaimed = false
-    return claimed
+  /**
+   * Take the claim if it was made for this branch, and clear it.
+   *
+   * Keyed rather than a bare flag: switches queue, so one already in flight can reach its own
+   * `BranchSwitched` while a claim for a different branch is standing, and an unkeyed claim
+   * would be spent on it — suppressing that switch's landing and leaving this one unclaimed.
+   */
+  consumeBranchLandingClaim(branchId: string | null): boolean {
+    if (!this.branchLandingClaim || this.branchLandingClaim.branchId !== branchId) return false
+    this.branchLandingClaim = null
+    return true
+  }
+
+  clearBranchLandingClaim() {
+    this.branchLandingClaim = null
   }
 
   requestEntryScroll(entryId: string) {

--- a/src/lib/stores/ui.svelte.ts
+++ b/src/lib/stores/ui.svelte.ts
@@ -114,8 +114,8 @@ class UIStore {
   activePanel = $state<ActivePanel>('story')
   sidebarTab = $state<SidebarTab>('characters')
   sidebarOpen = $state(typeof window !== 'undefined' ? window.innerWidth >= 640 : false)
-  // Not persisted, unlike `sidebarOpen`: opened to make one jump and dismissed again, so a
-  // remembered state would only ever be stale. Cleared by `story.closeStory()`.
+  // Persisted like `sidebarOpen`, but defaults closed at every width: it is a place the
+  // reader opts into, not an ambient reference the way the sidebar is.
   navPanelOpen = $state(false)
   settingsModalOpen = $state(false)
   isGenerating = $state(false)
@@ -390,6 +390,9 @@ class UIStore {
       // No DB persist — this is a layout constraint, not a user preference.
       // Persisting here would overwrite the desktop sidebar preference.
     }
+    // Where the panel overlays rather than sits beside the story, a remembered "open" would
+    // put the reader in front of the panel instead of the story they just opened.
+    this.closeNavPanelOnMobile()
   }
 
   /**
@@ -406,14 +409,26 @@ class UIStore {
   }
 
   toggleNavPanel() {
-    this.navPanelOpen = !this.navPanelOpen
+    this.setNavPanelOpen(!this.navPanelOpen)
   }
 
+  /** Dismissal the reader asked for — the close button, the scrim, the swipe — so it sticks. */
   closeNavPanel() {
-    this.navPanelOpen = false
+    this.setNavPanelOpen(false)
   }
 
-  /** The story navigation panel's twin of `closeSidebarOnMobile`, for the same reason. */
+  private setNavPanelOpen(open: boolean) {
+    this.navPanelOpen = open
+    database
+      .setSetting('nav_panel_open', open.toString())
+      .catch((err) => console.warn('[UI] Failed to persist nav panel state:', err))
+  }
+
+  /**
+   * The story navigation panel's twin of `closeSidebarOnMobile`, for the same reason — and
+   * likewise not persisted: getting out of the way of a jump on a narrow screen is a layout
+   * constraint, and must not overwrite the width where the panel sits beside the story.
+   */
   closeNavPanelOnMobile() {
     if (typeof window !== 'undefined' && window.innerWidth <= DESKTOP_BREAKPOINT) {
       this.navPanelOpen = false

--- a/src/lib/stores/ui.svelte.ts
+++ b/src/lib/stores/ui.svelte.ts
@@ -417,9 +417,9 @@ class UIStore {
     this.setNavPanelOpen(false)
   }
 
-  private setNavPanelOpen(open: boolean) {
+  setNavPanelOpen(open: boolean): Promise<void> {
     this.navPanelOpen = open
-    database
+    return database
       .setSetting('nav_panel_open', open.toString())
       .catch((err) => console.warn('[UI] Failed to persist nav panel state:', err))
   }

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -727,6 +727,7 @@ export interface UISettings {
   disableActionPrefixes: boolean
   showReasoning: boolean
   sidebarWidth: number
+  navPanelWidth: number
   autoScroll: boolean
   showScrollToTop: boolean
   showScrollToBottom: boolean

--- a/src/lib/utils/storyNavigation.test.ts
+++ b/src/lib/utils/storyNavigation.test.ts
@@ -124,6 +124,7 @@ describe('buildLandmarks', () => {
     const landmarks = buildLandmarks(
       branchView,
       [checkpoint('cp-late', 'b4'), checkpoint('cp-early', 'b2')],
+      [br1],
       br1,
     )
     expect(landmarks.map((l) => [l.kind, l.number])).toEqual([
@@ -137,49 +138,87 @@ describe('buildLandmarks', () => {
     const landmarks = buildLandmarks(
       branchView,
       [checkpoint('cp-origin', 'm1', 'Council of five')],
+      [br1],
       br1,
     )
     expect(landmarks.map((l) => [l.kind, l.label])).toEqual([['origin', 'Council of five']])
-    expect(landmarks[0].preview).toBe('Council of five preview')
+    expect(landmarks[0].branchName).toBe('Main')
   })
 
   it('falls back to a generic origin label when that checkpoint is gone', () => {
     // `checkpointId` is nullable for imported and legacy branches, and a checkpoint can be
     // deleted after the branch that came from it.
-    const orphaned = buildLandmarks(branchView, [], branch('br1', 'm1', 'Betrayal', 'deleted-cp'))
+    const orphaned = buildLandmarks(
+      branchView,
+      [],
+      [br1],
+      branch('br1', 'm1', 'Betrayal', 'deleted-cp'),
+    )
     expect(orphaned.map((l) => [l.kind, l.label])).toEqual([['origin', 'Branch origin']])
   })
 
   it('omits the origin row on the main branch', () => {
     const mainView = [entry('m0', 0), entry('m1', 1)]
-    const landmarks = buildLandmarks(mainView, [checkpoint('cp', 'm1')], null)
+    const landmarks = buildLandmarks(mainView, [checkpoint('cp', 'm1')], [], null)
     expect(landmarks.map((l) => l.kind)).toEqual(['checkpoint'])
   })
 
   it('omits an origin whose entry is not loaded', () => {
-    const landmarks = buildLandmarks(branchView, [], branch('br1', 'not-loaded', 'Betrayal'))
+    const landmarks = buildLandmarks(
+      branchView,
+      [],
+      [br1],
+      branch('br1', 'not-loaded', 'Betrayal'),
+    )
     expect(landmarks).toEqual([])
   })
 
-  it('excludes checkpoints inherited from an ancestor branch', () => {
-    // m1 is in view, but it belongs to main -- a new branch cannot be forked from it
-    // while reading br1.
-    const landmarks = buildLandmarks(branchView, [checkpoint('cp-main', 'm1')], br1)
-    expect(landmarks.map((l) => l.kind)).toEqual(['origin'])
+  it('includes checkpoints inherited from every branch in the visible lineage', () => {
+    const ancestor = branch('ancestor', 'm0', 'First path')
+    const lineageView = [
+      entry('m0', 0),
+      entry('a1', 1, 'ancestor'),
+      entry('a2', 2, 'ancestor'),
+      entry('b3', 3, 'br1'),
+    ]
+    const current = { ...br1, forkEntryId: 'a2', checkpointId: 'cp-origin' }
+    const landmarks = buildLandmarks(
+      lineageView,
+      [
+        checkpoint('cp-main', 'm0', 'Departure'),
+        checkpoint('cp-ancestor', 'a1', 'Crossroads'),
+        checkpoint('cp-origin', 'a2', 'Final choice'),
+        checkpoint('cp-current', 'b3', 'Arrival'),
+      ],
+      [ancestor, current],
+      current,
+    )
+
+    expect(landmarks.map((l) => [l.label, l.branchName])).toEqual([
+      ['Departure', 'Main'],
+      ['Crossroads', 'First path'],
+      ['Final choice', 'First path'],
+      ['Arrival', 'Betrayal'],
+    ])
   })
 
   it('excludes a checkpoint whose entry a rollback has deleted', () => {
-    const landmarks = buildLandmarks(branchView, [checkpoint('cp', 'gone')], br1)
+    const landmarks = buildLandmarks(branchView, [checkpoint('cp', 'gone')], [br1], br1)
     expect(landmarks.map((l) => l.kind)).toEqual(['origin'])
   })
 
   it('returns nothing for a main branch with no checkpoints', () => {
-    expect(buildLandmarks([entry('m0', 0)], [], null)).toEqual([])
+    expect(buildLandmarks([entry('m0', 0)], [], [], null)).toEqual([])
   })
 
-  it('carries the checkpoint name and preview onto the row', () => {
-    const [, row] = buildLandmarks(branchView, [checkpoint('cp', 'b2', 'Before the duel')], br1)
+  it('carries the checkpoint and branch names onto the row', () => {
+    const [, row] = buildLandmarks(
+      branchView,
+      [checkpoint('cp', 'b2', 'Before the duel')],
+      [br1],
+      br1,
+    )
     expect(row.label).toBe('Before the duel')
-    expect(row.preview).toBe('Before the duel preview')
+    expect(row.branchName).toBe('Betrayal')
   })
 })

--- a/src/lib/utils/storyNavigation.test.ts
+++ b/src/lib/utils/storyNavigation.test.ts
@@ -143,6 +143,7 @@ describe('buildLandmarks', () => {
     )
     expect(landmarks.map((l) => [l.kind, l.label])).toEqual([['origin', 'Council of five']])
     expect(landmarks[0].checkpointId).toBe('cp-origin')
+    expect(landmarks[0].branchId).toBeNull()
     expect(landmarks[0].branchName).toBe('Main')
   })
 
@@ -217,6 +218,7 @@ describe('buildLandmarks', () => {
     )
     expect(row.label).toBe('Before the duel')
     expect(row.checkpointId).toBe('cp')
+    expect(row.branchId).toBe('br1')
     expect(row.branchName).toBe('Betrayal')
   })
 })

--- a/src/lib/utils/storyNavigation.test.ts
+++ b/src/lib/utils/storyNavigation.test.ts
@@ -34,14 +34,19 @@ function checkpoint(id: string, lastEntryId: string, name = id): Checkpoint {
   }
 }
 
-function branch(id: string, forkEntryId: string, name = id): Branch {
+function branch(
+  id: string,
+  forkEntryId: string,
+  name = id,
+  checkpointId: string | null = null,
+): Branch {
   return {
     id,
     storyId: 's1',
     name,
     parentBranchId: null,
     forkEntryId,
-    checkpointId: null,
+    checkpointId,
     createdAt: 0,
   }
 }
@@ -113,7 +118,7 @@ describe('buildLandmarks', () => {
     entry('b3', 3, 'br1'),
     entry('b4', 4, 'br1'),
   ]
-  const br1 = branch('br1', 'm1', 'Betrayal')
+  const br1 = branch('br1', 'm1', 'Betrayal', 'cp-origin')
 
   it('puts the origin first, followed by the branch checkpoints in number order', () => {
     const landmarks = buildLandmarks(
@@ -126,7 +131,23 @@ describe('buildLandmarks', () => {
       ['checkpoint', 3],
       ['checkpoint', 5],
     ])
-    expect(landmarks[0].label).toBe('Betrayal')
+  })
+
+  it('names the origin after the checkpoint the branch was forked from, not the branch', () => {
+    const landmarks = buildLandmarks(
+      branchView,
+      [checkpoint('cp-origin', 'm1', 'Council of five')],
+      br1,
+    )
+    expect(landmarks.map((l) => [l.kind, l.label])).toEqual([['origin', 'Council of five']])
+    expect(landmarks[0].preview).toBe('Council of five preview')
+  })
+
+  it('falls back to a generic origin label when that checkpoint is gone', () => {
+    // `checkpointId` is nullable for imported and legacy branches, and a checkpoint can be
+    // deleted after the branch that came from it.
+    const orphaned = buildLandmarks(branchView, [], branch('br1', 'm1', 'Betrayal', 'deleted-cp'))
+    expect(orphaned.map((l) => [l.kind, l.label])).toEqual([['origin', 'Branch origin']])
   })
 
   it('omits the origin row on the main branch', () => {

--- a/src/lib/utils/storyNavigation.test.ts
+++ b/src/lib/utils/storyNavigation.test.ts
@@ -142,6 +142,7 @@ describe('buildLandmarks', () => {
       br1,
     )
     expect(landmarks.map((l) => [l.kind, l.label])).toEqual([['origin', 'Council of five']])
+    expect(landmarks[0].checkpointId).toBe('cp-origin')
     expect(landmarks[0].branchName).toBe('Main')
   })
 
@@ -155,6 +156,7 @@ describe('buildLandmarks', () => {
       branch('br1', 'm1', 'Betrayal', 'deleted-cp'),
     )
     expect(orphaned.map((l) => [l.kind, l.label])).toEqual([['origin', 'Branch origin']])
+    expect(orphaned[0].checkpointId).toBeNull()
   })
 
   it('omits the origin row on the main branch', () => {
@@ -164,12 +166,7 @@ describe('buildLandmarks', () => {
   })
 
   it('omits an origin whose entry is not loaded', () => {
-    const landmarks = buildLandmarks(
-      branchView,
-      [],
-      [br1],
-      branch('br1', 'not-loaded', 'Betrayal'),
-    )
+    const landmarks = buildLandmarks(branchView, [], [br1], branch('br1', 'not-loaded', 'Betrayal'))
     expect(landmarks).toEqual([])
   })
 
@@ -219,6 +216,7 @@ describe('buildLandmarks', () => {
       br1,
     )
     expect(row.label).toBe('Before the duel')
+    expect(row.checkpointId).toBe('cp')
     expect(row.branchName).toBe('Betrayal')
   })
 })

--- a/src/lib/utils/storyNavigation.test.ts
+++ b/src/lib/utils/storyNavigation.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest'
+import type { Branch, Checkpoint, StoryEntry } from '$lib/types'
+import { buildLandmarks, entryNumber, resolveEntryByNumber } from './storyNavigation'
+
+function entry(id: string, position: number, branchId: string | null = null): StoryEntry {
+  return {
+    id,
+    storyId: 's1',
+    type: 'narration',
+    content: id,
+    parentId: null,
+    position,
+    createdAt: position,
+    metadata: null,
+    branchId,
+  }
+}
+
+function checkpoint(id: string, lastEntryId: string, name = id): Checkpoint {
+  return {
+    id,
+    storyId: 's1',
+    name,
+    lastEntryId,
+    lastEntryPreview: `${name} preview`,
+    entryCount: 0,
+    entriesSnapshot: [],
+    charactersSnapshot: [],
+    locationsSnapshot: [],
+    itemsSnapshot: [],
+    storyBeatsSnapshot: [],
+    chaptersSnapshot: [],
+    createdAt: 0,
+  }
+}
+
+function branch(id: string, forkEntryId: string, name = id): Branch {
+  return {
+    id,
+    storyId: 's1',
+    name,
+    parentBranchId: null,
+    forkEntryId,
+    checkpointId: null,
+    createdAt: 0,
+  }
+}
+
+const contiguous = [entry('e0', 0), entry('e1', 1), entry('e2', 2), entry('e3', 3)]
+
+describe('entryNumber', () => {
+  it('is one-based, so the last number equals the entry count', () => {
+    expect(entryNumber(contiguous[0])).toBe(1)
+    expect(entryNumber(contiguous[contiguous.length - 1])).toBe(contiguous.length)
+  })
+})
+
+describe('resolveEntryByNumber', () => {
+  it('lands on the entry with that number', () => {
+    expect(resolveEntryByNumber(contiguous, 3)?.id).toBe('e2')
+  })
+
+  it('lands on the nearest lower entry when the number falls in a gap', () => {
+    const gapped = [entry('a', 0), entry('b', 1), entry('e', 40)]
+    expect(resolveEntryByNumber(gapped, 20)?.id).toBe('b')
+  })
+
+  it('clamps a number below the first entry to the first entry', () => {
+    expect(resolveEntryByNumber(contiguous, 0)?.id).toBe('e0')
+    expect(resolveEntryByNumber(contiguous, -5)?.id).toBe('e0')
+  })
+
+  it('clamps a number past the last entry to the last entry', () => {
+    expect(resolveEntryByNumber(contiguous, 9999)?.id).toBe('e3')
+  })
+
+  it('clamps below the first entry when the branch does not start at position 0', () => {
+    // A branch view always starts at 0, but a caller holding a slice should still land
+    // somewhere rather than on nothing.
+    const slice = [entry('x', 10), entry('y', 11)]
+    expect(resolveEntryByNumber(slice, 2)?.id).toBe('x')
+  })
+
+  it('handles a single-entry branch at either end', () => {
+    const single = [entry('only', 0)]
+    expect(resolveEntryByNumber(single, 1)?.id).toBe('only')
+    expect(resolveEntryByNumber(single, 0)?.id).toBe('only')
+    expect(resolveEntryByNumber(single, 50)?.id).toBe('only')
+  })
+
+  it('returns null for an empty branch', () => {
+    expect(resolveEntryByNumber([], 1)).toBeNull()
+  })
+
+  it('accepts a numeric string', () => {
+    expect(resolveEntryByNumber(contiguous, ' 2 ')?.id).toBe('e1')
+  })
+
+  it('returns null for empty or non-numeric input', () => {
+    expect(resolveEntryByNumber(contiguous, '')).toBeNull()
+    expect(resolveEntryByNumber(contiguous, '   ')).toBeNull()
+    expect(resolveEntryByNumber(contiguous, 'twelve')).toBeNull()
+    expect(resolveEntryByNumber(contiguous, '1.5')).toBeNull()
+  })
+})
+
+describe('buildLandmarks', () => {
+  // Main up to the fork at position 1, then the branch's own entries.
+  const branchView = [
+    entry('m0', 0),
+    entry('m1', 1),
+    entry('b2', 2, 'br1'),
+    entry('b3', 3, 'br1'),
+    entry('b4', 4, 'br1'),
+  ]
+  const br1 = branch('br1', 'm1', 'Betrayal')
+
+  it('puts the origin first, followed by the branch checkpoints in number order', () => {
+    const landmarks = buildLandmarks(
+      branchView,
+      [checkpoint('cp-late', 'b4'), checkpoint('cp-early', 'b2')],
+      br1,
+    )
+    expect(landmarks.map((l) => [l.kind, l.number])).toEqual([
+      ['origin', 2],
+      ['checkpoint', 3],
+      ['checkpoint', 5],
+    ])
+    expect(landmarks[0].label).toBe('Betrayal')
+  })
+
+  it('omits the origin row on the main branch', () => {
+    const mainView = [entry('m0', 0), entry('m1', 1)]
+    const landmarks = buildLandmarks(mainView, [checkpoint('cp', 'm1')], null)
+    expect(landmarks.map((l) => l.kind)).toEqual(['checkpoint'])
+  })
+
+  it('omits an origin whose entry is not loaded', () => {
+    const landmarks = buildLandmarks(branchView, [], branch('br1', 'not-loaded', 'Betrayal'))
+    expect(landmarks).toEqual([])
+  })
+
+  it('excludes checkpoints inherited from an ancestor branch', () => {
+    // m1 is in view, but it belongs to main -- a new branch cannot be forked from it
+    // while reading br1.
+    const landmarks = buildLandmarks(branchView, [checkpoint('cp-main', 'm1')], br1)
+    expect(landmarks.map((l) => l.kind)).toEqual(['origin'])
+  })
+
+  it('excludes a checkpoint whose entry a rollback has deleted', () => {
+    const landmarks = buildLandmarks(branchView, [checkpoint('cp', 'gone')], br1)
+    expect(landmarks.map((l) => l.kind)).toEqual(['origin'])
+  })
+
+  it('returns nothing for a main branch with no checkpoints', () => {
+    expect(buildLandmarks([entry('m0', 0)], [], null)).toEqual([])
+  })
+
+  it('carries the checkpoint name and preview onto the row', () => {
+    const [, row] = buildLandmarks(branchView, [checkpoint('cp', 'b2', 'Before the duel')], br1)
+    expect(row.label).toBe('Before the duel')
+    expect(row.preview).toBe('Before the duel preview')
+  })
+})

--- a/src/lib/utils/storyNavigation.ts
+++ b/src/lib/utils/storyNavigation.ts
@@ -55,27 +55,31 @@ export interface Landmark {
   number: number
   kind: LandmarkKind
   label: string
-  preview: string | null
+  branchName: string
 }
 
 /**
  * The places in the branch being read that are worth returning to: where it began, and every
- * checkpoint a new branch can be forked from here.
+ * checkpoint along the lineage that produced its current state.
  *
- * A checkpoint is forkable only from the branch its entry belongs to, so checkpoints inherited
- * from an ancestor are left out — they are visible in the story but cannot be branched from
- * while reading this branch. Resolution goes through `entries` rather than each checkpoint's
- * `entriesSnapshot` (a full deep copy of the story), which also drops checkpoints whose entry a
- * rollback has since deleted.
+ * Resolution goes through `entries` rather than each checkpoint's `entriesSnapshot` (a full deep
+ * copy of the story). This both includes inherited checkpoints in the visible lineage and drops
+ * checkpoints whose entry a rollback has since deleted.
  */
 export function buildLandmarks(
   entries: StoryEntry[],
   checkpoints: Checkpoint[],
+  branches: Branch[],
   activeBranch: Branch | null,
 ): Landmark[] {
   const byId = new Map(entries.map((entry) => [entry.id, entry]))
-  const branchId = activeBranch?.id ?? null
+  const branchNames = new Map(branches.map((branch) => [branch.id, branch.name]))
   const landmarks: Landmark[] = []
+
+  function getBranchName(branchId: string | null): string {
+    if (!branchId) return 'Main'
+    return branchNames.get(branchId) ?? 'Unknown branch'
+  }
 
   if (activeBranch) {
     const forkEntry = byId.get(activeBranch.forkEntryId)
@@ -90,20 +94,20 @@ export function buildLandmarks(
         number: entryNumber(forkEntry),
         kind: 'origin',
         label: origin?.name ?? 'Branch origin',
-        preview: origin?.lastEntryPreview ?? null,
+        branchName: getBranchName(forkEntry.branchId),
       })
     }
   }
 
   for (const checkpoint of checkpoints) {
     const entry = byId.get(checkpoint.lastEntryId)
-    if (!entry || entry.branchId !== branchId) continue
+    if (!entry || checkpoint.id === activeBranch?.checkpointId) continue
     landmarks.push({
       entryId: entry.id,
       number: entryNumber(entry),
       kind: 'checkpoint',
       label: checkpoint.name,
-      preview: checkpoint.lastEntryPreview,
+      branchName: getBranchName(entry.branchId),
     })
   }
 

--- a/src/lib/utils/storyNavigation.ts
+++ b/src/lib/utils/storyNavigation.ts
@@ -52,6 +52,7 @@ export type LandmarkKind = 'origin' | 'checkpoint'
 
 export interface Landmark {
   entryId: string
+  checkpointId: string | null
   number: number
   kind: LandmarkKind
   label: string
@@ -91,6 +92,7 @@ export function buildLandmarks(
       const origin = checkpoints.find((c) => c.id === activeBranch.checkpointId)
       landmarks.push({
         entryId: forkEntry.id,
+        checkpointId: origin?.id ?? null,
         number: entryNumber(forkEntry),
         kind: 'origin',
         label: origin?.name ?? 'Branch origin',
@@ -104,6 +106,7 @@ export function buildLandmarks(
     if (!entry || checkpoint.id === activeBranch?.checkpointId) continue
     landmarks.push({
       entryId: entry.id,
+      checkpointId: checkpoint.id,
       number: entryNumber(entry),
       kind: 'checkpoint',
       label: checkpoint.name,

--- a/src/lib/utils/storyNavigation.ts
+++ b/src/lib/utils/storyNavigation.ts
@@ -80,12 +80,17 @@ export function buildLandmarks(
   if (activeBranch) {
     const forkEntry = byId.get(activeBranch.forkEntryId)
     if (forkEntry) {
+      // The branch was forked from a checkpoint on its parent, and that checkpoint's entry is
+      // this fork entry. Naming the row after it keeps every row in the list a checkpoint name.
+      // It is not among the checkpoint rows below: it belongs to the parent branch, so nothing
+      // here is listed twice.
+      const origin = checkpoints.find((c) => c.id === activeBranch.checkpointId)
       landmarks.push({
         entryId: forkEntry.id,
         number: entryNumber(forkEntry),
         kind: 'origin',
-        label: activeBranch.name,
-        preview: null,
+        label: origin?.name ?? 'Branch origin',
+        preview: origin?.lastEntryPreview ?? null,
       })
     }
   }

--- a/src/lib/utils/storyNavigation.ts
+++ b/src/lib/utils/storyNavigation.ts
@@ -53,6 +53,7 @@ export type LandmarkKind = 'origin' | 'checkpoint'
 export interface Landmark {
   entryId: string
   checkpointId: string | null
+  branchId: string | null
   number: number
   kind: LandmarkKind
   label: string
@@ -93,6 +94,7 @@ export function buildLandmarks(
       landmarks.push({
         entryId: forkEntry.id,
         checkpointId: origin?.id ?? null,
+        branchId: forkEntry.branchId,
         number: entryNumber(forkEntry),
         kind: 'origin',
         label: origin?.name ?? 'Branch origin',
@@ -107,6 +109,7 @@ export function buildLandmarks(
     landmarks.push({
       entryId: entry.id,
       checkpointId: checkpoint.id,
+      branchId: entry.branchId,
       number: entryNumber(entry),
       kind: 'checkpoint',
       label: checkpoint.name,

--- a/src/lib/utils/storyNavigation.ts
+++ b/src/lib/utils/storyNavigation.ts
@@ -1,0 +1,106 @@
+import type { Branch, Checkpoint, StoryEntry } from '$lib/types'
+
+/**
+ * The number a reader sees for an entry: its stored position, one-based, so the last entry's
+ * number equals the entry count shown for the branch.
+ */
+export function entryNumber(entry: StoryEntry): number {
+  return entry.position + 1
+}
+
+/** Index of the last entry at or below `position`, or -1 when every entry is above it. */
+function floorIndex(entries: StoryEntry[], position: number): number {
+  let lo = 0
+  let hi = entries.length - 1
+  let found = -1
+
+  while (lo <= hi) {
+    const mid = (lo + hi) >>> 1
+    if (entries[mid].position <= position) {
+      found = mid
+      lo = mid + 1
+    } else {
+      hi = mid - 1
+    }
+  }
+
+  return found
+}
+
+/**
+ * The entry a reader means by a number, or null when there is nothing to navigate to.
+ *
+ * Positions are contiguous within a branch, but an imported or repaired story may have gaps,
+ * so a miss floors to the nearest lower-numbered entry and both ends clamp. `entries` must be
+ * sorted by position, which is how the store holds them.
+ */
+export function resolveEntryByNumber(
+  entries: StoryEntry[],
+  input: number | string,
+): StoryEntry | null {
+  if (entries.length === 0) return null
+
+  const parsed = typeof input === 'number' ? input : Number(input.trim())
+  if (typeof input === 'string' && input.trim() === '') return null
+  if (!Number.isInteger(parsed)) return null
+
+  const index = floorIndex(entries, parsed - 1)
+  return entries[index === -1 ? 0 : index]
+}
+
+export type LandmarkKind = 'origin' | 'checkpoint'
+
+export interface Landmark {
+  entryId: string
+  number: number
+  kind: LandmarkKind
+  label: string
+  preview: string | null
+}
+
+/**
+ * The places in the branch being read that are worth returning to: where it began, and every
+ * checkpoint a new branch can be forked from here.
+ *
+ * A checkpoint is forkable only from the branch its entry belongs to, so checkpoints inherited
+ * from an ancestor are left out — they are visible in the story but cannot be branched from
+ * while reading this branch. Resolution goes through `entries` rather than each checkpoint's
+ * `entriesSnapshot` (a full deep copy of the story), which also drops checkpoints whose entry a
+ * rollback has since deleted.
+ */
+export function buildLandmarks(
+  entries: StoryEntry[],
+  checkpoints: Checkpoint[],
+  activeBranch: Branch | null,
+): Landmark[] {
+  const byId = new Map(entries.map((entry) => [entry.id, entry]))
+  const branchId = activeBranch?.id ?? null
+  const landmarks: Landmark[] = []
+
+  if (activeBranch) {
+    const forkEntry = byId.get(activeBranch.forkEntryId)
+    if (forkEntry) {
+      landmarks.push({
+        entryId: forkEntry.id,
+        number: entryNumber(forkEntry),
+        kind: 'origin',
+        label: activeBranch.name,
+        preview: null,
+      })
+    }
+  }
+
+  for (const checkpoint of checkpoints) {
+    const entry = byId.get(checkpoint.lastEntryId)
+    if (!entry || entry.branchId !== branchId) continue
+    landmarks.push({
+      entryId: entry.id,
+      number: entryNumber(entry),
+      kind: 'checkpoint',
+      label: checkpoint.name,
+      preview: checkpoint.lastEntryPreview,
+    })
+  }
+
+  return landmarks.sort((a, b) => a.number - b.number)
+}


### PR DESCRIPTION
## Summary

- Add a persistent story navigation panel with entry-number and full-lineage landmark navigation.
- Label landmarks with their owning branch and support inline checkpoint renaming.
- Add a landmark navigation mode that stays on the current branch or switches to the owning branch before jumping.

## Verification

- npm run check — passed with 0 errors and 0 warnings.
- npm run lint — passed with 0 errors (existing warnings only).
- npm test — 1120 tests passed.

Target branch: upstream/master.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added story navigation with entry numbers, branch landmarks, checkpoints, renaming, and responsive controls.
  * Added mobile swipe gestures, desktop resizing, persistent panel preferences, and header/mobile-menu access.
  * Added automatic branch-tree expansion and improved response actions across screen sizes.

* **Bug Fixes**
  * Improved story loading, navigation, branch switching, and cleanup reliability.
  * Added clear errors for invalid navigation, failed renames, and loading failures.
  * Prevented conflicting edits or deletions during generation and retries.
  * Improved handling of unavailable checkpoint data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->