### PR TITLE
Provider Cleanup

### DIFF
--- a/src/lib/services/ai/core/reasoning.test.ts
+++ b/src/lib/services/ai/core/reasoning.test.ts
@@ -93,6 +93,17 @@ describe('reasoningCapabilityFor', () => {
     ).toBe('supported')
   })
 
+  it('treats an unknown model as supported when the catalogue omits the flag', () => {
+    // A capability-fetching provider whose entry for this model has no reasoning flag at all --
+    // distinct from an explicit false, which stays unsupported.
+    expect(
+      reasoningCapabilityFor({
+        ...base,
+        modelSupportsReasoning: undefined,
+      }),
+    ).toBe('supported')
+  })
+
   it('enforces only the thinking variants', () => {
     expect(reasoningCapabilityFor({ ...base, modelId: 'zai-org/glm-5:thinking' })).toBe('enforced')
   })

--- a/src/lib/services/ai/core/reasoning.ts
+++ b/src/lib/services/ai/core/reasoning.ts
@@ -88,10 +88,9 @@ export function reasoningCapabilityFor({
   modelSupportsReasoning,
 }: ReasoningCapabilityInput): ReasoningCapability {
   if (!modelId || !providerSupportsReasoning) return 'unsupported'
-  // Only a provider that publishes capabilities can say a model has none; elsewhere the
-  // absent flag means "unknown", and refusing reasoning on unknown would disable the slider
-  // for every provider that does not have a catalogue.
-  if (providerFetchesModelCapabilities && !modelSupportsReasoning) return 'unsupported'
+  // Only a provider that publishes capabilities can say a model has none; refusing reasoning on
+  // unknown would disable the slider for every provider that does not explicitly return false.
+  if (providerFetchesModelCapabilities && modelSupportsReasoning === false) return 'unsupported'
   if (modelSupportsReasoning && reasoningIsEnforced(providerType, modelId)) return 'enforced'
   return 'supported'
 }

--- a/src/lib/services/ai/sdk/generate.ts
+++ b/src/lib/services/ai/sdk/generate.ts
@@ -24,14 +24,14 @@ import { jsonrepair } from 'jsonrepair'
 import * as z from 'zod'
 import { loggingMiddleware, patchResponseMiddleware, promptSchemaMiddleware } from './middleware'
 import { retryOn429Middleware } from './middleware/retryMiddleware'
-import { createModelFromProfile } from './providers'
-import { usesThinkTag } from './providers/config'
 import {
   buildProviderOptions,
+  type ResolvedPreset,
   resolvePresetModel,
   thinkingNudgeApplies,
-  type ResolvedPreset,
 } from './presetResolution'
+import { createModelFromProfile } from './providers'
+import { usesThinkTag } from './providers/config'
 
 const log = createLogger('Generate')
 
@@ -57,8 +57,6 @@ interface GenerateObjectOptions<T extends z.ZodType> extends BaseGenerateOptions
 // Config Resolution
 // ============================================================================
 
