### PR TITLE
feat: add setting to change prompt-pack for a story

### DIFF
--- a/src/lib/components/settings/tabs/story-settings.svelte
+++ b/src/lib/components/settings/tabs/story-settings.svelte
@@ -10,7 +10,10 @@
   } from '$lib/services/prompts/templates'
   import { ContextBuilder } from '$lib/services/context'
   import { database } from '$lib/services/database'
+  import { packService } from '$lib/services/packs/pack-service'
+  import type { PresetPack } from '$lib/services/packs/types'
   import WritingStyleFields from '$lib/components/shared/WritingStyleFields.svelte'
+  import * as Select from '$lib/components/ui/select'
   import { Textarea } from '$lib/components/ui/textarea'
   import { Button } from '$lib/components/ui/button'
   import { Label } from '$lib/components/ui/label'
@@ -111,6 +114,34 @@
   let unknownVars = $state<string[]>([])
   let debounceTimer: ReturnType<typeof setTimeout> | null = null
   let showVarReference = $state(false)
+  let availablePacks = $state<PresetPack[]>([])
+  let selectedPackId = $state('default-pack')
+  let packChangePending = $state(false)
+  let packError = $state<string | null>(null)
+
+  const selectedPack = $derived(availablePacks.find((pack) => pack.id === selectedPackId))
+
+  $effect(() => {
+    const storyId = story.currentStory?.id
+    if (!storyId) return
+
+    let cancelled = false
+    Promise.all([packService.getAllPacks(), database.getStoryPackId(storyId)])
+      .then(([packs, packId]) => {
+        if (cancelled) return
+        availablePacks = packs
+        selectedPackId = packId || 'default-pack'
+        packError = null
+      })
+      .catch((error) => {
+        if (cancelled) return
+        packError = error instanceof Error ? error.message : String(error)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  })
 
   onDestroy(() => {
     if (debounceTimer) clearTimeout(debounceTimer)
@@ -136,8 +167,7 @@
     let cancelled = false
     const resolve = async () => {
       if (override) return templateUsesLengthInstruction(override)
-      const packId = (await database.getStoryPackId(storyId)) || 'default-pack'
-      const template = await new ContextBuilder(packId).resolveTemplate(templateId)
+      const template = await new ContextBuilder(selectedPackId).resolveTemplate(templateId)
       return templateUsesLengthInstruction(template?.content)
     }
 
@@ -179,6 +209,22 @@
     validationResult = null // clear stale result immediately so canSave goes false until debounce fires
     if (debounceTimer) clearTimeout(debounceTimer)
     debounceTimer = setTimeout(() => validate(value), 300)
+  }
+
+  async function changePromptPack(packId: string) {
+    const storyId = story.currentStory?.id
+    if (!storyId || packId === selectedPackId) return
+
+    packChangePending = true
+    packError = null
+    try {
+      await database.setStoryPack(storyId, packId)
+      selectedPackId = packId
+    } catch (error) {
+      packError = error instanceof Error ? error.message : String(error)
+    } finally {
+      packChangePending = false
+    }
   }
 
   function loadCurrentTemplate() {
@@ -237,8 +283,41 @@
     disabledReason="Cannot be changed mid-story. Set during story creation."
   />
 
-  <!-- ── Custom System Prompt ─────────────────────────────────────────────── -->
   <div class="border-t pt-4">
+    <div class="space-y-2">
+      <Label class="text-sm font-medium">Prompt Pack</Label>
+      <Select.Root
+        type="single"
+        value={selectedPackId}
+        disabled={packChangePending || availablePacks.length === 0}
+        onValueChange={(value) => {
+          if (value) void changePromptPack(value)
+        }}
+      >
+        <Select.Trigger class="w-full">
+          {selectedPack?.name ??
+            (availablePacks.length === 0 ? 'Loading prompt packs…' : 'Select a pack')}
+        </Select.Trigger>
+        <Select.Content>
+          {#each availablePacks as pack (pack.id)}
+            <Select.Item value={pack.id} label={pack.name}>
+              {pack.name}
+            </Select.Item>
+          {/each}
+        </Select.Content>
+      </Select.Root>
+      <p class="text-muted-foreground text-xs">
+        Changes take effect on the next generation. An active Custom System Prompt below still
+        replaces this pack's narrator template for this story.
+      </p>
+      {#if packError}
+        <p class="text-destructive text-xs">Could not change prompt pack: {packError}</p>
+      {/if}
+    </div>
+  </div>
+
+  <!-- ── Custom System Prompt ─────────────────────────────────────────────── -->
+  <div>
     <div class="mb-3 flex items-center justify-between gap-2">
       <div class="flex items-center gap-2">
         <Label class="text-sm font-medium">Custom System Prompt</Label>


### PR DESCRIPTION
## Problem

Stories imported from `.avt` files cannot specify which prompt pack they should use. This makes it impossible to use custom prompt packs with imported stories.

## Change

Adds a prompt pack selector to Story Settings, allowing a different prompt pack to be selected for an imported story.

## Verification

- pre-commit hooks: `npm run lint` and `npm run check`
- Import an `.avt` story, select a custom prompt pack in Story Settings, and verify that the next generation uses it.

<img width="1166" height="708" alt="Screenshot 2026-08-21 at 17 11 53" src="https://github.com/user-attachments/assets/99609cc6-fdfb-43d6-8224-1d2518b569e0" />
<img width="1163" height="707" alt="Screenshot 2026-08-21 at 17 11 59" src="https://github.com/user-attachments/assets/0b2e1a2c-6c6a-4fba-9887-387b8fd1dd70" />
<img width="1166" height="709" alt="Screenshot 2026-08-21 at 17 12 09" src="https://github.com/user-attachments/assets/c2ac53e5-5e3a-4506-b02d-b9e3ea3fda05" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a prompt-pack selector to story settings.
  * Automatically loads available prompt packs and the story’s current selection.
  * Saves prompt-pack changes with loading and error feedback.
  * Uses the selected prompt pack when resolving story prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->