-type ResolvedConfig = ResolvedPreset
-
 interface NarrativeConfig {
   profile: APIProfile
   providerType: ProviderType
@@ -68,10 +66,6 @@ interface NarrativeConfig {
   providerOptions?: SharedV4ProviderOptions
   reasoning: ReasoningEffort
   useThinkTag: boolean
-}
-
-function resolveConfig(presetId: string, serviceId: string, debugId?: string): ResolvedConfig {
-  return resolvePresetModel({ presetId, serviceId, debugId })
 }
 
 /**
@@ -148,7 +142,7 @@ function createJsonExtractMiddleware(): LanguageModelMiddleware {
  * Takes the resolved config rather than a row of booleans: every flag it needs is already on
  * it, and four positional `boolean`s in a row is a swap no type error would ever catch.
  */
-function buildStructuredMiddleware(config: ResolvedConfig): LanguageModelMiddleware[] {
+function buildStructuredMiddleware(config: ResolvedPreset): LanguageModelMiddleware[] {
   const { supportsStructuredOutput, useThinkTag, preset, providerType } = config
 
   // retryOn429Middleware is intentionally outermost: it re-invokes the whole
@@ -210,7 +204,7 @@ export async function generateStructured<T extends z.ZodType>(
   serviceId: string,
 ): Promise<z.infer<T>> {
   const { presetId, schema, system, prompt, signal } = options
-  const config = resolveConfig(presetId, serviceId)
+  const config = resolvePresetModel({ presetId, serviceId, debugId: undefined })
   const { preset, providerType, model, providerOptions, reasoning, supportsStructuredOutput } =
     config
 
@@ -244,10 +238,12 @@ export async function generatePlainText(
   serviceId: string,
 ): Promise<string> {
   const { presetId, system, prompt, signal } = options
-  const { preset, providerType, model, providerOptions, reasoning, useThinkTag } = resolveConfig(
-    presetId,
-    serviceId,
-  )
+  const { preset, providerType, model, providerOptions, reasoning, useThinkTag } =
+    resolvePresetModel({
+      presetId,
+      serviceId,
+      debugId: undefined,
+    })
 
   log('generatePlainText', { presetId, model: preset.model, providerType })
 

--- a/src/lib/services/ai/sdk/providers/modelFetcher.ts
+++ b/src/lib/services/ai/sdk/providers/modelFetcher.ts
@@ -6,8 +6,11 @@
 
 import type { ProviderType, TextModel } from '$lib/types'
 import { dedupeTextModels } from '$lib/utils/dedupeTextModels'
+import { createLogger } from '$lib/log'
 import { getBaseUrl, PROVIDERS } from './config'
 import { createTimeoutFetch } from './fetch'
+
+const log = createLogger('ModelFetcher')
 
 /** URLs that don't require authentication for model fetching */
 const NO_AUTH_PATTERNS = ['nano-gpt.com', 'gen.pollinations.ai', '127.0.0.1', 'localhost']
@@ -204,9 +207,13 @@ async function fetchNanoGptModels(baseUrl?: string, apiKey?: string): Promise<Te
   const textModels: NanoGptModelEntry[] = data?.data ?? []
   const models: TextModel[] = []
 
-  for (const [key, entry] of Object.entries(textModels)) {
+  for (const entry of textModels) {
+    if (!entry.id) {
+      log('dropping NanoGPT model entry with no id', entry)
+      continue
+    }
     models.push({
-      id: entry.id || key,
+      id: entry.id,
       reasoning: entry.capabilities?.reasoning,
       structuredOutput: entry.capabilities?.structured_output,
     })
@@ -227,14 +234,18 @@ async function fetchOpenRouterModels(baseUrl?: string): Promise<TextModel[]> {
   }
 
   const data = await response.json()
-  const textModels: { id: string; supported_parameters: string[] }[] = data?.data ?? []
+  const textModels: { id: string; name?: string; supported_parameters: string[] }[] =
+    data?.data ?? []
 
   const models: TextModel[] = []
 
   for (const entry of textModels) {
-    const modelId = entry.id
+    if (!entry.id) {
+      log('dropping OpenRouter model entry with no id', entry)
+      continue
+    }
     models.push({
-      id: modelId,
+      id: entry.id,
       reasoning: entry.supported_parameters?.includes('reasoning'),
       structuredOutput: entry.supported_parameters?.includes('structured_outputs'),
     })
@@ -247,18 +258,17 @@ async function fetchAnthropicModels(baseUrl?: string, apiKey?: string): Promise<
   const effectiveBaseUrl = baseUrl || 'https://api.anthropic.com/v1'
   const modelsUrl = effectiveBaseUrl.replace(/\/$/, '') + '/models'
 
+  const fetchFn = createTimeoutFetch(30000, 'model-fetch')
+  const headers: Record<string, string> = { 'anthropic-version': '2023-06-01' }
+  if (apiKey) headers['x-api-key'] = apiKey
+
+  const response = await fetchFn(modelsUrl, { method: 'GET', headers })
+
+  if (!response.ok) {
+    throw new Error(`Anthropic API returned ${response.status} ${response.statusText}`)
+  }
+
   try {
-    const fetchFn = createTimeoutFetch(30000, 'model-fetch')
-    const headers: Record<string, string> = { 'anthropic-version': '2023-06-01' }
-    if (apiKey) headers['x-api-key'] = apiKey
-
-    const response = await fetchFn(modelsUrl, { method: 'GET', headers })
-
-    if (!response.ok) {
-      console.warn(`[ModelFetcher] Anthropic API returned ${response.status}`)
-      return []
-    }
-
     const data = await response.json()
     if (data.data && Array.isArray(data.data)) {
       const models = data.data.map((m: { id: string }) => m.id).filter(Boolean)
@@ -267,7 +277,7 @@ async function fetchAnthropicModels(baseUrl?: string, apiKey?: string): Promise<
 
     return []
   } catch (error) {
-    console.warn('[ModelFetcher] Failed to fetch Anthropic models:', error)
+    log('Failed to fetch Anthropic models:', error)
     return []
   }
 }
@@ -299,15 +309,14 @@ async function fetchGoogleModels(baseUrl?: string, apiKey?: string): Promise<Tex
     encodeURIComponent(apiKey) +
     '&pageSize=200'
 
+  const fetchFn = createTimeoutFetch(30000, 'model-fetch')
+  const response = await fetchFn(modelsUrl, { method: 'GET' })
+
+  if (!response.ok) {
+    throw new Error(`Google API returned ${response.status} ${response.statusText}`)
+  }
+
   try {
-    const fetchFn = createTimeoutFetch(30000, 'model-fetch')
-    const response = await fetchFn(modelsUrl, { method: 'GET' })
-
-    if (!response.ok) {
-      console.warn(`[ModelFetcher] Google API returned ${response.status}`)
-      return []
-    }
-
     const data = await response.json()
     if (data.models && Array.isArray(data.models)) {
       const models = (data.models as GoogleModelEntry[])
@@ -330,7 +339,7 @@ async function fetchGoogleModels(baseUrl?: string, apiKey?: string): Promise<Tex
 
     return []
   } catch (error) {
-    console.warn('[ModelFetcher] Failed to fetch Google models:', error)
+    log('Failed to fetch Google models:', error)
     return []
   }
 }
@@ -371,15 +380,14 @@ async function fetchOllamaModels(baseUrl?: string): Promise<string[]> {
   const effectiveBaseUrl = baseUrl || PROVIDERS.ollama.baseUrl
   const tagsUrl = effectiveBaseUrl.replace(/\/$/, '').replace(/\/api$/, '') + '/api/tags'
 
+  const fetchFn = createTimeoutFetch(10000, 'model-fetch')
+  const response = await fetchFn(tagsUrl, { method: 'GET' })
+
+  if (!response.ok) {
+    throw new Error(`Ollama returned ${response.status} ${response.statusText}`)
+  }
+
   try {
-    const fetchFn = createTimeoutFetch(10000, 'model-fetch')
-    const response = await fetchFn(tagsUrl, { method: 'GET' })
-
-    if (!response.ok) {
-      console.warn(`[ModelFetcher] Ollama returned ${response.status}`)
-      return []
-    }
-
     const data = await response.json()
     if (data.models && Array.isArray(data.models)) {
       const models = data.models
@@ -390,7 +398,7 @@ async function fetchOllamaModels(baseUrl?: string): Promise<string[]> {
 
     return []
   } catch (error) {
-    console.warn('[ModelFetcher] Failed to fetch Ollama models (is Ollama running?):', error)
+    log('Failed to fetch Ollama models (is Ollama running?):', error)
     return []
   }
 }
@@ -403,18 +411,17 @@ async function fetchZhipuModels(baseUrl?: string, apiKey?: string): Promise<stri
   const effectiveBaseUrl = baseUrl || PROVIDERS.zhipu.baseUrl
   const modelsUrl = effectiveBaseUrl.replace(/\/$/, '') + '/models'
 
+  const fetchFn = createTimeoutFetch(30000, 'model-fetch')
+  const response = await fetchFn(modelsUrl, {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${apiKey}` },
+  })
+
+  if (!response.ok) {
+    throw new Error(`Zhipu API returned ${response.status} ${response.statusText}`)
+  }
+
   try {
-    const fetchFn = createTimeoutFetch(30000, 'model-fetch')
-    const response = await fetchFn(modelsUrl, {
-      method: 'GET',
-      headers: { Authorization: `Bearer ${apiKey}` },
-    })
-
-    if (!response.ok) {
-      console.warn(`[ModelFetcher] Zhipu API returned ${response.status}`)
-      return []
-    }
-
     const data = await response.json()
     if (data.data && Array.isArray(data.data)) {
       const models = data.data.map((m: { id?: string }) => m.id || '').filter(Boolean)
@@ -423,7 +430,7 @@ async function fetchZhipuModels(baseUrl?: string, apiKey?: string): Promise<stri
 
     return []
   } catch (error) {
-    console.warn('[ModelFetcher] Failed to fetch Zhipu models:', error)
+    log('Failed to fetch Zhipu models:', error)
     return []
   }
 }
@@ -436,18 +443,17 @@ async function fetchMistralModels(baseUrl?: string, apiKey?: string): Promise<st
   const effectiveBaseUrl = baseUrl || PROVIDERS.mistral.baseUrl
   const modelsUrl = effectiveBaseUrl.replace(/\/$/, '') + '/models'
 
+  const fetchFn = createTimeoutFetch(30000, 'model-fetch')
+  const response = await fetchFn(modelsUrl, {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${apiKey}` },
+  })
+
+  if (!response.ok) {
+    throw new Error(`Mistral API returned ${response.status} ${response.statusText}`)
+  }
+
   try {
-    const fetchFn = createTimeoutFetch(30000, 'model-fetch')
-    const response = await fetchFn(modelsUrl, {
-      method: 'GET',
-      headers: { Authorization: `Bearer ${apiKey}` },
-    })
-
-    if (!response.ok) {
-      console.warn(`[ModelFetcher] Mistral API returned ${response.status}`)
-      return []
-    }
-
     const data = await response.json()
     if (data.data && Array.isArray(data.data)) {
       const models = data.data.map((m: { id?: string }) => m.id || '').filter(Boolean)
@@ -456,7 +462,7 @@ async function fetchMistralModels(baseUrl?: string, apiKey?: string): Promise<st
 
     return []
   } catch (error) {
-    console.warn('[ModelFetcher] Failed to fetch Mistral models:', error)
+    log('Failed to fetch Mistral models:', error)
     return []
   }
 }
@@ -473,13 +479,15 @@ async function fetchPollinationsTextModels(apiKey?: string): Promise<TextModel[]
   const url = 'https://gen.pollinations.ai/text/models'
   const fetchFn = createTimeoutFetch(30000, 'model-fetch')
 
-  try {
-    const response = await fetchFn(url, {
-      method: 'GET',
-      headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : {},
-    })
-    if (!response.ok) return []
+  const response = await fetchFn(url, {
+    method: 'GET',
+    headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : {},
+  })
+  if (!response.ok) {
+    throw new Error(`Pollinations API returned ${response.status} ${response.statusText}`)
+  }
 
+  try {
     const data = await response.json()
     if (!Array.isArray(data)) return []
 
@@ -497,7 +505,7 @@ async function fetchPollinationsTextModels(apiKey?: string): Promise<TextModel[]
 
     return models.length > 0 ? dedupeTextModels(models) : []
   } catch (error) {
-    console.warn('[ModelFetcher] Failed to fetch Pollinations text models:', error)
+    log('Failed to fetch Pollinations text models:', error)
     return []
   }
 }

--- a/src/lib/services/ai/sdk/providers/modelFetcher.ts
+++ b/src/lib/services/ai/sdk/providers/modelFetcher.ts
@@ -295,15 +295,17 @@ async function fetchGoogleModels(baseUrl?: string, apiKey?: string): Promise<Tex
     const data = await response.json()
     if (data.models && Array.isArray(data.models)) {
       const models = (data.models as GoogleModelEntry[])
-        .filter((m) => m.supportedGenerationMethods?.includes('generateContent'))
+        .filter(
+          (m) =>
+            m.supportedGenerationMethods == null ||
+            m.supportedGenerationMethods.includes('generateContent'),
+        )
         .filter((m) => !isGoogleImageModel(m.name.replace(/^models\//, '')))
         .map((m) => {
           const id = m.name.replace(/^models\//, '')
-          const isGemini25 = id.includes('gemini-2.5')
           return {
             id,
-            reasoning: m.thinking ?? false,
-            isBudgetReasoning: isGemini25,
+            reasoning: m.thinking ?? true,
           }
         })
         .filter((m) => !!m.id)

--- a/src/lib/services/ai/sdk/providers/modelFetcher.ts
+++ b/src/lib/services/ai/sdk/providers/modelFetcher.ts
@@ -6,8 +6,8 @@
 
 import type { ProviderType, TextModel } from '$lib/types'
 import { dedupeTextModels } from '$lib/utils/dedupeTextModels'
+import { getBaseUrl, PROVIDERS } from './config'
 import { createTimeoutFetch } from './fetch'
-import { PROVIDERS, getBaseUrl } from './config'
 
 /** URLs that don't require authentication for model fetching */
 const NO_AUTH_PATTERNS = ['nano-gpt.com', 'gen.pollinations.ai', '127.0.0.1', 'localhost']
@@ -34,7 +34,7 @@ export async function fetchModelsFromProvider(
   apiKey?: string,
 ): Promise<TextModel[]> {
   // Provider-specific fetch logic
-  if (providerType === 'nanogpt') return fetchNanogptModels(baseUrl)
+  if (providerType === 'nanogpt') return fetchNanoGptModels(baseUrl, apiKey)
   if (providerType === 'openrouter') return fetchOpenRouterModels(baseUrl)
   if (providerType === 'google') return fetchGoogleModels(baseUrl, apiKey)
   if (providerType === 'anthropic') return wrap(fetchAnthropicModels(baseUrl, apiKey))
@@ -164,35 +164,51 @@ async function fetchNimModels(baseUrl?: string, apiKey?: string): Promise<TextMo
   return dedupeTextModels(raw.filter((m) => isNimTextGenModel(m.id)).map((m) => ({ id: m.id })))
 }
 
-interface NanogptModelEntry {
-  model: string
-  name?: string
-  capabilities?: string[]
+interface NanoGptCapabilities {
+  reasoning?: boolean
+  tool_calling?: boolean
+  parallel_tool_calls?: boolean
+  structured_output?: boolean
 }
 
-async function fetchNanogptModels(baseUrl?: string): Promise<TextModel[]> {
+interface NanoGptSubscriptionDetails {
+  included: boolean
+  inputTokenMultiplier?: number
+  note?: string
+}
+
+interface NanoGptModelEntry {
+  id: string
+  name?: string
+  capabilities?: NanoGptCapabilities
+  reasoning_efforts?: string[]
+  subscription: NanoGptSubscriptionDetails
+}
+
+async function fetchNanoGptModels(baseUrl?: string, apiKey?: string): Promise<TextModel[]> {
   // Use the detailed API to get capabilities including reasoning
-  const effectiveBase = baseUrl?.replace(/\/v1\/?$/, '') || 'https://nano-gpt.com/api'
+  const effectiveBase = baseUrl || 'https://nano-gpt.com/api/v1'
   const modelsUrl = effectiveBase.replace(/\/$/, '') + '/models?detailed=true'
 
   const fetchFn = createTimeoutFetch(30000, 'model-fetch')
-  const response = await fetchFn(modelsUrl, { method: 'GET' })
+  const response = await fetchFn(modelsUrl, {
+    method: 'GET',
+    headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : {},
+  })
 
   if (!response.ok) {
     throw new Error(`Failed to fetch NanoGPT models: ${response.status} ${response.statusText}`)
   }
 
   const data = await response.json()
-  const textModels: Record<string, NanogptModelEntry> = data?.models?.text ?? {}
-
+  const textModels: NanoGptModelEntry[] = data?.data ?? []
   const models: TextModel[] = []
 
   for (const [key, entry] of Object.entries(textModels)) {
-    const modelId = entry.model || key
     models.push({
-      id: modelId,
-      reasoning: entry.capabilities?.includes('reasoning'),
-      structuredOutput: entry.capabilities?.includes('structured-output'),
+      id: entry.id || key,
+      reasoning: entry.capabilities?.reasoning ?? false,
+      structuredOutput: entry.capabilities?.structured_output ?? false,
     })
   }
 

--- a/src/lib/services/ai/sdk/providers/modelFetcher.ts
+++ b/src/lib/services/ai/sdk/providers/modelFetcher.ts
@@ -207,8 +207,8 @@ async function fetchNanoGptModels(baseUrl?: string, apiKey?: string): Promise<Te
   for (const [key, entry] of Object.entries(textModels)) {
     models.push({
       id: entry.id || key,
-      reasoning: entry.capabilities?.reasoning ?? false,
-      structuredOutput: entry.capabilities?.structured_output ?? false,
+      reasoning: entry.capabilities?.reasoning,
+      structuredOutput: entry.capabilities?.structured_output,
     })
   }
 
@@ -321,7 +321,7 @@ async function fetchGoogleModels(baseUrl?: string, apiKey?: string): Promise<Tex
           const id = m.name.replace(/^models\//, '')
           return {
             id,
-            reasoning: m.thinking ?? true,
+            reasoning: m.thinking,
           }
         })
         .filter((m) => !!m.id)
@@ -492,7 +492,7 @@ async function fetchPollinationsTextModels(apiKey?: string): Promise<TextModel[]
       )
       .map((m) => ({
         id: m.name,
-        reasoning: m.reasoning ?? false,
+        reasoning: m.reasoning,
       }))
 
     return models.length > 0 ? dedupeTextModels(models) : []

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -668,8 +668,6 @@ export type ProviderType =
 export interface TextModel {
   id: string
   reasoning?: boolean
-  /** Whether the model uses a token budget for reasoning (Gemini 2.x, Anthropic) instead of effort levels */
-  isBudgetReasoning?: boolean
   structuredOutput?: boolean
 }
 

--- a/src/lib/utils/dedupeTextModels.test.ts
+++ b/src/lib/utils/dedupeTextModels.test.ts
@@ -63,6 +63,16 @@ describe('dedupeTextModels', () => {
       expect(result[0].reasoning).toBeUndefined()
       expect(result[0].structuredOutput).toBeUndefined()
     })
+
+    it('keeps an explicit false over a later undefined', () => {
+      const result = dedupeTextModels([model('a', { reasoning: false }), model('a')])
+      expect(result[0].reasoning).toBe(false)
+    })
+
+    it('keeps an explicit false from the later duplicate', () => {
+      const result = dedupeTextModels([model('a'), model('a', { reasoning: false })])
+      expect(result[0].reasoning).toBe(false)
+    })
   })
 
   it('returns an empty list unchanged', () => {

--- a/src/lib/utils/dedupeTextModels.test.ts
+++ b/src/lib/utils/dedupeTextModels.test.ts
@@ -58,26 +58,10 @@ describe('dedupeTextModels', () => {
       expect(result[0].structuredOutput).toBe(true)
     })
 
-    it('lets the first duplicate win on isBudgetReasoning', () => {
-      // `??` not `||` here, and deliberately: `false` is a real answer for this flag (the model
-      // takes effort levels, not a token budget), so the first source to state it is trusted.
-      const result = dedupeTextModels([
-        model('a', { isBudgetReasoning: false }),
-        model('a', { isBudgetReasoning: true }),
-      ])
-      expect(result[0].isBudgetReasoning).toBe(false)
-    })
-
-    it('takes isBudgetReasoning from the later duplicate when the first left it unset', () => {
-      const result = dedupeTextModels([model('a'), model('a', { isBudgetReasoning: true })])
-      expect(result[0].isBudgetReasoning).toBe(true)
-    })
-
     it('leaves a capability undefined rather than false when nobody declares it', () => {
       const result = dedupeTextModels([model('a'), model('a')])
       expect(result[0].reasoning).toBeUndefined()
       expect(result[0].structuredOutput).toBeUndefined()
-      expect(result[0].isBudgetReasoning).toBeUndefined()
     })
   })
 

--- a/src/lib/utils/dedupeTextModels.ts
+++ b/src/lib/utils/dedupeTextModels.ts
@@ -11,8 +11,8 @@ export function dedupeTextModels(models: TextModel[]): TextModel[] {
     if (existing) {
       deduped.set(id, {
         ...existing,
-        reasoning: existing.reasoning || model.reasoning || undefined,
-        structuredOutput: existing.structuredOutput || model.structuredOutput || undefined,
+        reasoning: existing.reasoning ?? model.reasoning,
+        structuredOutput: existing.structuredOutput ?? model.structuredOutput,
       })
       continue
     }

--- a/src/lib/utils/dedupeTextModels.ts
+++ b/src/lib/utils/dedupeTextModels.ts
@@ -12,7 +12,6 @@ export function dedupeTextModels(models: TextModel[]): TextModel[] {
       deduped.set(id, {
         ...existing,
         reasoning: existing.reasoning || model.reasoning || undefined,
-        isBudgetReasoning: existing.isBudgetReasoning ?? model.isBudgetReasoning ?? undefined,
         structuredOutput: existing.structuredOutput || model.structuredOutput || undefined,
       })
       continue


### PR DESCRIPTION
* Remove unused Gemini budget reasoning flag
* Return models from AI Studio filter if generation capabilities are missing (3rd party API implementations/proxies)
* Use authenticated NanoGPT model fetch endpoint
* Don't resolve missing model capabilities
* Allow unknown reasoning support to expose thinking slider
* Cleanup type alias and function forward

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved model discovery across supported providers, including more reliable authentication and model identification.
  * Models with unknown reasoning capabilities are now treated as available unless explicitly marked unsupported.
* **Bug Fixes**
  * Preserved explicit capability settings, including disabled reasoning and structured output, when duplicate models are combined.
  * Provider errors are now surfaced more consistently instead of appearing as empty model lists.
* **Refactor**
  * Simplified model configuration resolution without changing text or structured generation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->