### PR TITLE
M3 smaller followups

### DIFF
--- a/.storybook/vitest.setup.ts
+++ b/.storybook/vitest.setup.ts
@@ -1,0 +1,6 @@
+// react-native-css-interop's wrap-jsx guards its own component registration
+// with `if (process.env.NODE_ENV !== 'test')`, so under vitest nothing is
+// registered and every className in a story is inert. Importing the
+// registration module directly beats that guard while still using the
+// library's canonical component list rather than a local copy that can drift.
+import 'react-native-css-interop/dist/runtime/components'

--- a/.storybook/vitest.setup.ts
+++ b/.storybook/vitest.setup.ts
@@ -1,6 +1,4 @@
-// react-native-css-interop's wrap-jsx guards its own component registration
-// with `if (process.env.NODE_ENV !== 'test')`, so under vitest nothing is
-// registered and every className in a story is inert. Importing the
-// registration module directly beats that guard while still using the
-// library's canonical component list rather than a local copy that can drift.
+// css-interop's wrap-jsx skips component registration when NODE_ENV === 'test',
+// leaving every className in a story inert. Import the registration module
+// directly to beat that guard — never hand-roll a local component list.
 import 'react-native-css-interop/dist/runtime/components'

--- a/components/compounds/embedding-models-panel.stories.tsx
+++ b/components/compounds/embedding-models-panel.stories.tsx
@@ -64,7 +64,9 @@ export const TestSuccess: Story = {
   },
   play: async () => {
     await userEvent.click(await screen.findByText(LIGHTWEIGHT.displayName))
-    await userEvent.click(await screen.findByText('Test embedder'))
+    await userEvent.click(
+      await screen.findByRole('button', { name: `Test ${LIGHTWEIGHT.displayName}` }),
+    )
     await waitFor(() =>
       expect(screen.getByText(`OK · dim ${LIGHTWEIGHT.dim} · 42 ms`)).toBeTruthy(),
     )
@@ -80,7 +82,9 @@ export const TestFailure: Story = {
   },
   play: async () => {
     await userEvent.click(await screen.findByText(LIGHTWEIGHT.displayName))
-    await userEvent.click(await screen.findByText('Test embedder'))
+    await userEvent.click(
+      await screen.findByRole('button', { name: `Test ${LIGHTWEIGHT.displayName}` }),
+    )
     await waitFor(() => expect(screen.getByText('ONNX runtime init failed')).toBeTruthy())
   },
 }

--- a/components/compounds/expandable-row.stories.tsx
+++ b/components/compounds/expandable-row.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite'
-import { useState } from 'react'
+import { useState, type ReactNode } from 'react'
 import { Pressable, View } from 'react-native'
 import { expect, screen, userEvent, waitFor } from 'storybook/test'
 
@@ -40,7 +40,11 @@ function Demo({
           removeLabel={`Remove ${row.name}`}
           expandLabel={`Expand ${row.name}`}
           collapseLabel={`Collapse ${row.name}`}
-          compact={<Text className="font-medium">{row.name}</Text>}
+          compact={
+            <View className="min-h-control-sm justify-center">
+              <Text className="font-medium">{row.name}</Text>
+            </View>
+          }
           editor={<Text variant="muted">Editor body for {row.name}</Text>}
           compactAction={
             row.id === compactActionRowId ? (
@@ -161,7 +165,7 @@ export const RemovingARowPrunesItsExpansionSoARecycledIdStartsCollapsed: Story =
   },
 }
 
-function midY(el: Element): number {
+function mid(el: Element): number {
   const r = el.getBoundingClientRect()
   return (r.top + r.bottom) / 2
 }
@@ -174,8 +178,8 @@ function midY(el: Element): number {
  * to actually resolve under vitest, which they do as of the storybook project's
  * cssInterop registration.
  */
-export const CompactActionSharesTheIconActionCentreline: Story = {
-  render: () => (
+function row(compactAction?: ReactNode) {
+  return (
     <ExpandableRow
       expanded={false}
       invalid={false}
@@ -184,27 +188,62 @@ export const CompactActionSharesTheIconActionCentreline: Story = {
       removeLabel="Remove row"
       expandLabel="Expand row"
       collapseLabel="Collapse row"
-      compact={<Text className="font-medium">char</Text>}
-      editor={<Text variant="muted">Editor body</Text>}
-      compactAction={
-        <Button variant="secondary" size="sm">
-          <Text>Set as lead</Text>
-        </Button>
+      compact={
+        <View className="min-h-control-sm justify-center">
+          <Text className="font-medium">char</Text>
+        </View>
       }
+      editor={<Text variant="muted">Editor body</Text>}
+      compactAction={compactAction}
     />
-  ),
+  )
+}
+
+/**
+ * A control-height `compactAction` (a Button) sits beside 22px icon-actions.
+ * Top-aligning them parked their centres 7px apart, and the cluster being
+ * shorter than the row's content box dropped all its slack below the controls —
+ * the Button's top touched the row border with a gap underneath. The cluster
+ * now centres on a control-height line box, which `compact`'s first line
+ * matches. Asserting any of this needs NativeWind classNames to resolve under
+ * vitest, which they do as of the storybook project's cssInterop registration.
+ */
+export const CompactActionCentresOnTheRow: Story = {
+  render: () =>
+    row(
+      <Button variant="secondary" size="sm">
+        <Text>Set as lead</Text>
+      </Button>,
+    ),
   play: async () => {
     const action = screen.getByRole('button', { name: 'Set as lead' })
     const remove = screen.getByRole('button', { name: 'Remove row' })
     const name = screen.getByText('char')
+    const rowEl = action.closest('.rounded-md') as HTMLElement
 
-    // The two controls differ in height by design; only their centres must agree.
-    expect(action.getBoundingClientRect().height).toBeGreaterThan(
-      remove.getBoundingClientRect().height,
-    )
-    expect(Math.abs(midY(action) - midY(remove))).toBeLessThanOrEqual(1)
-    // ...and the cluster tracks the summary's first line rather than floating
-    // below it, which is what made the whole row read as badly centred.
-    expect(Math.abs(midY(name) - midY(remove))).toBeLessThanOrEqual(3)
+    const a = action.getBoundingClientRect()
+    const r = rowEl.getBoundingClientRect()
+    // The controls differ in height by design; only their centres must agree.
+    expect(a.height).toBeGreaterThan(remove.getBoundingClientRect().height)
+    expect(Math.abs(mid(action) - mid(remove))).toBeLessThanOrEqual(1)
+    expect(Math.abs(mid(action) - mid(name))).toBeLessThanOrEqual(1)
+    // The cluster is centred in the row, not top-anchored with the slack
+    // dumped underneath it.
+    expect(Math.abs(a.top - r.top - (r.bottom - a.bottom))).toBeLessThanOrEqual(1)
+    expect(Math.abs(mid(action) - mid(rowEl))).toBeLessThanOrEqual(1)
+  },
+}
+
+/** Without a compactAction the cluster is icon-actions only — it must still
+ *  centre on the same line box, or a consumer that passes no action (lore-list)
+ *  is tilted by the shared change. */
+export const IconOnlyClusterStaysCentred: Story = {
+  render: () => row(),
+  play: async () => {
+    const remove = screen.getByRole('button', { name: 'Remove row' })
+    const name = screen.getByText('char')
+    const rowEl = remove.closest('.rounded-md') as HTMLElement
+    expect(Math.abs(mid(remove) - mid(name))).toBeLessThanOrEqual(1)
+    expect(Math.abs(mid(remove) - mid(rowEl))).toBeLessThanOrEqual(1)
   },
 }

--- a/components/compounds/expandable-row.stories.tsx
+++ b/components/compounds/expandable-row.stories.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { Pressable, View } from 'react-native'
 import { expect, screen, userEvent, waitFor } from 'storybook/test'
 
+import { Button } from '@/components/ui/button'
 import { Text } from '@/components/ui/text'
 
 import { ExpandableRow, useRowExpansion } from './expandable-row'
@@ -157,5 +158,53 @@ export const RemovingARowPrunesItsExpansionSoARecycledIdStartsCollapsed: Story =
     // from the leaked "dup-id" entry left behind by Row A.
     expect(await screen.findByText('Row C')).toBeInTheDocument()
     expect(screen.queryByText('Editor body for Row C')).not.toBeInTheDocument()
+  },
+}
+
+function midY(el: Element): number {
+  const r = el.getBoundingClientRect()
+  return (r.top + r.bottom) / 2
+}
+
+/**
+ * A control-height `compactAction` (a Button, ~36px) sits beside 22px
+ * icon-actions. Top-aligning them parked their centres 7px apart and let the
+ * taller control drag the row off its own centre; the cluster centres on a
+ * control-height line box instead. Asserting this needs NativeWind classNames
+ * to actually resolve under vitest, which they do as of the storybook project's
+ * cssInterop registration.
+ */
+export const CompactActionSharesTheIconActionCentreline: Story = {
+  render: () => (
+    <ExpandableRow
+      expanded={false}
+      invalid={false}
+      onToggle={() => {}}
+      onRemove={() => {}}
+      removeLabel="Remove row"
+      expandLabel="Expand row"
+      collapseLabel="Collapse row"
+      compact={<Text className="font-medium">char</Text>}
+      editor={<Text variant="muted">Editor body</Text>}
+      compactAction={
+        <Button variant="secondary" size="sm">
+          <Text>Set as lead</Text>
+        </Button>
+      }
+    />
+  ),
+  play: async () => {
+    const action = screen.getByRole('button', { name: 'Set as lead' })
+    const remove = screen.getByRole('button', { name: 'Remove row' })
+    const name = screen.getByText('char')
+
+    // The two controls differ in height by design; only their centres must agree.
+    expect(action.getBoundingClientRect().height).toBeGreaterThan(
+      remove.getBoundingClientRect().height,
+    )
+    expect(Math.abs(midY(action) - midY(remove))).toBeLessThanOrEqual(1)
+    // ...and the cluster tracks the summary's first line rather than floating
+    // below it, which is what made the whole row read as badly centred.
+    expect(Math.abs(midY(name) - midY(remove))).toBeLessThanOrEqual(3)
   },
 }

--- a/components/compounds/expandable-row.stories.tsx
+++ b/components/compounds/expandable-row.stories.tsx
@@ -170,14 +170,6 @@ function mid(el: Element): number {
   return (r.top + r.bottom) / 2
 }
 
-/**
- * A control-height `compactAction` (a Button, ~36px) sits beside 22px
- * icon-actions. Top-aligning them parked their centres 7px apart and let the
- * taller control drag the row off its own centre; the cluster centres on a
- * control-height line box instead. Asserting this needs NativeWind classNames
- * to actually resolve under vitest, which they do as of the storybook project's
- * cssInterop registration.
- */
 function row(compactAction?: ReactNode) {
   return (
     <ExpandableRow
@@ -200,13 +192,9 @@ function row(compactAction?: ReactNode) {
 }
 
 /**
- * A control-height `compactAction` (a Button) sits beside 22px icon-actions.
- * Top-aligning them parked their centres 7px apart, and the cluster being
- * shorter than the row's content box dropped all its slack below the controls —
- * the Button's top touched the row border with a gap underneath. The cluster
- * now centres on a control-height line box, which `compact`'s first line
- * matches. Asserting any of this needs NativeWind classNames to resolve under
- * vitest, which they do as of the storybook project's cssInterop registration.
+ * Pins the cluster's centreline: a Button-sized `compactAction`, the 22px
+ * icon-actions, `compact`'s first line and the row itself all share it.
+ * Vacuous unless NativeWind classNames resolve under vitest (cssInterop).
  */
 export const CompactActionCentresOnTheRow: Story = {
   render: () =>
@@ -227,16 +215,14 @@ export const CompactActionCentresOnTheRow: Story = {
     expect(a.height).toBeGreaterThan(remove.getBoundingClientRect().height)
     expect(Math.abs(mid(action) - mid(remove))).toBeLessThanOrEqual(1)
     expect(Math.abs(mid(action) - mid(name))).toBeLessThanOrEqual(1)
-    // The cluster is centred in the row, not top-anchored with the slack
-    // dumped underneath it.
+    // Centred in the row, not top-anchored with the slack dumped underneath.
     expect(Math.abs(a.top - r.top - (r.bottom - a.bottom))).toBeLessThanOrEqual(1)
     expect(Math.abs(mid(action) - mid(rowEl))).toBeLessThanOrEqual(1)
   },
 }
 
-/** Without a compactAction the cluster is icon-actions only — it must still
- *  centre on the same line box, or a consumer that passes no action (lore-list)
- *  is tilted by the shared change. */
+/** Icon-only cluster (no `compactAction`) must centre on the same line box —
+ *  otherwise consumers that pass no action, like lore-list, sit tilted. */
 export const IconOnlyClusterStaysCentred: Story = {
   render: () => row(),
   play: async () => {

--- a/components/compounds/expandable-row.tsx
+++ b/components/compounds/expandable-row.tsx
@@ -66,7 +66,14 @@ export type ExpandableRowProps = {
   removeLabel: string
   expandLabel: string
   collapseLabel: string
-  /** Compact summary content (title line, preview, chips, inline errors). */
+  /**
+   * Compact summary content (title line, preview, chips, inline errors).
+   *
+   * Its **first line** must be a control-height line box (`min-h-control-sm`
+   * plus vertical centring). The action cluster centres on one so a
+   * control-height `compactAction` and the 22px icon-actions share a
+   * centreline; a bare text line would leave the summary sitting above them.
+   */
   compact: ReactNode
   /** Inline editor body, rendered only while expanded. */
   editor: ReactNode
@@ -119,31 +126,36 @@ export function ExpandableRow({
             and the taller control dragged the row off its own centre. The
             min-height is what holds the cluster on the summary's FIRST line
             when the compact body wraps to several. */}
-        <View className="min-h-control-sm flex-row items-center gap-1 pr-3">
-          {compactAction}
-          <IconAction
-            icon={Trash2}
-            label={removeLabel}
-            size="sm"
-            variant="destructive"
-            onPress={onRemove}
-          />
-          {/* Redundant pointer affordance for the row-wide Pressable above, which
+        <View className="flex-row py-row-y-lg pr-3">
+          {/* Inner element owns the line box: min-height is a border-box
+              measure, so putting it on the padded element lets the padding
+              absorb it and an icon-only cluster collapses below the box. */}
+          <View className="min-h-control-sm flex-row items-center gap-1">
+            {compactAction}
+            <IconAction
+              icon={Trash2}
+              label={removeLabel}
+              size="sm"
+              variant="destructive"
+              onPress={onRemove}
+            />
+            {/* Redundant pointer affordance for the row-wide Pressable above, which
               stays the single control assistive tech sees — two buttons carrying
               one action would read as a duplicate. RN derives both platforms'
               hiding from `aria-hidden` alone. The flip is a plain RN transform:
               it must reach neither react-native-svg (which can't resolve it) nor
               NativeWind (whose native output for it is unverified here). */}
-          <Pressable
-            aria-hidden
-            focusable={false}
-            onPress={onToggle}
-            className="h-icon-action-sm w-icon-action-sm items-center justify-center"
-          >
-            <View style={expanded ? CARET_FLIPPED : undefined}>
-              <Icon as={ChevronDown} size="sm" className="text-fg-muted" />
-            </View>
-          </Pressable>
+            <Pressable
+              aria-hidden
+              focusable={false}
+              onPress={onToggle}
+              className="h-icon-action-sm w-icon-action-sm items-center justify-center"
+            >
+              <View style={expanded ? CARET_FLIPPED : undefined}>
+                <Icon as={ChevronDown} size="sm" className="text-fg-muted" />
+              </View>
+            </Pressable>
+          </View>
         </View>
       </View>
       {expanded ? <View className="gap-4 px-3 pb-3">{editor}</View> : null}

--- a/components/compounds/expandable-row.tsx
+++ b/components/compounds/expandable-row.tsx
@@ -67,12 +67,10 @@ export type ExpandableRowProps = {
   expandLabel: string
   collapseLabel: string
   /**
-   * Compact summary content (title line, preview, chips, inline errors).
-   *
-   * Its **first line** must be a control-height line box (`min-h-control-sm`
-   * plus vertical centring). The action cluster centres on one so a
-   * control-height `compactAction` and the 22px icon-actions share a
-   * centreline; a bare text line would leave the summary sitting above them.
+   * Compact summary content (title line, preview, chips, inline errors). Its
+   * **first line** must be a control-height line box (`min-h-control-sm` plus
+   * vertical centring): the action cluster centres on one, so a bare text line
+   * leaves the summary sitting above the actions.
    */
   compact: ReactNode
   /** Inline editor body, rendered only while expanded. */
@@ -120,16 +118,12 @@ export function ExpandableRow({
         >
           <View className="min-w-0 flex-1 gap-1">{compact}</View>
         </Pressable>
-        {/* Centred on a control-height line box rather than top-aligned: the
-            compact action is a full-height Button and its neighbours are
-            22px icon-actions, so top-aligning parked their centres 7px apart
-            and the taller control dragged the row off its own centre. The
-            min-height is what holds the cluster on the summary's FIRST line
-            when the compact body wraps to several. */}
+        {/* Centred on a control-height line box: a Button-sized compact action
+            beside 22px icon-actions parks their centres 7px apart if top-aligned,
+            and the min-height holds the cluster on the summary's FIRST line. */}
         <View className="flex-row py-row-y-lg pr-3">
-          {/* Inner element owns the line box: min-height is a border-box
-              measure, so putting it on the padded element lets the padding
-              absorb it and an icon-only cluster collapses below the box. */}
+          {/* Inner element owns the line box: min-height is border-box, so on the
+              padded element the padding absorbs it and icon-only clusters collapse. */}
           <View className="min-h-control-sm flex-row items-center gap-1">
             {compactAction}
             <IconAction
@@ -139,12 +133,9 @@ export function ExpandableRow({
               variant="destructive"
               onPress={onRemove}
             />
-            {/* Redundant pointer affordance for the row-wide Pressable above, which
-              stays the single control assistive tech sees — two buttons carrying
-              one action would read as a duplicate. RN derives both platforms'
-              hiding from `aria-hidden` alone. The flip is a plain RN transform:
-              it must reach neither react-native-svg (which can't resolve it) nor
-              NativeWind (whose native output for it is unverified here). */}
+            {/* Pointer-only duplicate of the row-wide Pressable; `aria-hidden` leaves
+              one control for assistive tech. The flip must stay a plain RN transform —
+              react-native-svg can't resolve it, NativeWind's native output is unverified. */}
             <Pressable
               aria-hidden
               focusable={false}

--- a/components/compounds/expandable-row.tsx
+++ b/components/compounds/expandable-row.tsx
@@ -113,7 +113,13 @@ export function ExpandableRow({
         >
           <View className="min-w-0 flex-1 gap-1">{compact}</View>
         </Pressable>
-        <View className="flex-row items-start gap-1 pr-3 pt-row-y-lg">
+        {/* Centred on a control-height line box rather than top-aligned: the
+            compact action is a full-height Button and its neighbours are
+            22px icon-actions, so top-aligning parked their centres 7px apart
+            and the taller control dragged the row off its own centre. The
+            min-height is what holds the cluster on the summary's FIRST line
+            when the compact body wraps to several. */}
+        <View className="min-h-control-sm flex-row items-center gap-1 pr-3">
           {compactAction}
           <IconAction
             icon={Trash2}

--- a/components/foundations/nativewind-interop.stories.tsx
+++ b/components/foundations/nativewind-interop.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite'
+import { View } from 'react-native'
+import { expect } from 'storybook/test'
+
+// Guards the harness, not a component: react-native-css-interop's wrap-jsx
+// skips its own component registration when NODE_ENV is 'test', so without a
+// setup-file import every className in a story is inert and every style
+// assertion passes vacuously. This story fails loudly if that regresses.
+const meta = {
+  title: 'Foundations/NativeWind interop',
+  component: View,
+} satisfies Meta<typeof View>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const ClassNamesReachStyles: Story = {
+  render: () => (
+    // @ts-expect-error — dataSet is RN-Web only; not in RN's View type.
+    <View className="hidden rounded-md" dataSet={{ probe: 'interop' }} />
+  ),
+  play: async ({ canvasElement }) => {
+    const probe = canvasElement.querySelector('[data-probe="interop"]')
+    await expect(probe).not.toBeNull()
+    if (!probe) return
+    await expect(probe).toHaveClass('hidden')
+    await expect(probe).toHaveClass('rounded-md')
+    const computed = getComputedStyle(probe)
+    await expect(computed.display).toBe('none')
+    await expect(computed.borderRadius).not.toBe('0px')
+  },
+}

--- a/components/foundations/nativewind-interop.stories.tsx
+++ b/components/foundations/nativewind-interop.stories.tsx
@@ -2,10 +2,9 @@ import type { Meta, StoryObj } from '@storybook/react-native-web-vite'
 import { View } from 'react-native'
 import { expect } from 'storybook/test'
 
-// Guards the harness, not a component: react-native-css-interop's wrap-jsx
-// skips its own component registration when NODE_ENV is 'test', so without a
-// setup-file import every className in a story is inert and every style
-// assertion passes vacuously. This story fails loudly if that regresses.
+// Guards the harness, not a component: react-native-css-interop's wrap-jsx skips
+// component registration when NODE_ENV is 'test', so without the setup-file import
+// every className is inert and every style assertion passes vacuously.
 const meta = {
   title: 'Foundations/NativeWind interop',
   component: View,

--- a/components/story/crash-recovery-modal.stories.tsx
+++ b/components/story/crash-recovery-modal.stories.tsx
@@ -36,6 +36,21 @@ const multiReport: RecoveryReport = {
   failures: [],
 }
 
+// Nothing reversed: the orphan's writes survive and the branch is held back from the
+// cadence, so the modal must not title itself "Story recovered".
+const degradedReport: RecoveryReport = {
+  reversed: [],
+  failures: [
+    {
+      runId: 'run-classifier',
+      kind: 'periodic-classifier',
+      actionId: 'action-classifier',
+      storyId: 's1',
+      error: new Error('could not reverse'),
+    },
+  ],
+}
+
 const meta: Meta<typeof CrashRecoveryModal> = {
   title: 'Compounds/Story/CrashRecoveryModal',
   component: CrashRecoveryModal,
@@ -77,6 +92,19 @@ export const MultipleRuns: Story = {
   play: async () => {
     const description = screen.getByText(/chapter-close pass was reverted/)
     expect(description.textContent).toContain('last AI response was reverted')
+  },
+}
+
+export const MemoryPaused: Story = {
+  args: {
+    report: degradedReport,
+    storyNames: { s1: 'Mornstone' },
+  },
+  play: async () => {
+    expect(screen.getByText('Recovery incomplete')).toBeInTheDocument()
+    const description = screen.getByText(/Memory updates for this story are paused/)
+    expect(description.textContent).toContain('Mornstone')
+    expect(description.textContent).toContain('restarting the app retries automatically')
   },
 }
 

--- a/components/story/crash-recovery-modal.tsx
+++ b/components/story/crash-recovery-modal.tsx
@@ -14,7 +14,7 @@ import { Button } from '@/components/ui/button'
 import { Text } from '@/components/ui/text'
 import { t } from '@/lib/i18n'
 import type { RecoveryReport } from '@/lib/pipeline'
-import { formatRecoveryReport, type RecoveryStoryNames } from '@/lib/recovery'
+import { formatRecoveryReport, formatRecoveryTitle, type RecoveryStoryNames } from '@/lib/recovery'
 
 type CrashRecoveryModalProps = {
   open: boolean
@@ -44,7 +44,7 @@ export function CrashRecoveryModal({
         }
       >
         <AlertDialogHeader>
-          <AlertDialogTitle>{t('crashRecovery.title')}</AlertDialogTitle>
+          <AlertDialogTitle>{formatRecoveryTitle(report)}</AlertDialogTitle>
           <AlertDialogDescription>
             {formatRecoveryReport(report, storyNames)}
           </AlertDialogDescription>

--- a/components/ui/reason-tooltip.tsx
+++ b/components/ui/reason-tooltip.tsx
@@ -17,11 +17,9 @@ type ReasonTooltipProps = {
  * on the reason's presence changes the root element type, and React remounts
  * the control, dropping focus at the moment the state flips.
  *
- * The wrapper only takes a layout box while it carries a reason. `contents`
- * generates no box, so with a disabled control underneath — already
- * `pointer-events: none` — there is nothing left for the pointer to land on and
- * the browser never surfaces the tooltip. Varying the class keeps the same
- * element, so the remount hazard above still does not apply.
+ * `contents` generates no layout box, so over a `pointer-events: none` control
+ * nothing catches the pointer — hence `inline-flex` while a reason exists. The
+ * class-only change keeps the element, so the remount hazard above does not apply.
  */
 function ReasonTooltip({ reason, children }: ReasonTooltipProps) {
   if (Platform.OS !== 'web') return children

--- a/components/ui/reason-tooltip.tsx
+++ b/components/ui/reason-tooltip.tsx
@@ -16,11 +16,17 @@ type ReasonTooltipProps = {
  * Render this unconditionally and vary only `reason`: gating the wrapper itself
  * on the reason's presence changes the root element type, and React remounts
  * the control, dropping focus at the moment the state flips.
+ *
+ * The wrapper only takes a layout box while it carries a reason. `contents`
+ * generates no box, so with a disabled control underneath — already
+ * `pointer-events: none` — there is nothing left for the pointer to land on and
+ * the browser never surfaces the tooltip. Varying the class keeps the same
+ * element, so the remount hazard above still does not apply.
  */
 function ReasonTooltip({ reason, children }: ReasonTooltipProps) {
   if (Platform.OS !== 'web') return children
   return (
-    <div title={reason} className="contents">
+    <div title={reason} className={reason ? 'inline-flex' : 'contents'}>
       {children}
     </div>
   )

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -10,6 +10,7 @@ import {
   type ComponentProps,
 } from 'react'
 import {
+  BackHandler,
   Platform,
   StyleSheet,
   TextInput,
@@ -144,6 +145,22 @@ function BottomSheetContent({
       isMountedRef.current = false
     }
   }, [])
+
+  // @rn-primitives/dialog registers this on Content, but a bottom-anchored sheet
+  // renders a bare BottomSheetModal and gorhom registers no BackHandler anywhere —
+  // so the press would fall through to whatever the screen registered (in the
+  // wizard, a router.back() that pops the route out from under the open sheet).
+  // Routing it through onOpenChange lets a consumer's dismiss guard intercept it
+  // like every other dismiss path. Gated on `open` because the modal stays mounted
+  // while closed, and on Android because react-native-web's stub console.errors.
+  useEffect(() => {
+    if (!open || Platform.OS !== 'android') return
+    const sub = BackHandler.addEventListener('hardwareBackPress', () => {
+      onOpenChange(false)
+      return true
+    })
+    return () => sub.remove()
+  }, [open, onOpenChange])
 
   useEffect(() => {
     let cancelled = false

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -146,13 +146,9 @@ function BottomSheetContent({
     }
   }, [])
 
-  // @rn-primitives/dialog registers this on Content, but a bottom-anchored sheet
-  // renders a bare BottomSheetModal and gorhom registers no BackHandler anywhere —
-  // so the press would fall through to whatever the screen registered (in the
-  // wizard, a router.back() that pops the route out from under the open sheet).
-  // Routing it through onOpenChange lets a consumer's dismiss guard intercept it
-  // like every other dismiss path. Gated on `open` because the modal stays mounted
-  // while closed, and on Android because react-native-web's stub console.errors.
+  // Bottom-anchored sheets render a bare BottomSheetModal, and neither dialog (Content-only)
+  // nor gorhom registers a back handler — back would hit the screen's router.back() and pop
+  // the route out from under the sheet. Android-only: react-native-web's stub console.errors.
   useEffect(() => {
     if (!open || Platform.OS !== 'android') return
     const sub = BackHandler.addEventListener('hardwareBackPress', () => {

--- a/components/wizard/ai-assist.tsx
+++ b/components/wizard/ai-assist.tsx
@@ -494,17 +494,21 @@ export function AiAssist<T, P = unknown>(props: AiAssistProps<T, P>) {
                           />
                         </View>
                         <View className="min-w-0 flex-1 gap-0.5">
-                          <Text size="sm" className="font-medium">
-                            {row.name}
-                          </Text>
+                          {/* On the name line: it accounts for the disabled
+                              checkbox, so it has to be read before the row is. */}
+                          <View className="flex-row flex-wrap items-baseline gap-x-1.5">
+                            <Text size="sm" className="font-medium">
+                              {row.name}
+                            </Text>
+                            {row.exists ? (
+                              <Text size="xs" className="text-warning">
+                                {t('wizard:aiAssist.list.alreadyExists')}
+                              </Text>
+                            ) : null}
+                          </View>
                           <Text size="xs" variant="muted" numberOfLines={2}>
                             {row.detail}
                           </Text>
-                          {row.exists ? (
-                            <Text size="xs" variant="muted">
-                              {t('wizard:aiAssist.list.alreadyExists')}
-                            </Text>
-                          ) : null}
                         </View>
                       </Pressable>
                     )

--- a/components/wizard/ai-assist.tsx
+++ b/components/wizard/ai-assist.tsx
@@ -217,9 +217,8 @@ export function AiAssist<T, P = unknown>(props: AiAssistProps<T, P>) {
     }
   }
 
-  // Every dismiss that can still lose work: Escape, tap-outside, swipe-down and Android
-  // hardware back arrive through handleOpenChange, the failure card's Cancel calls this directly. A dirty overlay re-opens
-  // via the sibling confirm dialog; Keep clears nothing, Discard is the only reset.
+  // The single funnel for dismisses that can lose work. Dirty closes anyway and hands off to
+  // the sibling confirm dialog: Keep re-opens and clears nothing, Discard is the only reset.
   function requestClose() {
     setOpen(false)
     if (hasUnsavedCandidate()) {

--- a/components/wizard/ai-assist.tsx
+++ b/components/wizard/ai-assist.tsx
@@ -217,8 +217,8 @@ export function AiAssist<T, P = unknown>(props: AiAssistProps<T, P>) {
     }
   }
 
-  // Every dismiss that can still lose work: Escape, tap-outside and swipe-down arrive through
-  // handleOpenChange, the failure card's Cancel calls this directly. A dirty overlay re-opens
+  // Every dismiss that can still lose work: Escape, tap-outside, swipe-down and Android
+  // hardware back arrive through handleOpenChange, the failure card's Cancel calls this directly. A dirty overlay re-opens
   // via the sibling confirm dialog; Keep clears nothing, Discard is the only reset.
   function requestClose() {
     setOpen(false)
@@ -229,8 +229,6 @@ export function AiAssist<T, P = unknown>(props: AiAssistProps<T, P>) {
     resetOnClose()
   }
 
-  // Phone-sheet hardware back never reaches here — gorhom registers no BackHandler, so the
-  // press falls through to the wizard's own router.back().
   function handleOpenChange(next: boolean) {
     if (next) {
       setOpen(true)

--- a/components/wizard/cast-editors.stories.tsx
+++ b/components/wizard/cast-editors.stories.tsx
@@ -121,7 +121,7 @@ const meta: Meta = {
   parameters: { layout: 'padded' },
   decorators: [
     (Story) => (
-      <View className="w-[640px] gap-4 rounded-md bg-bg-base p-6">
+      <View className="w-[720px] gap-4 rounded-md bg-bg-base p-6">
         <Story />
       </View>
     ),

--- a/components/wizard/cast-editors.tsx
+++ b/components/wizard/cast-editors.tsx
@@ -253,7 +253,12 @@ export function CharacterEditor({
               nullLabel={t('wizard:cast.editor.unaffiliated')}
               candidates={factionCandidates}
               value={row.factionId}
-              onChange={(factionId) => wizardStore.patchCast(row, { factionId })}
+              // The remembered ask is cleared on any explicit assignment,
+              // including back to null: leaving it would let the warning
+              // resurrect on a field the user has already decided about.
+              onChange={(factionId) =>
+                wizardStore.patchCast(row, { factionId, unresolvedFactionName: '' })
+              }
             />
           </AccordionContent>
         </AccordionItem>
@@ -284,7 +289,9 @@ export function LocationEditor({ row, invalid, cast }: CommonEditorProps<WizardL
               nullLabel={t('wizard:cast.editor.noParent')}
               candidates={locationCandidates}
               value={row.parentLocationId}
-              onChange={(parentLocationId) => wizardStore.patchCast(row, { parentLocationId })}
+              onChange={(parentLocationId) =>
+                wizardStore.patchCast(row, { parentLocationId, unresolvedParentLocationName: '' })
+              }
             />
             <FormRow label={t('wizard:cast.editor.condition')}>
               <Input

--- a/components/wizard/cast-editors.tsx
+++ b/components/wizard/cast-editors.tsx
@@ -253,9 +253,8 @@ export function CharacterEditor({
               nullLabel={t('wizard:cast.editor.unaffiliated')}
               candidates={factionCandidates}
               value={row.factionId}
-              // The remembered ask is cleared on any explicit assignment,
-              // including back to null: leaving it would let the warning
-              // resurrect on a field the user has already decided about.
+              // Cleared on any explicit assignment, including back to null — a kept ask
+              // would resurrect the warning on a field the user has already decided.
               onChange={(factionId) =>
                 wizardStore.patchCast(row, { factionId, unresolvedFactionName: '' })
               }

--- a/components/wizard/cast-import.test.ts
+++ b/components/wizard/cast-import.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
 
-import { emptyCastDraft, entityStateSchemaForKind } from '@/lib/db'
+import { emptyCastDraft, entityStateSchemaForKind, type WizardCharacterDraft } from '@/lib/db'
 
-import { ARRAY_MAX, FIELD_MAX, resolveCastImports, VOICE_MAX } from './cast-import'
+import { ARRAY_MAX, FIELD_MAX, pendingCastRef, resolveCastImports, VOICE_MAX } from './cast-import'
 
 let n = 0
 /** Test seam — production mints real prefixed ids. */
@@ -470,5 +470,60 @@ describe('clamp constants track the entity-state-schema degradation bounds', () 
     const schema = entityStateSchemaForKind('faction')
     expect(boundAt(schema, ['agenda'])).toBe(ARRAY_MAX)
     expect(boundAt(schema, ['standing'])).toBe(FIELD_MAX)
+  })
+})
+
+describe('pendingCastRef', () => {
+  const character = (over: Partial<WizardCharacterDraft> = {}): WizardCharacterDraft => ({
+    ...emptyCastDraft('character', 'char_1'),
+    ...over,
+  })
+  const faction = (name: string, id = 'fact_1', status: 'active' | 'staged' = 'active') => ({
+    ...emptyCastDraft('faction', id),
+    name,
+    status,
+  })
+
+  it('reports nothing once the field is assigned, even with a remembered ask', () => {
+    const row = character({ factionId: 'fact_1', unresolvedFactionName: 'Ashfall Pact' })
+    expect(pendingCastRef(row, [row, faction('Ashfall Pact')])).toBeNull()
+  })
+
+  it('reports the ask as missing while no active row carries the name', () => {
+    const row = character({ unresolvedFactionName: 'Ashfall Pact' })
+    expect(pendingCastRef(row, [row])).toEqual({
+      field: 'faction',
+      wantedName: 'Ashfall Pact',
+      resolvableId: null,
+    })
+  })
+
+  // The whole point of re-checking at render: importing the faction afterwards
+  // has to change the message without a re-import.
+  it('reports the ask as resolvable once a matching active row exists', () => {
+    const row = character({ unresolvedFactionName: 'ashfall pact' })
+    expect(pendingCastRef(row, [row, faction('Ashfall Pact')])?.resolvableId).toBe('fact_1')
+  })
+
+  it('does not resolve against a staged row, matching what commit would accept', () => {
+    const row = character({ unresolvedFactionName: 'Ashfall Pact' })
+    expect(
+      pendingCastRef(row, [row, faction('Ashfall Pact', 'fact_1', 'staged')])?.resolvableId,
+    ).toBe(null)
+  })
+
+  it('does not resolve a faction ask against a same-named location', () => {
+    const row = character({ unresolvedFactionName: 'Mornstone' })
+    const loc = { ...emptyCastDraft('location', 'loc_1'), name: 'Mornstone' }
+    expect(pendingCastRef(row, [row, loc])?.resolvableId).toBe(null)
+  })
+
+  it('reports a location parent ask on its own field', () => {
+    const row = { ...emptyCastDraft('location', 'loc_1'), unresolvedParentLocationName: 'The Vale' }
+    expect(pendingCastRef(row, [row])).toEqual({
+      field: 'parentLocation',
+      wantedName: 'The Vale',
+      resolvableId: null,
+    })
   })
 })

--- a/components/wizard/cast-import.test.ts
+++ b/components/wizard/cast-import.test.ts
@@ -517,6 +517,17 @@ describe('pendingCastRef', () => {
     expect(pendingCastRef(row, [row, loc])?.resolvableId).toBe(null)
   })
 
+  // The editor's picker never offers the row itself and commit drops a
+  // self-pointer, so "attach it" would point at a control that cannot.
+  it('does not resolve a location parent ask against the row itself', () => {
+    const row = {
+      ...emptyCastDraft('location', 'loc_1'),
+      name: 'The Vale',
+      unresolvedParentLocationName: 'The Vale',
+    }
+    expect(pendingCastRef(row, [row])?.resolvableId).toBe(null)
+  })
+
   it('reports a location parent ask on its own field', () => {
     const row = { ...emptyCastDraft('location', 'loc_1'), unresolvedParentLocationName: 'The Vale' }
     expect(pendingCastRef(row, [row])).toEqual({

--- a/components/wizard/cast-import.test.ts
+++ b/components/wizard/cast-import.test.ts
@@ -489,7 +489,7 @@ describe('pendingCastRef', () => {
     expect(pendingCastRef(row, [row, faction('Ashfall Pact')])).toBeNull()
   })
 
-  it('reports the ask as missing while no active row carries the name', () => {
+  it('reports the ask as missing while no row carries the name', () => {
     const row = character({ unresolvedFactionName: 'Ashfall Pact' })
     expect(pendingCastRef(row, [row])).toEqual({
       field: 'faction',
@@ -499,16 +499,18 @@ describe('pendingCastRef', () => {
   })
 
   // Re-checked at render so a later import flips the message without a re-import.
-  it('reports the ask as resolvable once a matching active row exists', () => {
+  it('reports the ask as resolvable once a matching row exists', () => {
     const row = character({ unresolvedFactionName: 'ashfall pact' })
     expect(pendingCastRef(row, [row, faction('Ashfall Pact')])?.resolvableId).toBe('fact_1')
   })
 
-  it('does not resolve against a staged row, matching what commit would accept', () => {
+  // The picker offers a staged faction and commit keeps the pointer; whether an
+  // active character belongs to a not-yet-introduced one is the user's call.
+  it('resolves against a staged row, which the picker offers and commit keeps', () => {
     const row = character({ unresolvedFactionName: 'Ashfall Pact' })
     expect(
       pendingCastRef(row, [row, faction('Ashfall Pact', 'fact_1', 'staged')])?.resolvableId,
-    ).toBe(null)
+    ).toBe('fact_1')
   })
 
   it('does not resolve a faction ask against a same-named location', () => {

--- a/components/wizard/cast-import.test.ts
+++ b/components/wizard/cast-import.test.ts
@@ -498,8 +498,7 @@ describe('pendingCastRef', () => {
     })
   })
 
-  // The whole point of re-checking at render: importing the faction afterwards
-  // has to change the message without a re-import.
+  // Re-checked at render so a later import flips the message without a re-import.
   it('reports the ask as resolvable once a matching active row exists', () => {
     const row = character({ unresolvedFactionName: 'ashfall pact' })
     expect(pendingCastRef(row, [row, faction('Ashfall Pact')])?.resolvableId).toBe('fact_1')

--- a/components/wizard/cast-import.ts
+++ b/components/wizard/cast-import.ts
@@ -42,9 +42,17 @@ export function pendingCastRef(
   row: WizardCastDraft,
   cast: readonly WizardCastDraft[],
 ): { field: 'faction' | 'parentLocation'; wantedName: string; resolvableId: string | null } | null {
+  // Self-exclusion mirrors the import path's and finish.ts's: a location named
+  // like its own pending parent must stay "missing", since the editor's picker
+  // never offers the row itself and commit would drop the pointer anyway.
   const match = (kind: WizardCastDraft['kind'], wanted: string): string | null =>
-    cast.find((r) => r.kind === kind && r.status === 'active' && norm(r.name) === norm(wanted))
-      ?.id ?? null
+    cast.find(
+      (r) =>
+        r.id !== row.id &&
+        r.kind === kind &&
+        r.status === 'active' &&
+        norm(r.name) === norm(wanted),
+    )?.id ?? null
 
   if (row.kind === 'character' && row.factionId == null) {
     const wanted = row.unresolvedFactionName.trim()

--- a/components/wizard/cast-import.ts
+++ b/components/wizard/cast-import.ts
@@ -34,11 +34,9 @@ export type UnresolvedCastRef = {
 }
 
 /**
- * The reference a row still wants but has not got, re-checked against the live
- * cast rather than the selection it was imported with. `resolvableId` is set
- * once a matching active row exists, which distinguishes "you never imported
- * it" from "it is here, just not attached" — the user can act on those two
- * differently, and the first can become the second while the wizard is open.
+ * The reference a row still wants, re-checked against the live cast rather than the
+ * import-time selection. `resolvableId` is set once a matching active row exists —
+ * "here, just not attached" vs "never imported", and that can flip mid-session.
  */
 export function pendingCastRef(
   row: WizardCastDraft,
@@ -110,9 +108,8 @@ export function resolveCastImports(
   // guards this at commit time; resolving it here means the store never
   // carries the dangling self-pointer in the first place).
   const unresolved: UnresolvedCastRef[] = []
-  // Names that resolved to nothing, keyed by the importing row's id, so the
-  // row can carry the ask forward and the list can re-check it against a cast
-  // the user is still editing.
+  // Names that resolved to nothing, keyed by importing row id, so the row carries
+  // the ask forward for the list to re-check against a cast still being edited.
   const wantedByRow = new Map<string, string>()
   const ref = (
     kind: 'faction' | 'location',

--- a/components/wizard/cast-import.ts
+++ b/components/wizard/cast-import.ts
@@ -33,6 +33,38 @@ export type UnresolvedCastRef = {
   wantedName: string
 }
 
+/**
+ * The reference a row still wants but has not got, re-checked against the live
+ * cast rather than the selection it was imported with. `resolvableId` is set
+ * once a matching active row exists, which distinguishes "you never imported
+ * it" from "it is here, just not attached" — the user can act on those two
+ * differently, and the first can become the second while the wizard is open.
+ */
+export function pendingCastRef(
+  row: WizardCastDraft,
+  cast: readonly WizardCastDraft[],
+): { field: 'faction' | 'parentLocation'; wantedName: string; resolvableId: string | null } | null {
+  const match = (kind: WizardCastDraft['kind'], wanted: string): string | null =>
+    cast.find((r) => r.kind === kind && r.status === 'active' && norm(r.name) === norm(wanted))
+      ?.id ?? null
+
+  if (row.kind === 'character' && row.factionId == null) {
+    const wanted = row.unresolvedFactionName.trim()
+    if (wanted.length > 0)
+      return { field: 'faction', wantedName: wanted, resolvableId: match('faction', wanted) }
+  }
+  if (row.kind === 'location' && row.parentLocationId == null) {
+    const wanted = row.unresolvedParentLocationName.trim()
+    if (wanted.length > 0)
+      return {
+        field: 'parentLocation',
+        wantedName: wanted,
+        resolvableId: match('location', wanted),
+      }
+  }
+  return null
+}
+
 export type CastImportResult = {
   rows: WizardCastDraft[]
   /**
@@ -78,6 +110,10 @@ export function resolveCastImports(
   // guards this at commit time; resolving it here means the store never
   // carries the dangling self-pointer in the first place).
   const unresolved: UnresolvedCastRef[] = []
+  // Names that resolved to nothing, keyed by the importing row's id, so the
+  // row can carry the ask forward and the list can re-check it against a cast
+  // the user is still editing.
+  const wantedByRow = new Map<string, string>()
   const ref = (
     kind: 'faction' | 'location',
     name: string | undefined,
@@ -91,12 +127,14 @@ export function resolveCastImports(
     const resolved = found === selfId ? null : found
     // A self-reference counts: the row still imports without the pointer it
     // asked for, which is the thing worth telling the user about.
-    if (resolved === null)
+    if (resolved === null) {
       unresolved.push({
         rowName,
         field: kind === 'faction' ? 'faction' : 'parentLocation',
         wantedName: name ?? '',
       })
+      if (name != null) wantedByRow.set(selfId, name.trim())
+    }
     return resolved
   }
 
@@ -121,6 +159,7 @@ export function resolveCastImports(
             distinguishing: clampStr(s.visual?.distinguishing ?? '', FIELD_MAX),
           },
           factionId: ref('faction', s.faction_name, id, s.name),
+          unresolvedFactionName: wantedByRow.get(id) ?? '',
         })
       case 'location':
         return wizardCastDraftSchema.parse({
@@ -130,6 +169,7 @@ export function resolveCastImports(
           description: s.description,
           status: s.status,
           parentLocationId: ref('location', s.parent_location_name, id, s.name),
+          unresolvedParentLocationName: wantedByRow.get(id) ?? '',
           condition: clampStr(s.condition ?? '', FIELD_MAX),
         })
       case 'item':

--- a/components/wizard/cast-import.ts
+++ b/components/wizard/cast-import.ts
@@ -35,24 +35,20 @@ export type UnresolvedCastRef = {
 
 /**
  * The reference a row still wants, re-checked against the live cast rather than the
- * import-time selection. `resolvableId` is set once a matching active row exists —
+ * import-time selection. `resolvableId` is set once a matching row exists —
  * "here, just not attached" vs "never imported", and that can flip mid-session.
  */
 export function pendingCastRef(
   row: WizardCastDraft,
   cast: readonly WizardCastDraft[],
 ): { field: 'faction' | 'parentLocation'; wantedName: string; resolvableId: string | null } | null {
-  // Self-exclusion mirrors the import path's and finish.ts's: a location named
-  // like its own pending parent must stay "missing", since the editor's picker
-  // never offers the row itself and commit would drop the pointer anyway.
+  // Kind and self-exclusion only, matching resolveCastImports and the editor's
+  // pickers. Status is deliberately not a filter: the pickers offer a staged
+  // target and finish.ts's castRef commits the pointer, so calling it missing
+  // would be false. Self is the one exclusion all three agree on.
   const match = (kind: WizardCastDraft['kind'], wanted: string): string | null =>
-    cast.find(
-      (r) =>
-        r.id !== row.id &&
-        r.kind === kind &&
-        r.status === 'active' &&
-        norm(r.name) === norm(wanted),
-    )?.id ?? null
+    cast.find((r) => r.id !== row.id && r.kind === kind && norm(r.name) === norm(wanted))?.id ??
+    null
 
   if (row.kind === 'character' && row.factionId == null) {
     const wanted = row.unresolvedFactionName.trim()

--- a/components/wizard/cast-list.tsx
+++ b/components/wizard/cast-list.tsx
@@ -109,7 +109,7 @@ function CompactRow({ row, isLead, invalid, expanded }: CompactRowProps) {
   const staged = row.status === 'staged'
   return (
     <>
-      <View className="flex-row flex-wrap items-center gap-2">
+      <View className="min-h-control-sm flex-row flex-wrap content-center items-center gap-2">
         <Icon
           as={KIND_ICON[row.kind]}
           aria-hidden

--- a/components/wizard/cast-list.tsx
+++ b/components/wizard/cast-list.tsx
@@ -157,9 +157,8 @@ function CompactRow({ row, isLead, invalid, expanded, cast }: CompactRowProps) {
               {t('wizard:cast.editor.errors.name')}
             </Text>
           ) : null}
-          {/* A warning, not an error: the row commits fine, it just lost the
-              affiliation the model asked for — which the editors otherwise
-              render as "No factions yet", reading as "you have none". */}
+          {/* A warning, not an error: the row commits, it just lost the affiliation
+              the model asked for — which the editors render as "No factions yet". */}
           {pending ? (
             <View className="flex-row items-center gap-1">
               <Icon as={AlertTriangle} aria-hidden size="sm" className="shrink-0 text-warning" />

--- a/components/wizard/cast-list.tsx
+++ b/components/wizard/cast-list.tsx
@@ -1,4 +1,13 @@
-import { Flag, MapPin, Package, Plus, Star, User, type LucideIcon } from 'lucide-react-native'
+import {
+  AlertTriangle,
+  Flag,
+  MapPin,
+  Package,
+  Plus,
+  Star,
+  User,
+  type LucideIcon,
+} from 'lucide-react-native'
 import { useMemo, useRef, type ComponentRef } from 'react'
 import { Platform, Pressable, View } from 'react-native'
 
@@ -24,7 +33,7 @@ import {
   LocationEditor,
   SetAsLeadButton,
 } from './cast-editors'
-import { resolveCastImports } from './cast-import'
+import { pendingCastRef, resolveCastImports } from './cast-import'
 import { activeLead, invalidCastRowIds } from './step-cast-logic'
 import {
   resolveWizardAssistModelId,
@@ -103,9 +112,13 @@ type CompactRowProps = {
   isLead: boolean
   invalid: boolean
   expanded: boolean
+  cast: readonly WizardCastDraft[]
 }
 
-function CompactRow({ row, isLead, invalid, expanded }: CompactRowProps) {
+function CompactRow({ row, isLead, invalid, expanded, cast }: CompactRowProps) {
+  // Re-checked per render against the live cast, so importing the named row
+  // later downgrades "not in your cast" to "not attached" without a re-import.
+  const pending = pendingCastRef(row, cast)
   const staged = row.status === 'staged'
   return (
     <>
@@ -143,6 +156,26 @@ function CompactRow({ row, isLead, invalid, expanded }: CompactRowProps) {
             <Text size="xs" className="text-danger">
               {t('wizard:cast.editor.errors.name')}
             </Text>
+          ) : null}
+          {/* A warning, not an error: the row commits fine, it just lost the
+              affiliation the model asked for — which the editors otherwise
+              render as "No factions yet", reading as "you have none". */}
+          {pending ? (
+            <View className="flex-row items-center gap-1">
+              <Icon as={AlertTriangle} aria-hidden size="sm" className="shrink-0 text-warning" />
+              <Text size="xs" className="text-warning">
+                {t(
+                  pending.field === 'faction'
+                    ? pending.resolvableId != null
+                      ? 'wizard:cast.unresolvedRef.factionUnattached'
+                      : 'wizard:cast.unresolvedRef.factionMissing'
+                    : pending.resolvableId != null
+                      ? 'wizard:cast.unresolvedRef.parentUnattached'
+                      : 'wizard:cast.unresolvedRef.parentMissing',
+                  { name: pending.wantedName },
+                )}
+              </Text>
+            </View>
           ) : null}
         </>
       ) : null}
@@ -277,6 +310,7 @@ export function CastList({ onSetupAssist, assist }: CastListProps) {
                     isLead={lead?.id === row.id}
                     invalid={invalid}
                     expanded={isExpanded}
+                    cast={cast}
                   />
                 }
                 editor={

--- a/components/wizard/cast-row-layout.stories.tsx
+++ b/components/wizard/cast-row-layout.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite'
-import { cssInterop } from 'nativewind'
 import { View } from 'react-native'
 import { expect, screen, within } from 'storybook/test'
 
@@ -8,17 +7,13 @@ import { wizardStore } from '@/lib/stores'
 
 import { CharacterEditor } from './cast-editors'
 
-// `react-native-css-interop` skips component registration when NODE_ENV is 'test', so every
-// className is inert in vitest; registering View is the documented escape hatch, scoped here.
-cssInterop(View, { className: 'style' })
-
 const ROW: WizardCharacterDraft = {
   ...emptyCastDraft('character', 'char_layout'),
   name: 'Aria Stoneheart',
 }
 
-// Explicit pixel widths, never a className: the container has to be real even
-// if a future harness change makes the registration above a no-op again.
+// Explicit pixel widths, never a className: this story measures layout, so the
+// container must not depend on the harness resolving Tailwind at all.
 function Harness({ width }: { width: number }) {
   return (
     <View

--- a/components/wizard/lore-list.stories.tsx
+++ b/components/wizard/lore-list.stories.tsx
@@ -40,7 +40,7 @@ const meta: Meta<typeof LoreList> = {
   parameters: { layout: 'padded' },
   decorators: [
     (Story) => (
-      <View className="w-[640px] gap-4 rounded-md bg-bg-base p-6">
+      <View className="w-[720px] gap-4 rounded-md bg-bg-base p-6">
         <Story />
       </View>
     ),

--- a/components/wizard/lore-list.tsx
+++ b/components/wizard/lore-list.tsx
@@ -108,9 +108,13 @@ function LoreRow({ row, invalid, expanded, onToggleExpanded }: LoreRowProps) {
       collapseLabel={t('wizard:world.lore.collapse')}
       compact={
         <>
-          <Text className="font-medium" numberOfLines={1}>
-            {row.title.trim() || t('wizard:world.lore.untitled')}
-          </Text>
+          {/* Control-height line box: ExpandableRow centres its action cluster
+              on one, so a bare text line would sit above the icons. */}
+          <View className="min-h-control-sm justify-center">
+            <Text className="font-medium" numberOfLines={1}>
+              {row.title.trim() || t('wizard:world.lore.untitled')}
+            </Text>
+          </View>
           {!expanded ? (
             <>
               {!blank(row.body) ? (

--- a/components/wizard/opening-scene-tags.tsx
+++ b/components/wizard/opening-scene-tags.tsx
@@ -7,8 +7,7 @@ import { Text } from '@/components/ui/text'
 import type { WizardCastDraft } from '@/lib/db'
 import { t } from '@/lib/i18n'
 
-// Select carries string values, so "no location" needs a sentinel rather than
-// an empty string, which is indistinguishable from an unset trigger.
+// Select carries string values; an empty string is indistinguishable from unset.
 const NO_LOCATION = '__none__'
 
 function displayName(row: WizardCastDraft): string {
@@ -25,15 +24,9 @@ export type OpeningSceneTagsProps = {
 
 /**
  * Scene grounding for the opening entry: who is present, where it happens.
- * Both authorship paths edit the same fields — an AI-generated opening seeds
- * them through structured output and the user may correct them here, which is
- * the only remedy that doesn't discard prose edits the way regenerating does.
- *
- * Candidates are active-and-kind-filtered to match the filter Finish commits
- * through, so nothing offered here is silently dropped on the way to
- * `story_entries.metadata`, and a ref that fails that filter (a since-staged
- * row, or a character id sitting in the location slot) reads as unset rather
- * than rendering someone's name in the wrong slot.
+ * Candidates are active-and-kind-filtered to match what Finish commits, so a ref
+ * that fails that filter (since-staged row, character id in the location slot)
+ * reads as unset instead of rendering a name in the wrong slot.
  */
 export function OpeningSceneTags({
   cast,
@@ -52,9 +45,8 @@ export function OpeningSceneTags({
     const next = new Set(selected)
     if (next.has(id)) next.delete(id)
     else next.add(id)
-    // Emitted in candidate order off the filtered list, so a ref that no longer
-    // resolves drops on the next explicit edit. Canon keeps such refs across
-    // cast edits; this is the user authoring, not an auto-clear.
+    // Emitted off the filtered list, so an unresolvable ref drops on the next
+    // explicit edit — user authorship; canon keeps such refs across cast edits.
     onChangeSceneEntities(sceneCandidates.map((r) => r.id).filter((id) => next.has(id)))
   }
 

--- a/components/wizard/opening-scene-tags.tsx
+++ b/components/wizard/opening-scene-tags.tsx
@@ -1,0 +1,105 @@
+import { View } from 'react-native'
+
+import { FormRow } from '@/components/compounds/form-row'
+import { Chip } from '@/components/ui/chip'
+import { Select, type SelectOption } from '@/components/ui/select'
+import { Text } from '@/components/ui/text'
+import type { WizardCastDraft } from '@/lib/db'
+import { t } from '@/lib/i18n'
+
+// Select carries string values, so "no location" needs a sentinel rather than
+// an empty string, which is indistinguishable from an unset trigger.
+const NO_LOCATION = '__none__'
+
+function displayName(row: WizardCastDraft): string {
+  return row.name.trim() || t('wizard:cast.unnamed')
+}
+
+export type OpeningSceneTagsProps = {
+  cast: readonly WizardCastDraft[]
+  sceneEntities: readonly string[]
+  currentLocationId: string | null
+  onChangeSceneEntities: (next: string[]) => void
+  onChangeLocation: (next: string | null) => void
+}
+
+/**
+ * Scene grounding for the opening entry: who is present, where it happens.
+ * Both authorship paths edit the same fields — an AI-generated opening seeds
+ * them through structured output and the user may correct them here, which is
+ * the only remedy that doesn't discard prose edits the way regenerating does.
+ *
+ * Candidates are active-and-kind-filtered to match the filter Finish commits
+ * through, so nothing offered here is silently dropped on the way to
+ * `story_entries.metadata`, and a ref that fails that filter (a since-staged
+ * row, or a character id sitting in the location slot) reads as unset rather
+ * than rendering someone's name in the wrong slot.
+ */
+export function OpeningSceneTags({
+  cast,
+  sceneEntities,
+  currentLocationId,
+  onChangeSceneEntities,
+  onChangeLocation,
+}: OpeningSceneTagsProps) {
+  const sceneCandidates = cast.filter(
+    (r) => r.status === 'active' && (r.kind === 'character' || r.kind === 'item'),
+  )
+  const locationCandidates = cast.filter((r) => r.status === 'active' && r.kind === 'location')
+
+  const selected = new Set(sceneEntities)
+  const toggle = (id: string): void => {
+    const next = new Set(selected)
+    if (next.has(id)) next.delete(id)
+    else next.add(id)
+    // Emitted in candidate order off the filtered list, so a ref that no longer
+    // resolves drops on the next explicit edit. Canon keeps such refs across
+    // cast edits; this is the user authoring, not an auto-clear.
+    onChangeSceneEntities(sceneCandidates.map((r) => r.id).filter((id) => next.has(id)))
+  }
+
+  const locationValue =
+    currentLocationId != null && locationCandidates.some((r) => r.id === currentLocationId)
+      ? currentLocationId
+      : NO_LOCATION
+
+  return (
+    <View className="gap-3">
+      <FormRow label={t('wizard:opening.scene.cast')}>
+        {sceneCandidates.length === 0 ? (
+          <Text variant="muted" size="sm">
+            {t('wizard:opening.scene.noCast')}
+          </Text>
+        ) : (
+          <View className="flex-row flex-wrap gap-2">
+            {sceneCandidates.map((row) => (
+              <Chip key={row.id} selected={selected.has(row.id)} onPress={() => toggle(row.id)}>
+                <Text>{displayName(row)}</Text>
+              </Chip>
+            ))}
+          </View>
+        )}
+      </FormRow>
+
+      <FormRow label={t('wizard:opening.scene.location')}>
+        {locationCandidates.length === 0 ? (
+          <Text variant="muted" size="sm">
+            {t('wizard:opening.scene.noLocations')}
+          </Text>
+        ) : (
+          <Select
+            label={t('wizard:opening.scene.location')}
+            options={
+              [
+                { value: NO_LOCATION, label: t('wizard:opening.scene.noLocationChosen') },
+                ...locationCandidates.map((r) => ({ value: r.id, label: displayName(r) })),
+              ] satisfies SelectOption[]
+            }
+            value={locationValue}
+            onValueChange={(next) => onChangeLocation(next === NO_LOCATION ? null : next)}
+          />
+        )}
+      </FormRow>
+    </View>
+  )
+}

--- a/components/wizard/step-cast.stories.tsx
+++ b/components/wizard/step-cast.stories.tsx
@@ -365,9 +365,8 @@ export const ImportingWithoutTheReferencedFactionToastsTheDrop: Story = {
   },
 }
 
-// The toast above is transient; the row itself has to carry the ask, and the
-// message has to track a cast the user is still editing. Importing the faction
-// afterwards must downgrade "not in your cast" without a re-import.
+// The toast is transient, so the row carries the ask — and tracks a cast still
+// being edited: importing the faction downgrades the message without a re-import.
 export const ADroppedRefWarnsOnTheRowAndTracksTheLiveCast: Story = {
   beforeEach: () => seed(),
   render: () => (

--- a/components/wizard/step-cast.stories.tsx
+++ b/components/wizard/step-cast.stories.tsx
@@ -365,6 +365,39 @@ export const ImportingWithoutTheReferencedFactionToastsTheDrop: Story = {
   },
 }
 
+// The toast above is transient; the row itself has to carry the ask, and the
+// message has to track a cast the user is still editing. Importing the faction
+// afterwards must downgrade "not in your cast" without a re-import.
+export const ADroppedRefWarnsOnTheRowAndTracksTheLiveCast: Story = {
+  beforeEach: () => seed(),
+  render: () => (
+    <StepCast
+      onSetupAssist={fn()}
+      assist={{ resolveModelId: () => MODEL_ID, cast: okListRun(CAST_SUGGESTIONS) }}
+    />
+  ),
+  play: async () => {
+    await userEvent.click(screen.getByRole('button', { name: 'Suggest cast' }))
+    await userEvent.click(await screen.findByRole('button', { name: 'Generate' }))
+    await userEvent.click(await screen.findByRole('checkbox', { name: 'Aria Stoneheart' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Import selected' }))
+
+    // The faction was left out of the selection, so the row shows the ask.
+    expect(
+      await screen.findByText('Suggested faction “ashfall pact” is not in your cast.'),
+    ).toBeInTheDocument()
+
+    // Add the faction by hand; the row's warning re-checks and downgrades.
+    wizardStore.importCast([{ ...emptyCastDraft('faction', 'fact_added'), name: 'Ashfall Pact' }])
+    expect(
+      await screen.findByText('“ashfall pact” is in your cast — attach it in the editor.'),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText('Suggested faction “ashfall pact” is not in your cast.'),
+    ).not.toBeInTheDocument()
+  },
+}
+
 const SAME_NAME_ACROSS_KINDS: CastAssistValue = {
   entities: [
     {

--- a/components/wizard/step-opening.stories.tsx
+++ b/components/wizard/step-opening.stories.tsx
@@ -113,12 +113,12 @@ export const OpeningAssistCommits: Story = {
       expect(opening.sceneEntities).toEqual([LEAD_ID])
       expect(opening.model).toBe(MODEL_ID)
     })
-    // Committed state surfaces the resolved cast name in the metadata line.
-    expect(await screen.findByText('Scene metadata: Aria')).toBeInTheDocument()
+    // Committed state surfaces the resolved cast name on its scene chip.
+    expect(await screen.findByText('Aria')).toBeInTheDocument()
   },
 }
 
-export const SceneMetadataJoinsCastAndLocation: Story = {
+export const SceneTagsReflectCommittedRefs: Story = {
   beforeEach: () => {
     wizardStore.reset()
     appSettingsStore.__reset()
@@ -148,13 +148,17 @@ export const SceneMetadataJoinsCastAndLocation: Story = {
     await userEvent.click(await screen.findByRole('button', { name: 'Generate' }))
     await userEvent.click(screen.getByRole('button', { name: 'Use this' }))
 
-    // wizard.md → Committed prose: cast names and the resolved location join
-    // with the canon separator ("Aria Stoneheart · Mornstone Keep").
-    expect(await screen.findByText('Scene metadata: Aria · Mornstone Keep')).toBeInTheDocument()
+    // Generated refs seed the editable controls rather than a read-only line.
+    await waitFor(() => expect(screen.getByText('Aria')).toBeInTheDocument())
+    expect(screen.getByText('Mornstone Keep')).toBeInTheDocument()
+    // ...and the user can correct them without regenerating the prose.
+    await userEvent.click(screen.getByText('Aria'))
+    await waitFor(() => expect(wizardStore.getWizard().state.opening.sceneEntities).toEqual([]))
+    expect(wizardStore.getWizard().state.opening.content).toContain('Aria drew her blade')
   },
 }
 
-export const SceneMetadataDropsStagedAndKindMismatchedRefs: Story = {
+export const SceneTagsDropStagedAndKindMismatchedRefs: Story = {
   beforeEach: () => {
     wizardStore.reset()
     appSettingsStore.__reset()
@@ -167,6 +171,10 @@ export const SceneMetadataDropsStagedAndKindMismatchedRefs: Story = {
       // unlike reusing the lead's id, whose name would collide via dedupe.
       { ...emptyCastDraft('character', MISKIND_ID), name: 'Bran' },
       { ...emptyCastDraft('faction', FACTION_ID), name: 'The Ashen Court' },
+      // An active location, so the location control actually renders and the
+      // kind guard below is exercised rather than short-circuited by the
+      // no-locations empty state.
+      { ...emptyCastDraft('location', LOCATION_ID), name: 'Mornstone Keep' },
     ])
     wizardStore.setLeadEntityId(LEAD_ID)
   },
@@ -192,20 +200,24 @@ export const SceneMetadataDropsStagedAndKindMismatchedRefs: Story = {
     await userEvent.click(await screen.findByRole('button', { name: 'Generate' }))
     await userEvent.click(screen.getByRole('button', { name: 'Use this' }))
 
-    // Staged Gandalf is dropped (wizard.md → Status field: staged entities
-    // can't appear in scene metadata); the kind-mismatched location ref
-    // (Bran, a character) is dropped too; and the active faction is dropped
-    // because factions are never scene-tagged (data-model.md → Scene presence
-    // is kind-aware) — the same filter Finish commits through, so the preview
-    // can't promise scene state the story never gets.
-    expect(await screen.findByText('Scene metadata: Aria')).toBeInTheDocument()
+    // Staged Gandalf is never offered (wizard.md → Status field: staged
+    // entities can't appear in scene metadata), and the active faction is not
+    // either because factions are never scene-tagged (data-model.md → Scene
+    // presence is kind-aware). Bran is an active character so he IS a scene
+    // candidate — what must not happen is his id, sitting in the location
+    // slot, rendering as the chosen location.
+    await waitFor(() => expect(screen.getByText('Aria')).toBeInTheDocument())
     expect(screen.queryByText(/Gandalf/)).not.toBeInTheDocument()
-    expect(screen.queryByText(/Bran/)).not.toBeInTheDocument()
     expect(screen.queryByText(/Ashen Court/)).not.toBeInTheDocument()
+    // Bran's id sits in the location slot; resolveOpening's reverse
+    // substitution doesn't validate kind, so the control must read as unset
+    // rather than adopting a character as the location.
+    expect(screen.getByRole('radio', { name: 'Not set' })).toBeChecked()
+    expect(screen.getByRole('radio', { name: 'Mornstone Keep' })).not.toBeChecked()
   },
 }
 
-export const SceneMetadataDropsStagedLocation: Story = {
+export const SceneTagsDropStagedLocation: Story = {
   beforeEach: () => {
     wizardStore.reset()
     appSettingsStore.__reset()
@@ -237,12 +249,19 @@ export const SceneMetadataDropsStagedLocation: Story = {
     await userEvent.click(await screen.findByRole('button', { name: 'Generate' }))
     await userEvent.click(screen.getByRole('button', { name: 'Use this' }))
 
-    expect(await screen.findByText('Scene metadata: Aria')).toBeInTheDocument()
+    // Active-only applies to the location slot too, not just cast rows: the
+    // staged location is never offered, so the ref reads as unset.
+    await waitFor(() => expect(screen.getByText('Aria')).toBeInTheDocument())
     expect(screen.queryByText(/Shadowfen/)).not.toBeInTheDocument()
+    expect(
+      screen.getByText('Add a location on the Cast step to set where the opening happens.'),
+    ).toBeInTheDocument()
   },
 }
 
-export const SceneMetadataDedupesRepeatedNames: Story = {
+// The item this surface exists for: a user-written opening (no `model`) can be
+// grounded at wizard time instead of waiting for turn 2's classifier.
+export const UserWrittenSceneTagging: Story = {
   beforeEach: () => {
     wizardStore.reset()
     appSettingsStore.__reset()
@@ -252,29 +271,43 @@ export const SceneMetadataDedupesRepeatedNames: Story = {
       { ...emptyCastDraft('location', LOCATION_ID), name: 'Mornstone Keep' },
     ])
     wizardStore.setLeadEntityId(LEAD_ID)
+    wizardStore.patchOpening({ content: 'The harbor lay still under a bruised sky.' })
   },
-  render: () => (
-    <StepOpening
-      onSetupAssist={fn()}
-      assist={{
-        resolveModelId: () => MODEL_ID,
-        opening: okRun({
-          content: 'Aria drew her blade as the storm broke over Mornstone Keep.',
-          // The location also appears in sceneEntities alongside the lead —
-          // the joined label must not repeat "Mornstone Keep".
-          sceneEntities: [LEAD_ID, LOCATION_ID],
-          currentLocationId: LOCATION_ID,
-          model: MODEL_ID,
-        }),
-      }}
-    />
-  ),
   play: async () => {
-    await userEvent.click(screen.getByRole('button', { name: 'Suggest opening' }))
-    await userEvent.click(await screen.findByRole('button', { name: 'Generate' }))
-    await userEvent.click(screen.getByRole('button', { name: 'Use this' }))
+    const before = wizardStore.getWizard().state.opening
+    expect(before.model).toBeNull()
+    expect(before.sceneEntities).toEqual([])
+    expect(before.currentLocationId).toBeNull()
 
-    expect(await screen.findByText('Scene metadata: Aria · Mornstone Keep')).toBeInTheDocument()
+    await userEvent.click(await screen.findByText('Aria'))
+    await waitFor(() =>
+      expect(wizardStore.getWizard().state.opening.sceneEntities).toEqual([LEAD_ID]),
+    )
+
+    await userEvent.click(screen.getByText('Mornstone Keep'))
+    await waitFor(() =>
+      expect(wizardStore.getWizard().state.opening.currentLocationId).toBe(LOCATION_ID),
+    )
+    // Tagging is authorship of metadata only — it must not claim the prose was
+    // model-written, which is the discriminator Finish commits on.
+    expect(wizardStore.getWizard().state.opening.model).toBeNull()
+  },
+}
+
+// Both slots degrade to guidance rather than an empty control the user cannot act on.
+export const SceneTagsWithNoCast: Story = {
+  beforeEach: () => {
+    wizardStore.reset()
+    appSettingsStore.__reset()
+    wizardStore.patchOpening({ content: 'The harbor lay still under a bruised sky.' })
+  },
+  play: async () => {
+    expect(
+      await screen.findByText('Add a character or item on the Cast step to tag the opening scene.'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Add a location on the Cast step to set where the opening happens.'),
+    ).toBeInTheDocument()
   },
 }
 

--- a/components/wizard/step-opening.stories.tsx
+++ b/components/wizard/step-opening.stories.tsx
@@ -171,9 +171,8 @@ export const SceneTagsDropStagedAndKindMismatchedRefs: Story = {
       // unlike reusing the lead's id, whose name would collide via dedupe.
       { ...emptyCastDraft('character', MISKIND_ID), name: 'Bran' },
       { ...emptyCastDraft('faction', FACTION_ID), name: 'The Ashen Court' },
-      // An active location, so the location control actually renders and the
-      // kind guard below is exercised rather than short-circuited by the
-      // no-locations empty state.
+      // An active location so the location control renders at all — otherwise the
+      // kind guard below is short-circuited by the no-locations empty state.
       { ...emptyCastDraft('location', LOCATION_ID), name: 'Mornstone Keep' },
     ])
     wizardStore.setLeadEntityId(LEAD_ID)
@@ -200,18 +199,13 @@ export const SceneTagsDropStagedAndKindMismatchedRefs: Story = {
     await userEvent.click(await screen.findByRole('button', { name: 'Generate' }))
     await userEvent.click(screen.getByRole('button', { name: 'Use this' }))
 
-    // Staged Gandalf is never offered (wizard.md → Status field: staged
-    // entities can't appear in scene metadata), and the active faction is not
-    // either because factions are never scene-tagged (data-model.md → Scene
-    // presence is kind-aware). Bran is an active character so he IS a scene
-    // candidate — what must not happen is his id, sitting in the location
-    // slot, rendering as the chosen location.
+    // Staged entities can't be scene-tagged (wizard.md → Status field), nor can
+    // factions (data-model.md → Scene presence is kind-aware).
     await waitFor(() => expect(screen.getByText('Aria')).toBeInTheDocument())
     expect(screen.queryByText(/Gandalf/)).not.toBeInTheDocument()
     expect(screen.queryByText(/Ashen Court/)).not.toBeInTheDocument()
-    // Bran's id sits in the location slot; resolveOpening's reverse
-    // substitution doesn't validate kind, so the control must read as unset
-    // rather than adopting a character as the location.
+    // resolveOpening's reverse substitution doesn't validate kind, so Bran's id in
+    // the location slot must read as unset, not adopt a character as the location.
     expect(screen.getByRole('radio', { name: 'Not set' })).toBeChecked()
     expect(screen.getByRole('radio', { name: 'Mornstone Keep' })).not.toBeChecked()
   },
@@ -259,8 +253,8 @@ export const SceneTagsDropStagedLocation: Story = {
   },
 }
 
-// The item this surface exists for: a user-written opening (no `model`) can be
-// grounded at wizard time instead of waiting for turn 2's classifier.
+// A user-written opening (no `model`) is grounded at wizard time instead of
+// waiting for turn 2's classifier.
 export const UserWrittenSceneTagging: Story = {
   beforeEach: () => {
     wizardStore.reset()

--- a/components/wizard/step-opening.tsx
+++ b/components/wizard/step-opening.tsx
@@ -22,6 +22,7 @@ import { appSettingsStore, wizardStore } from '@/lib/stores'
 
 import { AiAssist } from './ai-assist'
 import { MemoryCostDisclosure } from './memory-cost-disclosure'
+import { OpeningSceneTags } from './opening-scene-tags'
 import {
   refineDescriptionAssist,
   refineOpeningAssist,
@@ -62,49 +63,9 @@ export function StepOpening({ onSetupAssist, assist }: StepOpeningProps) {
   // wizard.md → Replace-on-existing: a candidate accepted over authored prose
   // is staged here until confirmed, never written straight to the store.
   const [pendingOpening, setPendingOpening] = useState<OpeningAssistValue | null>(null)
-  const isAiGenerated = opening.model != null
 
   const handleSetup = onSetupAssist ?? (() => {})
   const resolveModelId = assist?.resolveModelId ?? (() => resolveWizardAssistModelId())
-
-  // Resolved live against the current cast, not snapshotted at generation
-  // time (wizard.md → Committed prose: refs stay intact across cast edits;
-  // the user regenerates via ✨ for fresh metadata rather than this label
-  // silently going stale-but-blank). Active AND character/item, matching the
-  // filter Finish commits through (data-model.md → Scene presence is
-  // kind-aware): previewing a ref that Finish then drops would promise the
-  // user scene state the story never gets.
-  const sceneNames = opening.sceneEntities
-    .map((id) =>
-      cast
-        .find(
-          (r) =>
-            r.id === id && r.status === 'active' && (r.kind === 'character' || r.kind === 'item'),
-        )
-        ?.name.trim(),
-    )
-    .filter((name): name is string => name != null && name.length > 0)
-  // Kind-guarded: resolveOpening's reverse substitution doesn't validate kind,
-  // so a non-placeholder id that survives it must not render a character's
-  // name in the location slot.
-  const locationName =
-    opening.currentLocationId != null
-      ? (cast
-          .find(
-            (r) =>
-              r.id === opening.currentLocationId && r.kind === 'location' && r.status === 'active',
-          )
-          ?.name.trim() ?? null)
-      : null
-  // De-duped: a repeated id, two rows sharing a name, or the location id also
-  // present in sceneEntities would otherwise render "Aria · Aria".
-  const parts = [
-    ...new Set([
-      ...sceneNames,
-      ...(locationName != null && locationName.length > 0 ? [locationName] : []),
-    ]),
-  ]
-  const metadataLabel = isAiGenerated && hasContent && parts.length > 0 ? parts.join(' · ') : null
 
   // An absent default-story-setting tracks the code default, which is 'local'.
   const embeddingBackend =
@@ -152,11 +113,16 @@ export function StepOpening({ onSetupAssist, assist }: StepOpeningProps) {
           placeholder={t('wizard:opening.placeholder')}
           aria-label={t('wizard:opening.opening.label')}
         />
-        {metadataLabel != null ? (
-          <Text size="sm" variant="muted">
-            {t('wizard:opening.sceneMetadata', { value: metadataLabel })}
-          </Text>
-        ) : null}
+        <OpeningSceneTags
+          cast={cast}
+          sceneEntities={opening.sceneEntities}
+          currentLocationId={opening.currentLocationId}
+          onChangeSceneEntities={(sceneEntities) => wizardStore.patchOpening({ sceneEntities })}
+          onChangeLocation={(currentLocationId) => wizardStore.patchOpening({ currentLocationId })}
+        />
+        <Text size="sm" variant="muted">
+          {t('wizard:opening.scene.hint')}
+        </Text>
       </View>
 
       <View className="gap-4">

--- a/components/wizard/tier-tuple-input.tsx
+++ b/components/wizard/tier-tuple-input.tsx
@@ -67,9 +67,8 @@ export function TierTupleInput({
 
         return (
           <View key={tier.name} className={hasLabels ? 'w-40' : 'w-24'}>
-            {/* The w-24/w-40 wrapper is always under FormRow's 640px threshold, so
-                the unpinned heuristic guesses two-column from the window tier and
-                corrects on layout — remounting the control mid-edit. */}
+            {/* `stacked` pinned: the wrapper is always under FormRow's 640px
+                threshold, so the unpinned heuristic remounts the control mid-edit. */}
             <FormRow
               stacked
               label={tierLabel(tier.name)}

--- a/components/wizard/tier-tuple-input.tsx
+++ b/components/wizard/tier-tuple-input.tsx
@@ -67,7 +67,14 @@ export function TierTupleInput({
 
         return (
           <View key={tier.name} className={hasLabels ? 'w-40' : 'w-24'}>
-            <FormRow label={tierLabel(tier.name)} error={showError ? errorMessage : undefined}>
+            {/* The w-24/w-40 wrapper is always under FormRow's 640px threshold, so
+                the unpinned heuristic guesses two-column from the window tier and
+                corrects on layout — remounting the control mid-edit. */}
+            <FormRow
+              stacked
+              label={tierLabel(tier.name)}
+              error={showError ? errorMessage : undefined}
+            >
               {hasLabels ? (
                 <Select
                   mode="dropdown"

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1822,7 +1822,12 @@ refs are constrained.
 **No separate classifier pass on the opening (v1).** User-written
 openings start with empty metadata (`worldTime: 0`,
 `sceneEntities: []`, `currentLocationId: null`); turn 2's classifier
-populates scene presence going forward. The first AI reply's prompt
+populates scene presence going forward. The wizard's opening step
+offers optional hand-tagging of the two scene fields on either
+authorship path (see
+[`wizard.md → Committed prose`](./ui/screens/wizard/wizard.md#committed-prose-after-use-this-or-after-manual-typing)),
+which changes what those fields may hold at commit but not the
+absence of a classifier pass, and never sets `metadata.model`. The first AI reply's prompt
 context includes the opening prose verbatim (protected buffer
 covers it — chapter 1 has only the opening entry, so the protected
 floor pulls the opening into context), so the AI grounds itself

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -266,25 +266,6 @@ for the placement rule.
   undo stack, or wants the redo-clear narrowed. Not scoped to the
   world-state-block work; surfaced alongside it 2026-07-23.
 
-- **A crash mid-burst re-classifies the window and duplicates its
-  happenings.** The classifier phase yields its planned writes one at a
-  time and the orchestrator commits each as its own delta; the watermark
-  advances only after the last one
-  (`lib/pipeline/definitions/periodic-classifier.ts`). A crash in between
-  leaves the deltas on disk with `processedThrough` unmoved, so the next
-  pass re-reads the same window. Boot's `resetStuckClassifierRunState`
-  assumes that state is coherent ("the watermark never advanced"), but it
-  is only coherent when _no_ delta landed. `createHappening` allocates a
-  fresh id per call and nothing keys on content, so the replay writes a
-  second copy of every happening, involvement and awareness row the
-  interrupted burst had already committed. Options, roughly in order of
-  cost: advance the watermark inside the same transaction as the burst;
-  give the pass a run marker that recovery reverse-replays like any other
-  orphan; or an idempotency key on classifier-sourced happenings. Not the
-  same hole as the `state: 'running'` orphan the boot reset already
-  covers. Surfaced 2026-07-31 reviewing
-  [Slice 3.3](./implementation/milestones/03-memory-floor/slices/03-classifier.md).
-
 - **Q3 needs an overhaul and a re-spec, not signal-by-signal patches.**
   [`retrieval.md → Q3`](./memory/retrieval.md#q3-heuristic-prose-extract)
   specifies five per-sentence signals; three of them, plus the

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -13,19 +13,6 @@ for the placement rule.
 
 ## UX
 
-- **Suggest-cast unresolved references should surface visually, not
-  fall back to `null` silently.** Canon
-  ([`wizard.md → AI-suggest — structured identity`](./ui/screens/wizard/wizard.md#ai-suggest--structured-identity))
-  resolves a suggestion's `parent_location_name` / `faction_name`
-  at import time against same-kind rows in the imported selection
-  and the existing cast, and unresolved names fall back to `null`
-  with no feedback — the user learns their suggested character's
-  faction never attached only by opening the editor later. Wanted:
-  resolve at runtime in the list surface and render an inline error
-  or warning on rows whose references cannot be resolved (e.g. the
-  named faction was left unchecked at import). Surfaced during 3.6b
-  slice planning (2026-08-13); deliberately not in 3.6b scope.
-
 - **World-state block: render from metadata, strip the XML out of
   persisted entry content.** Scheduled for the post-M3 reconciliation
   pass, before M4 opens. Today `EntryCard` detects the block by

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -37,26 +37,6 @@ for the placement rule.
   [Entry metadata shape](./data-model.md#entry-metadata-shape));
   only the wizard UX is missing.
 
-- **Hardware back on a phone `Sheet` bypasses `onOpenChange`, so no
-  sheet can guard it.** `@rn-primitives/dialog` registers its
-  `hardwareBackPress` handler on `Content`, but a bottom-anchored
-  `SheetContent` routes to `BottomSheetContent`
-  (`components/ui/sheet.tsx`), which renders a bare `BottomSheetModal`
-  — and `@gorhom/bottom-sheet` registers no `BackHandler` anywhere.
-  The press reaches whatever the screen registered instead; in the
-  wizard that is `app/wizard.tsx`, which calls `router.back()` and
-  returns true, popping the route out from under the open sheet.
-  Surfaced by Slice 3.12b's AiAssist discard-confirm, where it is the
-  one dismiss path the confirm cannot intercept — on Android phone,
-  the platform that decision record singled out as unrecoverable.
-  The fix is a guarded `BackHandler` in `BottomSheetContent` mirroring
-  the dialog primitive, which would benefit every sheet consumer.
-  Held out of 3.12b for verification reasons, not effort: it changes
-  back-button behaviour app-wide and only an Android device can prove
-  it, E2E being desktop-only per
-  [`testing.md`](./testing.md#e2e-target-desktop-only). Land it in a
-  slice that can run the device loop.
-
 - **Suggest-cast unresolved references should surface visually, not
   fall back to `null` silently.** Canon
   ([`wizard.md → AI-suggest — structured identity`](./ui/screens/wizard/wizard.md#ai-suggest--structured-identity))

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -13,30 +13,6 @@ for the placement rule.
 
 ## UX
 
-- **Optional user-side scene tagging on user-written openings.**
-  User-written openings start with empty
-  `metadata.sceneEntities` / `currentLocationId` / `worldTime: 0`
-  per the locked
-  [opening entry contract](./data-model.md#opening-entry).
-  Turn-2 classifier picks up scene presence from there. Some users may
-  want to pre-tag scene presence on the opening at wizard time — pick
-  which cast members are in the opening's scene, which location is
-  current — so first-turn generation context is grounded from entry 1.
-
-  Wizard concern, not data-model. The
-  [Wizard design pass](./explorations/2026-04-30-story-creation-wizard.md)
-  landed without this affordance — AI-generated openings emit
-  metadata refs via structured output, but user-written openings
-  remain empty until turn-2 classifier picks up. Adding a manual
-  scene-tagging surface on the wizard's step 5 was deliberately
-  deferred. Lifted from parked to active during 3.6b slice planning
-  (2026-08-13): with the Cast step landing, a starting-location
-  marker for user-written openings is the remaining gap turn 1
-  cannot recover on its own. The data shape already supports it
-  (metadata fields exist and are user-editable per
-  [Entry metadata shape](./data-model.md#entry-metadata-shape));
-  only the wizard UX is missing.
-
 - **Suggest-cast unresolved references should surface visually, not
   fall back to `null` silently.** Canon
   ([`wizard.md → AI-suggest — structured identity`](./ui/screens/wizard/wizard.md#ai-suggest--structured-identity))

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -388,53 +388,6 @@ for the placement rule.
   Surfaced 2026-07-30 finishing
   [Slice 3.3](./implementation/milestones/03-memory-floor/slices/03-classifier.md).
 
-- **Storybook vitest project applies no NativeWind classNames, so every
-  style assertion in a story passes vacuously.** Components render with
-  only react-native-web's own generated class — no `rounded-md`, no
-  `hidden`, no theme tokens — so the repo has zero style-level test
-  coverage in CI. The Storybook dev server is unaffected. Confirmed by
-  probe (2026-08-18): a `<View className="hidden rounded-md">` renders
-  `class="css-view-g5y9jx"`, `style="null"`, computed `display: flex`,
-  `border-radius: 0px`.
-  **The obvious fix is disproven.** Carrying
-  `framework.options.pluginReactOptions.jsxImportSource: 'nativewind'`
-  into the vitest project does not work: adding
-  `rnw({ jsxRuntime: 'automatic', jsxImportSource: 'nativewind' })` to the
-  storybook project's plugins changes nothing, in either plugin order, and
-  `esbuild.jsxImportSource` changes nothing either. The plugin genuinely
-  runs — pointing it at a nonexistent module fails the build on
-  `<module>/jsx-runtime` — so the option is read but the transform that
-  actually compiles the story is not the one it configures.
-  **Root cause is the interop registration, not the JSX transform.** The
-  stylesheets are fine (6 sheets, 861 rules, the `.hidden` rule present).
-  What is missing is `cssInterop` registration for the RN core components:
-  adding `cssInterop(View, { className: 'style' })` by hand makes the same
-  probe render `class="css-view-g5y9jx hidden rounded-md"` with
-  `display: none` and `border-radius: 6px`.
-  `components/wizard/cast-row-layout.stories.tsx:16` already carries that
-  hand-registration as a local workaround.
-  **Importing NativeWind's own registration module does not work
-  (2026-08-18).** `nativewind/jsx-runtime` reaches
-  `react-native-css-interop`'s `runtime/components`, which owns the
-  canonical list, but that prebuilt CJS resolves `react-native` to a
-  different identity than the aliased stories do, so it decorates the
-  wrong `View`. Adding the import leaves the probe unchanged while the
-  full storybook project still reports 776 passing tests, so the suite
-  cannot be used to tell whether registration took: verify with the probe.
-  Registering in `.storybook/preview.tsx`, which the same aliasing
-  applies to, does work. That leaves the setup-file route as the only
-  path, and it must restate NativeWind's list (15 components plus 3
-  special mappings) locally, where it can drift.
-  **Cost is measured (2026-08-18).** With the full list registered, 17
-  story tests across 7 files fail: `world-time-edit-form` (4),
-  `lore-list` (4), `cast-editors` (3), `tier-tuple-input` (2),
-  `embedding-models-panel` (2), `worldtime-edit-sheet` (1), `button` (1),
-  heavily TextInput-adjacent. Payoff today is small — 6 style assertions
-  exist repo-wide — so the value is unlocking style and visual-regression
-  assertions going forward. Until it lands, treat any style assertion in
-  a story as unproven. Surfaced by M3.11 Task 7 (2026-07-22), root-caused
-  and priced 2026-08-18.
-
 ## Code structure
 
 Near-future refactors routed out of the Slice 3.12 split

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -315,23 +315,6 @@ for the placement rule.
   replaced. Surfaced 2026-08-06 reviewing
   [Slice 3.4](./implementation/milestones/03-memory-floor/slices/04-retrieval.md).
 
-## Tooling
-
-- **`pnpm test:run` over the whole repo cannot be read as a gate.** A
-  full run reports failed test _files_ with zero failed tests: a varying
-  handful of Storybook browser-project files fail to _load_ under
-  parallel contention (`Failed to fetch dynamically imported module`,
-  `Cannot connect to the iframe …`). The same files pass in isolation,
-  and the failing set differs run to run. Reproduced on `main`
-  (`54528591`) from a clean install — 9 files, 0 failed tests — so it is
-  not branch-specific. Until it is fixed, every slice's finish step has
-  to run the `unit` project and the Storybook files separately and argue
-  the residual by hand, which is exactly the shape that lets a real
-  browser-project regression hide. Likely levers: concurrency limits on
-  the browser project, or isolating it from the `unit` project's workers.
-  Surfaced 2026-07-30 finishing
-  [Slice 3.3](./implementation/milestones/03-memory-floor/slices/03-classifier.md).
-
 ## Code structure
 
 Near-future refactors routed out of the Slice 3.12 split

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -297,12 +297,45 @@ for the placement rule.
   covers. Surfaced 2026-07-31 reviewing
   [Slice 3.3](./implementation/milestones/03-memory-floor/slices/03-classifier.md).
 
-- **Q3's Medium-weight signals are English-shaped and fail silently.**
+- **Q3 needs an overhaul and a re-spec, not signal-by-signal patches.**
   [`retrieval.md → Q3`](./memory/retrieval.md#q3-heuristic-prose-extract)
-  scores five signals; the two High ones (entity-name, lore-keyword) are
-  language-agnostic by construction — `matchTerms` uses `\p{L}\p{N}`
-  lookarounds specifically so accented and Cyrillic names match. Both
-  Medium ones are not, and neither degrades loudly.
+  specifies five per-sentence signals; three of them, plus the
+  tokenizer underneath, assume a lexical, Latin-script, past-tense
+  narrative, and the design has no way to report that the assumption
+  failed. The two High signals (entity-name, lore-keyword) are the
+  exception and are sound — `matchTerms` uses `\p{L}\p{N}` lookarounds
+  specifically so accented and Cyrillic names match, and they reuse an
+  index the hybrid pathway already builds. That layer is worth keeping;
+  what sits around it is what wants redesigning.
+
+  Two structural findings drive the re-spec, ahead of any individual
+  signal:
+  - **Q3 can never report itself absent, so a degenerate extract still
+    spends its full `w_prose` share.** `buildQueryStack`
+    (`lib/retrieval/queries.ts`) derives presence from `nonEmpty(text)`,
+    and `extractProse` returns top-K by source-order tie-break even when
+    every sentence scores zero — so a no-signal extract is textually
+    indistinguishable from a good one and reads present. Canon already
+    reasoned this exact failure through for Q2, which renders to the
+    empty string when every conditional line is empty and correctly
+    drops out of the blend
+    ([`retrieval.md → Q2`](./memory/retrieval.md#q2-structural-digest));
+    Q3 shipped without the equivalent, which makes this an
+    inconsistency inside the spec rather than a gap in the code. It is
+    also the prerequisite for measuring anything else here: a silent
+    degradation cannot be tuned against, so no empirical argument about
+    `w_prose` is available until Q3 can say it found nothing.
+  - **The score carries too little resolution to rank with.** Five
+    booleans sum to at most 11, and an ordinary sentence lands in the
+    0-4 band, so ties are the common case and every tie resolves to
+    source order. Selection collapses toward "the earliest sentences
+    that scored at all" well before any language mismatch enters the
+    picture. The signals are also summed as though independent when
+    they are not: `said` and `Drew` each fire the verb weight and the
+    entity weight off a single token.
+
+  The language-shape findings underneath, verified 2026-08-06 against
+  the shipped code:
   - **Action verbs.** `ACTION_VERBS` (`lib/retrieval/prose-extract.ts`)
     is 13 hardcoded English simple-past verbs matched by exact
     `Set.has`, no stemming. `stories.settings.definition.narration`
@@ -312,43 +345,42 @@ for the placement rule.
     `draw` / `drawing` do not. There is also no narrative-language
     setting at all (`translation.targetLanguage` is the translation
     _target_; entries store the original), so a story written in
-    Spanish or Russian scores zero on this signal permanently. And it
-    false-positives on names: `words` is lowercased before lookup, so
-    "**Drew** nodded." fires the verb weight, and if Drew is an entity
-    the same token also fires the entity weight — one word, two
-    signals, no action. `Said` has the same problem.
-  - **Dialogue spans.** `DIALOGUE_SPAN` covers `"…"`, `“…”` and
-    `‘…’` and misses `«…»` (French, Russian), `„…”` (German, Polish,
-    Czech) and `「…」` (CJK). Same weight, same silent miss, but
-    unlike the verb list this one is a three-alternative regex change
-    with no linguistics in it — worth taking on its own if the wider
-    redesign stalls.
+    Spanish or Russian scores zero on this signal permanently.
+  - **Dialogue spans.** `DIALOGUE_SPAN` covers `"…"`, `“…”` and `‘…’`
+    and misses `«…»` (French, Russian), `„…”` (German, Polish, Czech)
+    and `「…」` (CJK). Same weight, same silent miss.
   - **Brevity** is character-counted (`BREVITY_MAX_CHARS = 90`), so in
     CJK it fires on nearly every sentence and stops discriminating.
   - **CJK is never split into sentences at all**, which sits upstream
     of every signal above. `splitSentences` terminates on `[.!?…]`
     followed by whitespace; CJK uses ideographic terminators and no
-    inter-sentence space, so a whole entry collapses to one
-    "sentence". Q3 then embeds the full 400-1000 token entry — the
-    cost the extract exists to avoid — and `scores` degenerates to a
-    single meaningless number, emptying the probe's per-sentence
-    capture. Verified against the shipped splitter (2026-08-06):
-    a three-sentence Japanese passage returns one element.
+    inter-sentence space, so a whole entry collapses to one "sentence".
+    Q3 then embeds the full 400-1000 token entry — the cost the extract
+    exists to avoid — and `scores` degenerates to a single meaningless
+    number, emptying the probe's per-sentence capture. Verified against
+    the shipped splitter (2026-08-06): a three-sentence Japanese
+    passage returns one element.
     [`name-index.ts`](../lib/retrieval/name-index.ts) documents CJK as
     out of scope for word-boundary matching; nothing documents it for
     splitting, so this reads as an oversight rather than a deferral.
     Whatever replaces the scorer has to own this first.
 
-  Failure is silent throughout: when every sentence scores 0,
-  `extractProse` still returns top-K by source-order tie-break, so Q3
-  quietly degrades to "the first 4 sentences" while carrying its full
-  `w_prose = 0.30` share of the blend. One redesign direction worth
-  arguing: drop the hardcoded list for a set derived from the branch's
-  own happening titles, which the classifier writes in the story's
-  language — self-localizing, no linguistics, reuses an index the pass
-  already builds. Mildly circular, hence a discussion rather than a
-  patch. Touches the canon signal table, so it is a spec change, not
-  only a code change. Surfaced 2026-08-06 reviewing
+  One redesign direction worth arguing: drop the hardcoded verb list
+  for a term set derived from the branch's own happening titles, which
+  the classifier writes in the story's language — self-localizing, no
+  linguistics, reuses an index the pass already builds. The
+  circularity is sharper than it first reads, and settling it is part
+  of the re-spec: happening titles summarize what the memory layer has
+  already absorbed, so scoring sentences by resemblance to them biases
+  Q3 toward recorded material and away from the novel prose a
+  retrieval pass most needs to surface.
+
+  Scope is the canon signal table, the sentence tokenizer, the
+  presence contract and the scorer — a spec change before it is a code
+  change. The dialogue-span regex was previously carved out here as
+  separately shippable; folded back in 2026-08-24, because landing it
+  alone tunes one Medium signal inside a scoring model that is being
+  replaced. Surfaced 2026-08-06 reviewing
   [Slice 3.4](./implementation/milestones/03-memory-floor/slices/04-retrieval.md).
 
 ## Tooling

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -265,14 +265,22 @@ for the placement rule.
   single per-column side-channel exemption
   ([`data-model.md → Entry mutability & rollback`](./data-model.md#entry-mutability--rollback)):
   editing it mutates the row directly, writes no delta, and preserves
-  no prior text, so CTRL-Z cannot reach it. The implementation goes
-  further than the doc implies — `updateStoryEntryContent`
-  (`lib/actions/story-entries/operational.ts`) also calls
-  `undoRedoStore.clear()`, so a typo fix silently discards the redo
-  stack for _unrelated_ actions. Meanwhile the metadata edits landing
-  on the same card are fully delta-logged and reversible, so one entry
-  will carry two adjacent edit affordances with opposite reversibility
-  and no visible reason for the difference. The exemption is a
+  no prior text, so CTRL-Z cannot reach it. `updateStoryEntryContent`
+  (`lib/actions/story-entries/operational.ts`) additionally calls
+  `undoRedoStore.clear()`, so a typo fix discards the redo stack for
+  unrelated actions — but that matches canon rather than exceeding it
+  ("the stack clears on any new action", same section), and mirrors by
+  hand what `apply-delta-action.ts` does for every delta-logged write.
+  The genuine asymmetry is narrower: writing no delta, a content edit
+  is the only action that clears the forward path while contributing
+  nothing to the backward one, so it is pure loss where every other
+  action trades redo for undo. Narrowing it is therefore a canon
+  change, not a blast-radius fix, and cannot be split off from the
+  question below (re-verified 2026-08-24). Meanwhile the metadata
+  edits landing on the same card are fully delta-logged and
+  reversible, so one entry will carry two adjacent edit affordances
+  with opposite reversibility and no visible reason for the
+  difference. The exemption is a
   deliberate storage-economy decision, not an oversight — the open
   question is whether the UX is defensible as-is, wants an editor-local
   undo stack, or wants the redo-clear narrowed. Not scoped to the

--- a/docs/generation-pipeline.md
+++ b/docs/generation-pipeline.md
@@ -1077,9 +1077,10 @@ modals — the case is vanishingly rare (concurrent same-kind runs
 can't happen; chained runs don't run simultaneously), so pretty UI
 for it isn't worth designing.
 
-Zero-reverse orphans (the pre-first-delta case) and recovery
-failures don't mount the modal; they surface via observability
-only.
+Zero-reverse orphans (the pre-first-delta case) don't mount the
+modal — nothing reached disk, so there is nothing to report.
+Recovery failures do mount it, under a different title; see
+[Recovery-failure policy](#recovery-failure-policy).
 
 #### Recovery-failure policy
 
@@ -1088,16 +1089,36 @@ recovery, the loop catches per-orphan and continues; boot is not
 blocked. The orphan row stays with `finished_at = NULL` so the next
 boot retries, and the failure emits `pipeline.recovery_failed` at
 `error` severity via observability — visible in the Diagnostics Hub
-Logs tab. The modal layer stays silent: the user's state is
-consistent (SQLite ROLLBACK undid any partial replay), the failure
-is almost always cross-version-related (an orphan's `undo_payload`
-references a column shape that no longer exists post-migration —
-the deferred multi-version apply-dispatcher case), and the orphan
-retries transparently on next boot.
+Logs tab.
+
+The modal reports it too. SQLite ROLLBACK undoes the partial
+reverse-replay, not the orphan's own writes: those stay on disk, and
+for a `periodic-classifier` orphan the branch stays held back from
+the cadence (`resetStuckClassifierRunState` skips branches whose
+deltas survived). A story whose memory has silently stopped updating
+is indistinguishable from a healthy one, so this is not an
+observability-only state:
+
+- The title reads _"Recovery incomplete"_ unless every orphan
+  reversed. A boot that reversed one orphan and failed another has
+  still left writes behind, and _"Story recovered"_ would over-claim
+  it.
+- A `periodic-classifier` failure is the one kind that can promise
+  the pause, because it writes `state: 'running'` before any delta
+  and so definitionally causes one. Other kinds describe the fault
+  without promising a pause.
+- Both variants say the story's content is intact and that
+  restarting the app retries automatically.
 
 No max-retry counter and no admin "drop orphan" affordance for v1;
-stuck orphans remain visible in Logs across boots. The real fix
-lives with the multi-version apply-dispatcher work.
+stuck orphans remain visible in Logs across boots. Nearly every
+failure is transient DB IO that self-heals on the next boot. Two
+cannot, and both are parked: an orphan whose `undo_payload`
+references a column shape that no longer exists post-migration (the
+[multi-version apply-dispatcher](./parked.md#multi-version-undo_payload-apply-dispatcher)
+case, which that work resolves), and
+[a delta whose target table left the registry](./parked.md#a-delta-whose-target-table-left-the-registry-cannot-be-reversed).
+Reaching either means running a build older than its own data.
 
 ### `chainsTo` on predecessor
 

--- a/docs/implementation/lessons-learned/README.md
+++ b/docs/implementation/lessons-learned/README.md
@@ -187,6 +187,10 @@ slice plans when relevant.
 - [Vite-built targets never read `babel.config.js` — wire worklets yourself](./vite-targets-dont-read-babel-config.md)
   — the rnw preset hardcodes `babelrc: false`; Storybook now declares the
   plugin itself, and any new Vite target must too.
+- [Failed Storybook files with zero failed tests](./storybook-load-flake-zero-failed-tests.md)
+  — a file-load flake, not a test failure; contention is ruled out
+  empirically and serializing the project breaks isolation, so check
+  `server.fs.allow` first.
 
 ### Native deps / install ritual
 

--- a/docs/implementation/lessons-learned/formrow-narrow-story-remount.md
+++ b/docs/implementation/lessons-learned/formrow-narrow-story-remount.md
@@ -37,11 +37,31 @@ export const Phone: Story = {
 }
 ```
 
+## The width can come from a className, not just an inline style
+
+Until the Storybook vitest project registered NativeWind's `cssInterop`
+(2026-08-24), classNames were inert there, so a `w-24` or `w-[640px]`
+wrapper measured full-width and the correction never fired. Stories
+written under that harness look like they pass at a wide layout while
+production stacks and remounts. Two shapes surfaced when registration
+landed:
+
+- **A component that is always narrow should pin the branch itself.**
+  `TierTupleInput` wraps every `FormRow` in `w-24` / `w-40`, so the
+  correction fired on every mount in production too — a real remount,
+  not a test artifact. It now passes `stacked`.
+- **A story wrapper sitting just under the threshold is a race.**
+  `w-[640px]` plus `p-6` measures 592 px, and stories doing that went
+  flaky (4 / 2 / 5 failures across identical runs) rather than failing
+  outright. Widen the wrapper so the guess and the measurement agree.
+
 ## How to apply
 
-- Any play story with a `FormRow` under an inline width below 640 px
-  passes `stacked` explicitly. Render-only stories may leave it to the
-  heuristic — the remount is harmless without assertions.
+- Any play story with a `FormRow` under a width below 640 px — inline
+  style **or** className, and remember to subtract padding — passes
+  `stacked` explicitly or widens past the threshold. Render-only
+  stories may leave it to the heuristic — the remount is harmless
+  without assertions.
 - The rule is about the **first frame**; a `waitFor` after the
   correction would also work, but it encodes the remount as a
   timing dependency instead of removing it.

--- a/docs/implementation/lessons-learned/storybook-load-flake-zero-failed-tests.md
+++ b/docs/implementation/lessons-learned/storybook-load-flake-zero-failed-tests.md
@@ -1,0 +1,70 @@
+# Failed Storybook files with zero failed tests
+
+A full `pnpm test:run` can exit non-zero reporting failed test
+_files_ while the test count is all-green — a handful of
+browser-project files fail to _load_ with
+`Failed to fetch dynamically imported module` or
+`Cannot connect to the iframe …`. The failing set varies run to
+run and the same files pass in isolation, so the run reads as
+"something is broken, unclear what," and the residual gets argued
+by hand. That is the shape that hides a real browser-project
+regression.
+
+## Why
+
+**Not worker contention**, which is the intuitive read and the one
+the original report assumed. Measured at `abc6b9d9` on a 32-core
+machine — 432 files, 4318 tests:
+
+| Condition                        | Result                    |
+| -------------------------------- | ------------------------- |
+| 10× warm repeat                  | green                     |
+| Cold Vite dep-optimizer cache    | green                     |
+| 28 CPU burners, 2.6× slower wall | green                     |
+| `--maxWorkers=1` vs `=128`       | no effect at all          |
+| `--fileParallelism=false`        | 3.6× slower, 1 test fails |
+
+Starvation severe enough to more than double the wall clock should
+trip a contention-driven flake and does not. Timeout headroom says
+the same: under that starvation the slowest file takes 18s against
+the 60s browser `connectTimeout`, with a 1.2s median.
+
+Two of those rows also invalidate the remedy the report proposed
+("concurrency limits on the browser project"):
+
+- **`maxWorkers` is inert here.** Forcing 1 and forcing 128 produce
+  the same wall clock to within 4%. Browser-mode parallelism does
+  not resolve from it, so capping it changes nothing but the
+  config's apparent intent.
+- **`fileParallelism: false` is the knob that works, and it is
+  harmful.** It takes the Storybook project from 26s to 96s, and it
+  fails `app-actions-menu-pure.stories.tsx > Diagnostics On`
+  reproducibly (2/2 runs) — a test that passes alone. Serializing
+  puts every file in one page, so app-level DOM state (a leftover
+  `data-density` on `<body>`) survives across files. Parallel
+  execution is load-bearing for isolation, not just for speed.
+
+The leading hypothesis for the original failures is instead a **404
+on the addon's setup file**, which produces the first error string
+exactly. A worktree that symlinks `node_modules` resolves that file
+to its real path, outside the Vite root, where the browser cannot
+fetch it — the case `server.fs.allow` in `vitest.config.ts` exists
+to cover. That guard landed in `a867976b` (2026-08-18), after the
+report. It stays a hypothesis: a blanket 404 should fail every file
+deterministically, which does not explain the run-to-run variation
+the report described.
+
+## How to apply
+
+- Treat `pnpm test:run` as the gate. Splitting the run and eyeballing
+  the residual was a workaround for this flake, and it costs the
+  signal it was meant to protect.
+- Failed files with zero failed tests is an **infrastructure**
+  signature, not a test signature. A real regression fails tests.
+  Read the file-level error before assuming a product bug.
+- If it returns, check `server.fs.allow` first, and check whether the
+  checkout's `node_modules` is a symlink (`readlink node_modules`).
+  Rerun the named files in isolation to confirm they load.
+- Do not serialize the browser project to chase a flake. The table
+  above is the measurement: it costs 3.6× wall clock and breaks an
+  isolation assumption the suite currently relies on.

--- a/docs/implementation/milestones/02-first-user-loop/slices/10-recovery-ui.md
+++ b/docs/implementation/milestones/02-first-user-loop/slices/10-recovery-ui.md
@@ -113,7 +113,8 @@ the failure state slot lives in the stories store (C1).
 - Bootstrap publishes a recovery report to the UI-state slot iff
   it contains at least one reversed orphan; a zero-reverse pass,
   failure-only report, or empty report leaves the slot empty and
-  boot proceeds normally.
+  boot proceeds normally. (Superseded in M3 — failure-only reports
+  now publish; see Implementation notes.)
 - The slot drains exactly once — re-render / re-navigation does
   not re-show the modal.
 - A story row with corrupted `settings` JSON (fixture) badges on
@@ -149,7 +150,7 @@ None.
 
 Resolved developer decisions and notable implementation details.
 
-- **Recovery handoff.** M2.10 repairs the 1.7a bootstrap seam by publishing only reports with reversed deltas. The UI store uses a pending-to-active claim so React Strict Mode can replay the host's async effect without losing or duplicating the notice; explicit acknowledgement is the only terminal drain.
+- **Recovery handoff.** M2.10 repairs the 1.7a bootstrap seam by publishing only reports with reversed deltas; M3 widened the gate to any non-empty report, because a failure leaves the orphan's writes on disk and a classifier failure holds its branch back from the cadence, so a failure-only pass is not a silent state (canonical: [`generation-pipeline.md → Recovery-failure policy`](../../../../generation-pipeline.md#recovery-failure-policy)). The UI store uses a pending-to-active claim so React Strict Mode can replay the host's async effect without losing or duplicating the notice; explicit acknowledgement is the only terminal drain.
 - **Definition recovery.** `stories.definition` remains strict and non-recoverable because wizard-authored identity has no valid default. Desktop exposes the existing database-file reveal bridge for manual repair; Android has no definition-repair affordance in v1, and neither platform offers reset.
 - **Settings recovery.** `stories.settings` reset reuses `buildStorySettings` with the current app-level defaults, matching copy-on-create. The action updates only the settings and timestamp, preserving the definition and all narrative/world rows; reset is gated by confirmation on both platforms.
 - **Recovery request lifetime.** Landing opens and reset-then-reopen flows share a latest-intent coordinator, with cancellation checked before action-layer store and navigation publication. Same-story reset writes remain coalesced until their owning operation settles, even if the dialog is dismissed; stale failures stay silent, while a current reopen failure uses the ordinary story-open diagnostic instead of claiming the reset failed.

--- a/docs/implementation/milestones/03-memory-floor/slices/03-classifier.md
+++ b/docs/implementation/milestones/03-memory-floor/slices/03-classifier.md
@@ -218,15 +218,22 @@ world-state-block edit surface rather than by this pipeline.
   the burst has landed. The orchestrator applies each delta as it is
   yielded, so there is no run-wide transaction to join. Watermark-after
   is the right order — the reverse would advance over facts that were
-  then reversed, a silent permanent hole in the graph — but it is **not**
-  coherent by construction, as this note originally claimed. The claim
-  assumed boot recovery reverse-replays an interrupted pass; nothing
-  does. Classifier runs leave no `pipeline_runs` marker, and
-  `resetStuckClassifierRunState` only repairs `$.state`, so a crash
-  between two committed deltas leaves those deltas on disk with the
-  watermark unmoved and the next pass re-writes the window's happenings.
-  Tracked in [`followups.md`](../../../../followups.md); closing it needs
-  either a transactional watermark, a run marker, or an idempotency key.
+  then reversed, a silent permanent hole in the graph — and it is
+  coherent, though not by the watermark alone. A crash between two
+  committed deltas does leave them on disk with the watermark unmoved,
+  but the marker is what closes the window: `beginRun` persists a
+  `pipeline_runs` row for every kind including this one, each burst delta
+  carries that run's `action_id`, and boot's `recoverInFlightRuns`
+  reverse-replays all of them before anything re-reads the range —
+  `abortRun` does the same for an in-process cancel. Pinned by
+  `lib/pipeline/__tests__/classifier-burst-recovery.test.ts`. The marker
+  settles inside the reversal's own transaction, because the replay is
+  not idempotent — undoing a `create` deletes (repeatable), undoing a
+  `delete` re-inserts (conflicts) — so an orphan left open over
+  already-reversed deltas would fail deterministically on every later
+  boot. The residual is the reversal that itself fails; boot then leaves
+  the branch un-reconciled rather than freeing it, so the cadence cannot
+  re-read the window (see the boot note below).
 - **`bracketProseReversal` is the only sanctioned entry to the reversal
   sweep.** It owns both classifier-era obligations (drain the in-flight
   run, hold `reversalInProgress` across the whole wait → sweep window),
@@ -366,7 +373,13 @@ world-state-block edit surface rather than by this pipeline.
   `pipeline_runs`), and is one key-scoped UPDATE on `$.state`;
   `retrying` and `failed-persistent` are explicitly left alone, since
   resetting those would erase a real error state and re-arm a broken
-  provider.
+  provider. It consumes that pass's failures rather than merely following
+  it: a branch still holding deltas from an orphan that would not reverse
+  keeps `running`, which already suspends the cadence, so the classifier
+  cannot re-read a window whose partial writes survive. The boot that
+  finally reverses them reconciles the branch normally, and
+  `[Run classifier now]` overrides throughout — the suspension is
+  automatic only.
 - **The reader was narrowed rather than the classifier widened.**
   `isGenerating` was "any run on this branch", which gave a `no-gate`
   classifier run a phantom streaming placeholder and a

--- a/docs/implementation/milestones/03-memory-floor/slices/03-classifier.md
+++ b/docs/implementation/milestones/03-memory-floor/slices/03-classifier.md
@@ -379,7 +379,9 @@ world-state-block edit surface rather than by this pipeline.
   cannot re-read a window whose partial writes survive. The boot that
   finally reverses them reconciles the branch normally, and
   `[Run classifier now]` overrides throughout — the suspension is
-  automatic only.
+  automatic only. The hold keys on this branch's own status, so another
+  kind's failed reversal does not trigger it; that residue is parked
+  ([parked.md](../../../../parked.md#the-classifier-can-read-a-window-holding-un-reversed-writes)).
 - **The reader was narrowed rather than the classifier widened.**
   `isGenerating` was "any run on this branch", which gave a `no-gate`
   classifier run a phantom streaming placeholder and a

--- a/docs/implementation/milestones/03-memory-floor/slices/12a-runtime-integrity.md
+++ b/docs/implementation/milestones/03-memory-floor/slices/12a-runtime-integrity.md
@@ -272,8 +272,9 @@ corrected premises as of that pass; file/line references are dated
   [`roadmap.md`](../../../roadmap.md) during the 2026-08-18 triage
   drain, and items parked under
   [`parked.md → Parked until signal`](../../../../parked.md#parked-until-signal).
-- Root-causing the flake and NativeWind gaps tracked in
-  [`followups.md → Tooling`](../../../../followups.md#tooling).
+- Root-causing the Storybook file-load flake and the NativeWind
+  gaps, both since closed — see
+  [`lessons-learned → Failed Storybook files with zero failed tests`](../../../lessons-learned/storybook-load-flake-zero-failed-tests.md).
 
 ## Acceptance criteria
 

--- a/docs/implementation/triage.md
+++ b/docs/implementation/triage.md
@@ -19,26 +19,77 @@ slice-planning gate forces its resolution before that slice is planned.
 
 ## Inbox
 
-- **A boot recovery that fails to reverse leaves the branch runnable
-  against un-reversed writes.** `recoverInFlightRuns`
-  (`lib/pipeline/runtime/recovery.ts`) logs a per-orphan
-  `DeltaReplayError` and leaves the row for the next boot — correct on
-  its own, but `resetStuckClassifierRunState` runs immediately after
-  and flips `classifier_status` to idle regardless, so the classifier
-  can start a fresh pass over a window whose partial writes are still
-  on disk. That is the duplication the (now removed) crash-mid-burst
-  followup described, reachable only when recovery itself fails rather
-  than on any ordinary crash. Cross-cutting: the same gap lets any kind
-  re-run against its own un-reversed orphan. The code already carries a
-  TODO at the catch site. Raised 2026-08-24 disproving that followup.
-- **`app-actions-menu-pure.stories.tsx` depends on cross-file DOM
-  cleanliness.** Under `--fileParallelism=false` the `Diagnostics On`
-  story fails reproducibly (2/2) with the body still carrying a
-  `data-density` attribute an earlier file set; it passes alone and
-  under the default parallel run, where each file gets its own page.
+- **An orphan that will not reverse is suspended, never resolved.**
+  Raised 2026-08-24 disproving the crash-mid-burst followup; the
+  classifier half is closed as of 2026-08-25.
+  `resetStuckClassifierRunState` now consumes the recovery pass's
+  failures and leaves a branch still holding their deltas `running`,
+  which suspends the cadence, so the automatic path can no longer
+  re-read a window whose partial writes are on disk. A second fix the
+  same day made the `pipeline_runs` marker settle inside the reversal's
+  own transaction: written separately, a failure between the two left the
+  deltas reversed and the orphan open, and the replay is not idempotent —
+  undoing a `create` deletes (repeatable) but undoing a `delete`
+  re-inserts (conflicts), so one transient error hardened into a
+  permanent one on every later boot. Failures now also reach the user
+  through the existing crash-recovery modal, which no longer titles
+  itself "Story recovered" when nothing was reversed. Two gaps survive,
+  both cross-cutting:
+  - **The gate is keyed on the classifier having been mid-run, not on
+    the branch being hazardous.** A branch is only held back if its own
+    `classifier_status` was left `running`. When some other kind's
+    orphan fails to reverse and the classifier happened to be `idle`,
+    nothing holds the branch: the cadence fires over a window carrying
+    those un-reversed writes. `[Run classifier now]` bypasses the
+    suspension by design, and the other kinds are event-triggered with
+    no equivalent gate at all. One rule at run-start — refuse to start
+    any kind on a branch with un-reversed orphan deltas — would cover
+    every kind, the manual override, and this asymmetry together, but it
+    needs the concurrency contract to learn about orphans.
+  - **`abortRun` strands its deltas when its own reversal fails.** The
+    marker now rides the reversal transaction on the success path, but
+    when reverse-replay throws, `abortRun`
+    (`lib/pipeline/runtime/orchestrator.ts`) still settles the marker
+    with `outcome: 'failed'`. `recoverInFlightRuns` selects on
+    `finished_at IS NULL`, so boot never sees that run and the
+    un-reversed writes are stranded with no retry at all — worse than the
+    boot path, which at least keeps trying. Leaving the marker open
+    instead would hand it to boot recovery, but it also re-opens a run
+    the user was told had finished; that trade has not been made.
+  - **A permanently unreversible orphan has no resolution.** Boot retries
+    the reversal each time, so anything transient self-heals; what
+    remains is version skew — a delta naming a domain the running build's
+    registry lacks (`unknown target_table`), which no retry can fix. The
+    TODO at the catch site (`lib/pipeline/runtime/recovery.ts`) proposes
+    deleting the orphaned rows: **not viable as written.** Deltas are the
+    undo stack (`undoLastAction` reads them through `selectUndoTarget`),
+    so deleting them erases undo history while leaving the writes they
+    describe in place, and the next ctrl-Z reverses an older action
+    against a state it never saw.
+- **Story isolation leaks across files under
+  `--fileParallelism=false`.** Serializing puts every story file in one
+  page, and some app-level DOM state survives the file that set it.
   Latent rather than active — nothing runs the suite serially — but it
   means "run the browser project sequentially" is not available as a
-  debugging move until the story stops relying on ambient body state.
-  Cross-cutting: any story that reads app-level DOM state has the same
-  exposure, so the fix is a cleanup contract, not one story's patch.
-  Raised 2026-08-24 verifying the `pnpm test:run` gate followup.
+  debugging move, which is exactly the move a browser-project
+  regression calls for. See
+  [failed Storybook files with zero failed tests](lessons-learned/storybook-load-flake-zero-failed-tests.md)
+  for the parallel-run flake this sits next to; the two may share a
+  cause. **Anchor item — accumulating evidence, not yet actionable.**
+  Append observations rather than rewriting.
+
+  Evidence so far:
+  - 2026-08-24, raised at `384823d6`: the `Diagnostics On` story in
+    `app-actions-menu-pure.stories.tsx` failed 2/2, body carrying a
+    `data-density` attribute. Attributed to that story; both the
+    attribution and the mechanism are unconfirmed.
+  - 2026-08-25 at `edce17b8`, three full serial runs (96 files, 803
+    tests): green, then a failure in `Trigger Opens Overlay`
+    (`preset-browser.stories.tsx`), then green. `Diagnostics On` passed
+    all three; `components/compounds` alone is green 26/26. So it is
+    intermittent (~1 in 3), the failing story varies across
+    directories, and it is not one story's dependency. Root cause
+    unidentified — an overlay that fails to open suggests residual
+    pointer-events or portal state rather than `data-density`, which
+    every file sets for itself through the global decorator in
+    `.storybook/preview.tsx`.

--- a/docs/implementation/triage.md
+++ b/docs/implementation/triage.md
@@ -33,8 +33,10 @@ slice-planning gate forces its resolution before that slice is planned.
   re-inserts (conflicts), so one transient error hardened into a
   permanent one on every later boot. Failures now also reach the user
   through the existing crash-recovery modal, which no longer titles
-  itself "Story recovered" when nothing was reversed. Two gaps survive,
-  both cross-cutting:
+  itself "Story recovered" when nothing was reversed. The one
+  unreversible-by-any-retry case, version skew, is parked as a non-issue
+  ([parked.md](../parked.md#a-delta-whose-target-table-left-the-registry-cannot-be-reversed)),
+  which leaves two gaps, both cross-cutting:
   - **The gate is keyed on the classifier having been mid-run, not on
     the branch being hazardous.** A branch is only held back if its own
     `classifier_status` was left `running`. When some other kind's
@@ -56,16 +58,6 @@ slice-planning gate forces its resolution before that slice is planned.
     boot path, which at least keeps trying. Leaving the marker open
     instead would hand it to boot recovery, but it also re-opens a run
     the user was told had finished; that trade has not been made.
-  - **A permanently unreversible orphan has no resolution.** Boot retries
-    the reversal each time, so anything transient self-heals; what
-    remains is version skew — a delta naming a domain the running build's
-    registry lacks (`unknown target_table`), which no retry can fix. The
-    TODO at the catch site (`lib/pipeline/runtime/recovery.ts`) proposes
-    deleting the orphaned rows: **not viable as written.** Deltas are the
-    undo stack (`undoLastAction` reads them through `selectUndoTarget`),
-    so deleting them erases undo history while leaving the writes they
-    describe in place, and the next ctrl-Z reverses an older action
-    against a state it never saw.
 - **Story isolation leaks across files under
   `--fileParallelism=false`.** Serializing puts every story file in one
   page, and some app-level DOM state survives the file that set it.

--- a/docs/implementation/triage.md
+++ b/docs/implementation/triage.md
@@ -31,3 +31,14 @@ slice-planning gate forces its resolution before that slice is planned.
   than on any ordinary crash. Cross-cutting: the same gap lets any kind
   re-run against its own un-reversed orphan. The code already carries a
   TODO at the catch site. Raised 2026-08-24 disproving that followup.
+- **`app-actions-menu-pure.stories.tsx` depends on cross-file DOM
+  cleanliness.** Under `--fileParallelism=false` the `Diagnostics On`
+  story fails reproducibly (2/2) with the body still carrying a
+  `data-density` attribute an earlier file set; it passes alone and
+  under the default parallel run, where each file gets its own page.
+  Latent rather than active — nothing runs the suite serially — but it
+  means "run the browser project sequentially" is not available as a
+  debugging move until the story stops relying on ambient body state.
+  Cross-cutting: any story that reads app-level DOM state has the same
+  exposure, so the fix is a cleanup contract, not one story's patch.
+  Raised 2026-08-24 verifying the `pnpm test:run` gate followup.

--- a/docs/implementation/triage.md
+++ b/docs/implementation/triage.md
@@ -36,7 +36,8 @@ slice-planning gate forces its resolution before that slice is planned.
   itself "Story recovered" when nothing was reversed. The one
   unreversible-by-any-retry case, version skew, is parked as a non-issue
   ([parked.md](../parked.md#a-delta-whose-target-table-left-the-registry-cannot-be-reversed)),
-  which leaves two gaps, both cross-cutting:
+  and `abortRun` now leaves its marker open when its own reversal fails
+  so boot recovery still owns those deltas. One gap survives:
   - **The gate is keyed on the classifier having been mid-run, not on
     the branch being hazardous.** A branch is only held back if its own
     `classifier_status` was left `running`. When some other kind's
@@ -48,16 +49,6 @@ slice-planning gate forces its resolution before that slice is planned.
     any kind on a branch with un-reversed orphan deltas — would cover
     every kind, the manual override, and this asymmetry together, but it
     needs the concurrency contract to learn about orphans.
-  - **`abortRun` strands its deltas when its own reversal fails.** The
-    marker now rides the reversal transaction on the success path, but
-    when reverse-replay throws, `abortRun`
-    (`lib/pipeline/runtime/orchestrator.ts`) still settles the marker
-    with `outcome: 'failed'`. `recoverInFlightRuns` selects on
-    `finished_at IS NULL`, so boot never sees that run and the
-    un-reversed writes are stranded with no retry at all — worse than the
-    boot path, which at least keeps trying. Leaving the marker open
-    instead would hand it to boot recovery, but it also re-opens a run
-    the user was told had finished; that trade has not been made.
 - **Story isolation leaks across files under
   `--fileParallelism=false`.** Serializing puts every story file in one
   page, and some app-level DOM state survives the file that set it.

--- a/docs/implementation/triage.md
+++ b/docs/implementation/triage.md
@@ -19,4 +19,15 @@ slice-planning gate forces its resolution before that slice is planned.
 
 ## Inbox
 
-_Empty._
+- **A boot recovery that fails to reverse leaves the branch runnable
+  against un-reversed writes.** `recoverInFlightRuns`
+  (`lib/pipeline/runtime/recovery.ts`) logs a per-orphan
+  `DeltaReplayError` and leaves the row for the next boot — correct on
+  its own, but `resetStuckClassifierRunState` runs immediately after
+  and flips `classifier_status` to idle regardless, so the classifier
+  can start a fresh pass over a window whose partial writes are still
+  on disk. That is the duplication the (now removed) crash-mid-burst
+  followup described, reachable only when recovery itself fails rather
+  than on any ordinary crash. Cross-cutting: the same gap lets any kind
+  re-run against its own un-reversed orphan. The code already carries a
+  TODO at the catch site. Raised 2026-08-24 disproving that followup.

--- a/docs/implementation/triage.md
+++ b/docs/implementation/triage.md
@@ -19,36 +19,6 @@ slice-planning gate forces its resolution before that slice is planned.
 
 ## Inbox
 
-- **An orphan that will not reverse is suspended, never resolved.**
-  Raised 2026-08-24 disproving the crash-mid-burst followup; the
-  classifier half is closed as of 2026-08-25.
-  `resetStuckClassifierRunState` now consumes the recovery pass's
-  failures and leaves a branch still holding their deltas `running`,
-  which suspends the cadence, so the automatic path can no longer
-  re-read a window whose partial writes are on disk. A second fix the
-  same day made the `pipeline_runs` marker settle inside the reversal's
-  own transaction: written separately, a failure between the two left the
-  deltas reversed and the orphan open, and the replay is not idempotent —
-  undoing a `create` deletes (repeatable) but undoing a `delete`
-  re-inserts (conflicts), so one transient error hardened into a
-  permanent one on every later boot. Failures now also reach the user
-  through the existing crash-recovery modal, which no longer titles
-  itself "Story recovered" when nothing was reversed. The one
-  unreversible-by-any-retry case, version skew, is parked as a non-issue
-  ([parked.md](../parked.md#a-delta-whose-target-table-left-the-registry-cannot-be-reversed)),
-  and `abortRun` now leaves its marker open when its own reversal fails
-  so boot recovery still owns those deltas. One gap survives:
-  - **The gate is keyed on the classifier having been mid-run, not on
-    the branch being hazardous.** A branch is only held back if its own
-    `classifier_status` was left `running`. When some other kind's
-    orphan fails to reverse and the classifier happened to be `idle`,
-    nothing holds the branch: the cadence fires over a window carrying
-    those un-reversed writes. `[Run classifier now]` bypasses the
-    suspension by design, and the other kinds are event-triggered with
-    no equivalent gate at all. One rule at run-start — refuse to start
-    any kind on a branch with un-reversed orphan deltas — would cover
-    every kind, the manual override, and this asymmetry together, but it
-    needs the concurrency contract to learn about orphans.
 - **Story isolation leaks across files under
   `--fileParallelism=false`.** Serializing puts every story file in one
   page, and some app-level DOM state survives the file that set it.

--- a/docs/parked.md
+++ b/docs/parked.md
@@ -835,6 +835,42 @@ Parked 2026-08-25 as a non-issue until a downgrade path exists; a
 `pipeline.recovery_failed` log naming `unknown target_table` in the
 field is the signal to revisit.
 
+#### The classifier can read a window holding un-reversed writes
+
+Boot holds a branch back from the cadence only when its own
+`classifier_status` was left `running`
+(`resetStuckClassifierRunState`). Another kind's failed reversal, on a
+branch whose classifier happened to be `idle`, holds nothing — so the
+cadence can fire over a window carrying those un-reversed writes.
+
+Benign in every reachable case, which is why it is parked rather than
+fixed:
+
+- **On the boot path it needs the version skew above.** Every other
+  reversal failure is transient and the next boot's retry clears it,
+  so the branch is either reconciled or already held back.
+- **In-session it needs a later successful turn.** The scheduler ticks
+  only on `kind === PER_TURN_KIND && outcome === 'completed'`, so the
+  failed run does not fire it.
+- **What is stranded is not duplicate material.** A failed reversal
+  leaves the aborted run's own entry and its piggyback facts on disk
+  _and_ on screen — the patchers never ran either, so the store keeps
+  the row too. The classifier then reading that prose is the ordinary
+  piggyback/classifier division of labour over a turn that, to the
+  user, happened. The real duplication case — the classifier re-reading
+  the window its own interrupted pass half-wrote — is covered.
+
+The obvious remedy is wrong and is recorded so it is not re-proposed:
+a run-start gate goes through `checkConcurrencyContract`, which gates
+**every** kind including `per-turn`, so it would block the user from
+submitting a turn to protect a background pass. A correct version has
+to be scoped to the kinds that re-derive from a window, and needs the
+concurrency contract to learn about orphans.
+
+Parked 2026-08-25 after the boot-recovery work closed the reachable
+half; duplicated happenings observed after a failed reversal are the
+signal to revisit.
+
 ### Memory pipeline (parked)
 
 Subsystem-scoped deferrals for the memory pipeline (retrieval,

--- a/docs/parked.md
+++ b/docs/parked.md
@@ -810,6 +810,31 @@ person to ask "why is this regression not warned about?" finds the
 answer. Revisit if flashbacks ever get their own marker.
 Raised 2026-08-15 by the Slice 3.8 Task 2 review.
 
+#### A delta whose target table left the registry cannot be reversed
+
+`reverseReplayDeltas` resolves `deltas.target_table` through the
+runtime registry and throws `unknown target_table` when it misses, so
+an orphan written by a build that carried a domain the running build
+does not is unreversible by any retry. Boot then holds that branch
+back from the classifier cadence indefinitely
+(`resetStuckClassifierRunState`), which is the safe direction but a
+permanent one. Reaching it requires running a build older than its own
+data — a downgrade, or a domain renamed without a migration. Not
+corruption, and not otherwise reachable: every other reversal failure
+is transient DB IO and self-heals on the next boot.
+
+The obvious remedy is wrong and is recorded here so it is not
+re-proposed: deleting the orphaned rows would erase undo history,
+since deltas **are** the undo stack (`undoLastAction` reads them
+through `selectUndoTarget`), while leaving the writes they describe on
+disk — the next ctrl-Z would then reverse an older action against a
+state it never saw. A real fix needs the registry to carry retired
+table descriptors, or the reversal to degrade to a row-level no-op.
+
+Parked 2026-08-25 as a non-issue until a downgrade path exists; a
+`pipeline.recovery_failed` log naming `unknown target_table` in the
+field is the signal to revisit.
+
 ### Memory pipeline (parked)
 
 Subsystem-scoped deferrals for the memory pipeline (retrieval,

--- a/docs/ui/screens/wizard/wizard.html
+++ b/docs/ui/screens/wizard/wizard.html
@@ -172,6 +172,9 @@
   /* chip input */
   .chip-input { display: flex; flex-wrap: wrap; gap: 4px; padding: 4px 6px; border: 1px solid var(--line); border-radius: 4px; background: var(--bg-region); min-height: 28px; align-items: center; }
   .chip { font-size: 11px; padding: 2px 8px; background: var(--bg-faint); border: 1px solid var(--line-soft); border-radius: 12px; color: var(--ink); display: inline-flex; align-items: center; gap: 4px; }
+  .chip.selected { background: var(--ink); border-color: var(--ink); color: #fff; }
+  .scene-tags { margin-top: 10px; display: grid; grid-template-columns: 96px 1fr; gap: 8px 12px; align-items: center; }
+  .scene-tags .chip-row { display: flex; flex-wrap: wrap; gap: 4px; }
   .chip .chip-x { color: var(--ink-muted); cursor: pointer; font-size: 11px; }
   .chip-input .chip-input-typer { flex: 1; min-width: 80px; border: none; outline: none; padding: 3px 4px; font-size: 12px; font-family: inherit; background: transparent; color: var(--ink); }
   .chip-cap-warn { font-size: 10px; color: var(--warn); margin-top: 2px; }
@@ -709,6 +712,8 @@
           <div class="ai-result">
             <div class="ai-result-title"><span class="sparkle">✨</span> Suggested opening</div>
             <div class="ai-preview">The bell of the abbey tolled twice as Aria reached the tree line. Snow lay thick on the broken road, and the wind smelled of old smoke. Below, the keep's torches flickered against the dusk — too few, she thought, for a household preparing supper.</div>
+            <!-- Read-only here: generation's proposal until the prose is
+                 accepted; editable in the committed state below. -->
             <div class="ai-meta">
               <strong>Scene metadata:</strong><br>
               Cast in scene: Aria Stoneheart<br>
@@ -726,7 +731,22 @@
         <!-- Committed state (variant: opening-committed) -->
         <div id="opening-committed" class="hidden">
           <div class="opening-preview" contenteditable="true">The bell of the abbey tolled twice as Aria reached the tree line. Snow lay thick on the broken road, and the wind smelled of old smoke. Below, the keep's torches flickered against the dusk — too few, she thought, for a household preparing supper.</div>
-          <div class="ai-meta" style="margin-top: 8px;">Scene metadata: Aria Stoneheart · Mornstone Keep</div>
+          <!-- Authored on both paths: generation seeds these, the user corrects
+               them in place. Chips keep the names legible, which is what the
+               older read-only line was for. -->
+          <div class="scene-tags">
+            <span class="field-label">Cast in scene</span>
+            <div class="chip-row">
+              <span class="chip selected">Aria Stoneheart</span>
+              <span class="chip">Bran</span>
+              <span class="chip">Old Jorin</span>
+            </div>
+            <span class="field-label">Location</span>
+            <div class="segment">
+              <div class="seg">Not set</div>
+              <div class="seg active">Mornstone Keep</div>
+            </div>
+          </div>
         </div>
       </div>
 

--- a/docs/ui/screens/wizard/wizard.md
+++ b/docs/ui/screens/wizard/wizard.md
@@ -623,12 +623,16 @@ at import, which separates two states the user acts on differently:
 _not in your cast_ (import the named row, or pick another) and _in
 your cast, not attached_ (assign it in the editor). Importing the
 named row afterwards therefore downgrades the warning with no
-re-import. Re-checking follows the same active-and-kind rule as
-resolution itself, so nothing is offered that commit would drop.
-Assigning the field — including back to `null` — clears the
-remembered ask, so a decision the user has already made cannot
-resurrect the warning. The ask is wizard-draft state only; Finish
-projects named columns and never carries it to an entity.
+re-import. Re-checking applies the same name-and-kind rule as
+resolution itself, status included: a staged row is in the cast, the
+editor's picker offers it, and Finish commits the pointer, so
+reporting it as missing would be false. Whether an active character
+belongs to a faction the story has yet to introduce is an authoring
+question left to the user. Assigning the field — including back to
+`null` — clears the remembered ask, so a decision the user has
+already made cannot resurrect the warning. The ask is wizard-draft
+state only; Finish projects named columns and never carries it to an
+entity.
 
 ### Lead-required gating
 

--- a/docs/ui/screens/wizard/wizard.md
+++ b/docs/ui/screens/wizard/wizard.md
@@ -665,9 +665,11 @@ Scene metadata:
 
 The metadata block surfaces structured-output refs
 (`sceneEntities`, `currentLocationId`) emitted by wizard-assist,
-resolved to entity names. Read-only — generation owns the refs.
-Constrained to **active** wizard-curated cast; prose can mention
-unbacked or staged names freely.
+resolved to entity names. Read-only **in the preview** — the refs
+are generation's proposal until the prose is accepted; they become
+editable in the committed state below. Constrained to **active**
+wizard-curated cast; prose can mention unbacked or staged names
+freely.
 
 #### Committed prose (after `Use this` OR after manual typing)
 
@@ -676,21 +678,41 @@ Opening                                            [✨]
 
 [textarea, editable, contains the prose]
 
-Scene metadata: Aria Stoneheart · Mornstone Keep
-  (visible only if AI-generated; user-written = empty)
+Cast in scene   [Aria Stoneheart] [Bran] [Old Jorin]
+Location        ( Not set | Mornstone Keep )
 ```
+
+**Scene tagging is authored, on both paths.** A generated opening
+seeds the two controls through structured output; a user-written
+one starts empty and can be tagged by hand. Toggle chips carry the
+active characters and items — names stay legible at a glance, which
+is what the older read-only line was for — and the location is a
+single-select whose control shape follows the usual option-count
+rule. Both slots degrade to guidance text when the Cast step has no
+candidate of that kind.
+
+Candidates are **active** and kind-filtered to match the filter
+Finish commits through, so nothing offered here is dropped on the
+way to `story_entries.metadata`, and a ref that fails that filter (a
+since-staged row, or a character id in the location slot) reads as
+unset rather than rendering a name in the wrong slot.
+
+Tagging writes metadata only. It never sets `metadata.model`, which
+stays the authorship discriminator per
+[`data-model.md → Opening entry`](../../../data-model.md#opening-entry).
 
 User edits prose freely after committing. Editing AI-generated
 prose does **not** clear metadata refs — refs stay intact (user
 might tweak prose without invalidating cast/location grounding).
-For fresh metadata, user regenerates via `✨`.
+For fresh metadata, the user regenerates via `✨` or corrects the
+refs in place, which is the remedy that keeps prose edits.
 
 The same rule covers a back-jump to Cast that reassigns the lead
-after generation: `sceneEntities` isn't re-derived, so the metadata
-line keeps resolving names from whoever it already references (the
-prior lead included) rather than going blank or auto-clearing. It's
-model-authored scene metadata, not an authored field — same
-resolution path as any other stale ref, regenerate via `✨`.
+after generation: `sceneEntities` isn't re-derived, so the controls
+keep resolving whoever they already reference (the prior lead
+included) rather than going blank or auto-clearing. A ref that no
+longer resolves is simply not offered, and drops on the next
+explicit edit — the user authoring, not an auto-clear.
 
 `✨` stays available in the committed state as the regenerate /
 refine entry point, per

--- a/docs/ui/screens/wizard/wizard.md
+++ b/docs/ui/screens/wizard/wizard.md
@@ -616,6 +616,20 @@ mean they have none rather than that the AI's answer was dropped.
 A reference the model simply omitted is not counted — only one it
 supplied and the wizard could not honour.
 
+The toast is transient, so the **row keeps the ask** and warns
+inline in the compact list until the field is decided. The name is
+re-checked against the live cast on every render rather than frozen
+at import, which separates two states the user acts on differently:
+_not in your cast_ (import the named row, or pick another) and _in
+your cast, not attached_ (assign it in the editor). Importing the
+named row afterwards therefore downgrades the warning with no
+re-import. Re-checking follows the same active-and-kind rule as
+resolution itself, so nothing is offered that commit would drop.
+Assigning the field — including back to `null` — clears the
+remembered ask, so a decision the user has already made cannot
+resurrect the warning. The ask is wizard-draft state only; Finish
+projects named columns and never carries it to an entity.
+
 ### Lead-required gating
 
 - **Trigger** (set in step 1): `mode='adventure'` OR

--- a/lib/actions/classifier/deps.test.ts
+++ b/lib/actions/classifier/deps.test.ts
@@ -1,7 +1,7 @@
 import { eq } from 'drizzle-orm'
 import { describe, expect, it } from 'vitest'
 
-import { branches, stories, storyEntries, type ClassifierStatus } from '@/lib/db'
+import { branches, deltas, stories, storyEntries, type ClassifierStatus } from '@/lib/db'
 import { createTestDb } from '@/lib/db/__tests__/test-db'
 
 import { resetStuckClassifierRunState, unprocessedTurnCount } from './deps'
@@ -17,6 +17,27 @@ async function seed(
     name: branchId,
     createdAt: 1,
     classifierStatus,
+  })
+}
+
+async function seedDelta(
+  db: Awaited<ReturnType<typeof createTestDb>>['db'],
+  branchId: string,
+  actionId: string,
+) {
+  await db.insert(deltas).values({
+    id: `d_${branchId}_${actionId}`,
+    branchId,
+    entryId: null,
+    actionId,
+    logPosition: 1,
+    source: 'ai_classifier',
+    targetTable: 'happenings',
+    targetId: 'hap_1',
+    op: 'create',
+    undoPayload: null,
+    encodingVersion: 1,
+    createdAt: 1,
   })
 }
 
@@ -44,7 +65,7 @@ describe('resetStuckClassifierRunState', () => {
     }
     await seed(db, 'b1', running)
 
-    await resetStuckClassifierRunState({ db, runInTransaction })
+    await resetStuckClassifierRunState({ db, runInTransaction }, [])
 
     expect(await readStatus(db, 'b1')).toEqual({ ...running, state: 'idle' })
   })
@@ -69,7 +90,7 @@ describe('resetStuckClassifierRunState', () => {
     await seed(db, 'b-retrying', retrying)
     await seed(db, 'b-failed', failedPersistent)
 
-    await resetStuckClassifierRunState({ db, runInTransaction })
+    await resetStuckClassifierRunState({ db, runInTransaction }, [])
 
     expect(await readStatus(db, 'b-retrying')).toEqual(retrying)
     expect(await readStatus(db, 'b-failed')).toEqual(failedPersistent)
@@ -80,9 +101,49 @@ describe('resetStuckClassifierRunState', () => {
     await db.insert(stories).values({ id: 's1', title: 'T', createdAt: 1, updatedAt: 1 })
     await seed(db, 'b-null', null)
 
-    await resetStuckClassifierRunState({ db, runInTransaction })
+    await resetStuckClassifierRunState({ db, runInTransaction }, [])
 
     expect(await readStatus(db, 'b-null')).toBeNull()
+  })
+
+  it('leaves a branch holding an unreversed orphan running, reconciling its peers', async () => {
+    const { db, runInTransaction } = await createTestDb()
+    await db.insert(stories).values({ id: 's1', title: 'T', createdAt: 1, updatedAt: 1 })
+    const running: ClassifierStatus = {
+      state: 'running',
+      lastSuccessAt: null,
+      lastError: null,
+      retryCount: 0,
+      processedThrough: 4,
+    }
+    await seed(db, 'b-hazard', running)
+    await seed(db, 'b-clean', running)
+    await seedDelta(db, 'b-hazard', 'act_failed')
+    // A second branch's orphan that DID reverse: its id is absent from the argument,
+    // so its surviving deltas must not quarantine it.
+    await seedDelta(db, 'b-clean', 'act_reversed')
+
+    await resetStuckClassifierRunState({ db, runInTransaction }, ['act_failed'])
+
+    expect(await readStatus(db, 'b-hazard')).toEqual(running)
+    expect(await readStatus(db, 'b-clean')).toEqual({ ...running, state: 'idle' })
+  })
+
+  it('reconciles a failed orphan that left no deltas behind', async () => {
+    const { db, runInTransaction } = await createTestDb()
+    await db.insert(stories).values({ id: 's1', title: 'T', createdAt: 1, updatedAt: 1 })
+    const running: ClassifierStatus = {
+      state: 'running',
+      lastSuccessAt: null,
+      lastError: null,
+      retryCount: 0,
+      processedThrough: 4,
+    }
+    await seed(db, 'b1', running)
+
+    await resetStuckClassifierRunState({ db, runInTransaction }, ['act_no_deltas'])
+
+    expect(await readStatus(db, 'b1')).toEqual({ ...running, state: 'idle' })
   })
 
   it('leaves an idle branch alone (no-op, not just a matching outcome)', async () => {
@@ -97,7 +158,7 @@ describe('resetStuckClassifierRunState', () => {
     }
     await seed(db, 'b-idle', idle)
 
-    await resetStuckClassifierRunState({ db, runInTransaction })
+    await resetStuckClassifierRunState({ db, runInTransaction }, [])
 
     expect(await readStatus(db, 'b-idle')).toEqual(idle)
   })

--- a/lib/actions/classifier/deps.ts
+++ b/lib/actions/classifier/deps.ts
@@ -1,7 +1,7 @@
 import { and, eq, gt, ne, sql } from 'drizzle-orm'
 
 import { IDLE_STATUS_JSON, idleStatus, nextStatusOnFailure } from '@/lib/classifier'
-import { branches, storyEntries, type ClassifierStatus, type DbCtx } from '@/lib/db'
+import { branches, deltas, storyEntries, type ClassifierStatus, type DbCtx } from '@/lib/db'
 import { embedTexts, type EmbedderConfig } from '@/lib/embedder'
 import { appSettingsStore, currentStoryStore } from '@/lib/stores'
 
@@ -88,11 +88,32 @@ export async function recordClassifierPreflightFailure(
  * Boot-time orphan reconciliation: a branch left `state: 'running'` was owned by a
  * process that no longer exists. Scoped to `$.state` and to 'running' only —
  * 'retrying' / 'failed-persistent' are real errors the manual run must surface.
+ *
+ * `unreversedActionIds` are the orphans boot could not reverse-replay. A branch
+ * still holding their deltas is NOT reconcilable, so it keeps `running`, which
+ * already suspends the cadence — reconciling it would let the classifier re-read a
+ * window whose partial writes are still on disk. The boot that finally reverses
+ * them drops the branch from this set and reconciles it normally; `[Run classifier
+ * now]` overrides in the meantime, which is the user's call to make.
  */
-export async function resetStuckClassifierRunState(ctx: DbCtx): Promise<void> {
+export async function resetStuckClassifierRunState(
+  ctx: DbCtx,
+  unreversedActionIds: readonly string[],
+): Promise<void> {
+  // Keyed on surviving deltas, not on the failure alone: the boot path reverses
+  // without pruning, so a failure that left nothing behind (the marker write threw
+  // after a clean reversal) correctly reconciles.
+  const quarantine =
+    unreversedActionIds.length === 0
+      ? sql``
+      : sql` AND ${branches.id} NOT IN (SELECT ${deltas.branchId} FROM ${deltas}
+              WHERE ${deltas.actionId} IN (${sql.join(
+                unreversedActionIds.map((id) => sql`${id}`),
+                sql`, `,
+              )}))`
   await ctx.db.run(
     sql`UPDATE ${branches}
         SET classifier_status = json_set(classifier_status, '$.state', 'idle')
-        WHERE json_extract(classifier_status, '$.state') = 'running'`,
+        WHERE json_extract(classifier_status, '$.state') = 'running'${quarantine}`,
   )
 }

--- a/lib/actions/delta/reverse-replay.test.ts
+++ b/lib/actions/delta/reverse-replay.test.ts
@@ -175,6 +175,38 @@ describe('reverseReplayDeltas', () => {
     expect(await reverseReplayDeltas('act_none', { db, runInTransaction })).toBe(0)
   })
 
+  it('runs settleOps even when the action has no deltas left to reverse', async () => {
+    const { db, runInTransaction } = await createTestDb()
+    await seed(db)
+    await db.insert(stories).values({ id: 's-settle', title: 'X', createdAt: 1, updatedAt: 1 })
+
+    const count = await reverseReplayDeltas('act_none', { db, runInTransaction }, () => [
+      db.delete(stories).where(eq(stories.id, 's-settle')).toSQL(),
+    ])
+
+    expect(count).toBe(0)
+    expect(await db.select().from(stories).where(eq(stories.id, 's-settle'))).toHaveLength(0)
+  })
+
+  it('rolls the reversal back when a settleOp fails, so a retry meets untouched deltas', async () => {
+    const { db, runInTransaction } = await createTestDb()
+    const ctx = { db, runInTransaction }
+    await seed(db)
+    await createKnight(ctx, 'act_rev')
+    expect(await knightRow(db)).toBeDefined()
+
+    await expect(
+      reverseReplayDeltas('act_rev', ctx, () => [
+        { sql: 'UPDATE no_such_table SET x = 1', params: [] },
+      ]),
+    ).rejects.toThrow()
+
+    // Undoing a create deletes the row; the failed settle must have taken that with
+    // it, or the next attempt reverses an already-reversed action.
+    expect(await knightRow(db)).toBeDefined()
+    expect(await db.select().from(deltas).where(eq(deltas.actionId, 'act_rev'))).toHaveLength(1)
+  })
+
   it('reverses a single update with the row surviving (positive restore)', async () => {
     const { db, runInTransaction } = await createTestDb()
     const ctx = { db, runInTransaction }

--- a/lib/actions/delta/reverse-replay.ts
+++ b/lib/actions/delta/reverse-replay.ts
@@ -181,17 +181,30 @@ export async function reverseAndPruneDeltaRows(
   return rows.length
 }
 
-export async function reverseReplayDeltas(actionId: string, ctx: DbCtx): Promise<number> {
+/**
+ * `settleOps` commits caller ops in the SAME transaction as the reversal, keyed on
+ * the delta count so the caller can branch on it. Recovery uses it for the
+ * `pipeline_runs` marker: written separately, a failure between the two leaves the
+ * deltas reversed but the orphan open, and the next boot's replay is not idempotent
+ * — undoing a `create` deletes (repeatable), undoing a `delete` re-inserts (conflicts),
+ * so a transient error would harden into a permanent one.
+ */
+export async function reverseReplayDeltas(
+  actionId: string,
+  ctx: DbCtx,
+  settleOps: (deltaCount: number) => readonly SqlOp[] = () => [],
+): Promise<number> {
   try {
     const rows = (await ctx.db
       .select()
       .from(deltas)
       .where(eq(deltas.actionId, actionId))
       .orderBy(desc(deltas.logPosition))) as Delta[]
-    if (rows.length === 0) return 0
+    const settle = settleOps(rows.length)
+    if (rows.length === 0 && settle.length === 0) return 0
 
     const { ops, patches } = await buildUndoOps(rows, ctx)
-    await ctx.runInTransaction(ops)
+    await ctx.runInTransaction([...ops, ...settle])
     // Action layer owns the patch: invert in the held-branch store after the tx.
     for (const p of patches) resolveByTable(p.table)?.patcher?.(p.branchId, p.patch)
     return rows.length

--- a/lib/boot/bootstrap.test.ts
+++ b/lib/boot/bootstrap.test.ts
@@ -90,7 +90,7 @@ describe('runBootstrap', () => {
     expect(recoveryReportStore.getSnapshot().pendingRecoveryReport).toBeNull()
   })
 
-  it('a per-orphan reversal failure does not block boot or publish a report', async () => {
+  it('a per-orphan reversal failure does not block boot, and is reported', async () => {
     await seedRow()
     await ctx.db.insert(stories).values({ id: 's1', title: 'T', createdAt: 1, updatedAt: 1 })
     await ctx.db.insert(branches).values({ id: 'b1', storyId: 's1', name: 'm', createdAt: 1 })
@@ -121,7 +121,11 @@ describe('runBootstrap', () => {
     const r = await runBootstrap(ctx)
 
     expect(r).toEqual({ status: 'ok' })
-    expect(recoveryReportStore.getSnapshot().pendingRecoveryReport).toBeNull()
+    // The orphan's writes are still on disk, so the user is told rather than left
+    // with a silently degraded story.
+    const published = recoveryReportStore.getSnapshot().pendingRecoveryReport
+    expect(published?.reversed).toEqual([])
+    expect(published?.failures).toMatchObject([{ runId: 'r-failed', storyId: 's1' }])
   })
 
   // Guards the load-bearing registerAllDomains()-before-recovery order. Simulate a

--- a/lib/boot/bootstrap.ts
+++ b/lib/boot/bootstrap.ts
@@ -21,6 +21,7 @@ import {
   PER_TURN_KIND,
   pipelineEventBus,
   recoverInFlightRuns,
+  type RecoveryReport,
 } from '@/lib/pipeline'
 import {
   appSettingsStore,
@@ -117,9 +118,10 @@ export async function runBootstrap(ctx: DbCtx): Promise<BootHydrateResult> {
   wireClassifierScheduler(ctx)
   // Recovery must never block boot: a failure of the orphan pass itself (not just
   // a per-orphan delta) is logged and boot proceeds to hydrate.
+  let recovery: RecoveryReport | null = null
   try {
-    const report = await recoverInFlightRuns(ctx)
-    if (report.reversed.length > 0) recoveryReportStore.publish(report)
+    recovery = await recoverInFlightRuns(ctx)
+    recoveryReportStore.publish(recovery)
   } catch (err) {
     logger.error('bootstrap.recovery_failed', {
       error: err instanceof Error ? err.message : String(err),
@@ -128,13 +130,20 @@ export async function runBootstrap(ctx: DbCtx): Promise<BootHydrateResult> {
   // A branch's own orphan: state: 'running' outlived the process that wrote it.
   // Separate from recoverInFlightRuns (pipeline_runs markers) because
   // classifier_status is a branches column with no marker row of its own — and
-  // unlike a marker's deltas, there is nothing here to reverse-replay.
-  try {
-    await resetStuckClassifierRunState(ctx)
-  } catch (err) {
-    logger.error('bootstrap.classifier_running_reset_failed', {
-      error: err instanceof Error ? err.message : String(err),
-    })
+  // unlike a marker's deltas, there is nothing here to reverse-replay. Ordered
+  // after recovery because which branches are reconcilable depends on which
+  // orphans reversed; with no report at all, none of them are.
+  if (recovery !== null) {
+    try {
+      await resetStuckClassifierRunState(
+        ctx,
+        recovery.failures.map((f) => f.actionId),
+      )
+    } catch (err) {
+      logger.error('bootstrap.classifier_running_reset_failed', {
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
   }
   // ctx.db (not the module-level default) so recovery and hydrate hit the
   // same instance.

--- a/lib/db/wizard-sessions/working-state.test.ts
+++ b/lib/db/wizard-sessions/working-state.test.ts
@@ -120,12 +120,15 @@ describe('cast drafts', () => {
       traits: [],
       drives: [],
       factionId: null,
+      // The remembered import ask starts empty: a hand-added row never had one.
+      unresolvedFactionName: '',
       tags: [],
       visual: { physique: '', face: '', hair: '', eyes: '', attire: '', distinguishing: '' },
     })
     expect(emptyCastDraft('location', 'loc_1')).toMatchObject({
       kind: 'location',
       parentLocationId: null,
+      unresolvedParentLocationName: '',
       condition: '',
     })
     expect(emptyCastDraft('item', 'item_1')).toMatchObject({ kind: 'item', condition: '' })

--- a/lib/db/wizard-sessions/working-state.ts
+++ b/lib/db/wizard-sessions/working-state.ts
@@ -67,9 +67,8 @@ const characterCastDraftSchema = z.object({
   visual: castVisualDraftSchema.default(() => castVisualDraftSchema.parse({})),
   factionId: z.string().nullable().default(null),
   /**
-   * The faction name an import asked for that resolved to no row, kept so the
-   * list can re-check it against the live cast instead of the drop being
-   * visible only as an empty picker. Cleared once the user assigns the field.
+   * The faction name an import asked for that resolved to no row, kept so the list
+   * can re-check it against the live cast. Cleared once the user assigns the field.
    * Wizard-only: Finish projects named columns, so it never reaches an entity.
    */
   unresolvedFactionName: z.string().default(''),

--- a/lib/db/wizard-sessions/working-state.ts
+++ b/lib/db/wizard-sessions/working-state.ts
@@ -66,6 +66,13 @@ const characterCastDraftSchema = z.object({
   drives: z.array(z.string()).default(() => []),
   visual: castVisualDraftSchema.default(() => castVisualDraftSchema.parse({})),
   factionId: z.string().nullable().default(null),
+  /**
+   * The faction name an import asked for that resolved to no row, kept so the
+   * list can re-check it against the live cast instead of the drop being
+   * visible only as an empty picker. Cleared once the user assigns the field.
+   * Wizard-only: Finish projects named columns, so it never reaches an entity.
+   */
+  unresolvedFactionName: z.string().default(''),
 })
 
 const locationCastDraftSchema = z.object({
@@ -73,6 +80,8 @@ const locationCastDraftSchema = z.object({
   kind: z.literal('location'),
   parentLocationId: z.string().nullable().default(null),
   condition: z.string().default(''),
+  /** Parent-location counterpart of `unresolvedFactionName`. */
+  unresolvedParentLocationName: z.string().default(''),
 })
 
 const itemCastDraftSchema = z.object({

--- a/lib/pipeline/__tests__/classifier-burst-recovery.test.ts
+++ b/lib/pipeline/__tests__/classifier-burst-recovery.test.ts
@@ -6,13 +6,9 @@ import { recoverInFlightRuns } from '@/lib/pipeline'
 
 import { makeHarness, resetSingletons } from './harness'
 
-// A periodic-classifier burst yields each planned write separately and the
-// orchestrator commits each as its own delta, advancing the watermark only
-// after the last one. A crash in between therefore leaves committed happenings
-// behind an unmoved watermark, and the next pass re-reads the same window.
-// What keeps that from duplicating them is the run's pipeline_runs marker:
-// beginRun writes one for every kind, and boot's recoverInFlightRuns
-// reverse-replays every delta sharing the orphan's action_id.
+// A crashed burst leaves committed happenings behind an unmoved watermark, so the
+// next pass re-reads the same window. The pipeline_runs marker is what stops a
+// duplicate: boot reverse-replays every delta sharing the orphan's action_id.
 describe('a crashed classifier burst', () => {
   beforeEach(() => resetSingletons())
   afterEach(() => resetSingletons())

--- a/lib/pipeline/__tests__/classifier-burst-recovery.test.ts
+++ b/lib/pipeline/__tests__/classifier-burst-recovery.test.ts
@@ -1,7 +1,8 @@
+import { eq } from 'drizzle-orm'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { registerAllDomains } from '@/lib/actions'
-import { deltas, happenings, pipelineRuns } from '@/lib/db'
+import { registerAllDomains, resetStuckClassifierRunState } from '@/lib/actions'
+import { branches, deltas, happenings, pipelineRuns, type ClassifierStatus } from '@/lib/db'
 import { recoverInFlightRuns } from '@/lib/pipeline'
 
 import { makeHarness, resetSingletons } from './harness'
@@ -64,5 +65,74 @@ describe('a crashed classifier burst', () => {
     const [marker] = await db.select().from(pipelineRuns)
     expect(marker.outcome).toBe('recovered')
     expect(marker.finishedAt).not.toBeNull()
+  })
+
+  // The mirror: when the reversal itself fails the window is NOT clean, so the
+  // branch must not be handed back to the cadence — 'running' is what suspends it.
+  it('stays un-reconciled when its deltas could not be reversed', async () => {
+    const { db, ctx } = await makeHarness()
+    registerAllDomains()
+
+    const running: ClassifierStatus = {
+      state: 'running',
+      lastSuccessAt: null,
+      lastError: null,
+      retryCount: 0,
+      processedThrough: 4,
+    }
+    await db.update(branches).set({ classifierStatus: running }).where(eq(branches.id, 'b1'))
+    await db.insert(pipelineRuns).values({
+      runId: 'run_classifier',
+      kind: 'periodic-classifier',
+      actionId: 'act_burst',
+      storyId: 's1',
+      startedAt: 1,
+    })
+    await db.insert(happenings).values({
+      id: 'hap_1',
+      branchId: 'b1',
+      title: 'landed',
+      commonKnowledge: 0,
+      createdAt: 1,
+      updatedAt: 1,
+    })
+    // target_table is free text resolved through the runtime registry, so an
+    // unregistered name is the cheapest real reverse-replay failure.
+    await db.insert(deltas).values({
+      id: 'delta_unreversible',
+      branchId: 'b1',
+      entryId: null,
+      actionId: 'act_burst',
+      logPosition: 1,
+      source: 'ai_classifier',
+      targetTable: 'not_a_registered_table',
+      targetId: 'hap_1',
+      op: 'create',
+      undoPayload: null,
+      encodingVersion: 1,
+      createdAt: 1,
+    })
+
+    const report = await recoverInFlightRuns(ctx)
+
+    expect(report.reversed).toHaveLength(0)
+    expect(report.failures).toHaveLength(1)
+    expect(report.failures[0]).toMatchObject({ kind: 'periodic-classifier', actionId: 'act_burst' })
+    // Left for the next boot to retry rather than settled.
+    const [marker] = await db.select().from(pipelineRuns)
+    expect(marker.finishedAt).toBeNull()
+    // The partial write survived, which is exactly why the branch cannot re-run.
+    expect(await db.select().from(happenings)).toHaveLength(1)
+
+    await resetStuckClassifierRunState(
+      ctx,
+      report.failures.map((f) => f.actionId),
+    )
+
+    const [branch] = await db
+      .select({ classifierStatus: branches.classifierStatus })
+      .from(branches)
+      .where(eq(branches.id, 'b1'))
+    expect(branch.classifierStatus).toEqual(running)
   })
 })

--- a/lib/pipeline/__tests__/classifier-burst-recovery.test.ts
+++ b/lib/pipeline/__tests__/classifier-burst-recovery.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { registerAllDomains } from '@/lib/actions'
+import { deltas, happenings, pipelineRuns } from '@/lib/db'
+import { recoverInFlightRuns } from '@/lib/pipeline'
+
+import { makeHarness, resetSingletons } from './harness'
+
+// A periodic-classifier burst yields each planned write separately and the
+// orchestrator commits each as its own delta, advancing the watermark only
+// after the last one. A crash in between therefore leaves committed happenings
+// behind an unmoved watermark, and the next pass re-reads the same window.
+// What keeps that from duplicating them is the run's pipeline_runs marker:
+// beginRun writes one for every kind, and boot's recoverInFlightRuns
+// reverse-replays every delta sharing the orphan's action_id.
+describe('a crashed classifier burst', () => {
+  beforeEach(() => resetSingletons())
+  afterEach(() => resetSingletons())
+
+  it('has its committed happenings reversed at boot, so a re-run cannot duplicate them', async () => {
+    const { db, ctx } = await makeHarness()
+    registerAllDomains()
+
+    await db.insert(pipelineRuns).values({
+      runId: 'run_classifier',
+      kind: 'periodic-classifier',
+      actionId: 'act_burst',
+      storyId: 's1',
+      startedAt: 1,
+    })
+
+    // Two of the burst's happenings landed before the crash; the third never did.
+    for (const [i, id] of ['hap_1', 'hap_2'].entries()) {
+      await db.insert(happenings).values({
+        id,
+        branchId: 'b1',
+        title: `landed ${id}`,
+        commonKnowledge: 0,
+        createdAt: 1,
+        updatedAt: 1,
+      })
+      await db.insert(deltas).values({
+        id: `delta_${id}`,
+        branchId: 'b1',
+        entryId: null,
+        actionId: 'act_burst',
+        logPosition: i + 1,
+        source: 'ai_classifier',
+        targetTable: 'happenings',
+        targetId: id,
+        op: 'create',
+        undoPayload: null,
+        encodingVersion: 1,
+        createdAt: 1,
+      })
+    }
+
+    expect(await db.select().from(happenings)).toHaveLength(2)
+
+    const report = await recoverInFlightRuns(ctx)
+
+    expect(report.failures).toHaveLength(0)
+    expect(report.reversed).toHaveLength(1)
+    expect(report.reversed[0]).toMatchObject({ kind: 'periodic-classifier', deltas: 2 })
+    // The window is clean before the watermark re-reads it: nothing to duplicate.
+    expect(await db.select().from(happenings)).toHaveLength(0)
+    // The marker is settled, so a second boot cannot reverse the burst twice.
+    const [marker] = await db.select().from(pipelineRuns)
+    expect(marker.outcome).toBe('recovered')
+    expect(marker.finishedAt).not.toBeNull()
+  })
+})

--- a/lib/pipeline/__tests__/orchestrator-hardening.test.ts
+++ b/lib/pipeline/__tests__/orchestrator-hardening.test.ts
@@ -4,7 +4,13 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { type PipelineAction } from '@/lib/actions'
 import { deltas, entities, pipelineRuns, storyEntries } from '@/lib/db'
 import { getDiagnosticsSnapshot } from '@/lib/diagnostics'
-import { definePipeline, runPipeline, type PhaseResult } from '@/lib/pipeline'
+import {
+  definePipeline,
+  recoverInFlightRuns,
+  runPipeline,
+  type PhaseContext,
+  type PhaseResult,
+} from '@/lib/pipeline'
 import { generationStore } from '@/lib/stores'
 
 import { expectRan, makeHarness, resetSingletons } from './harness'
@@ -174,6 +180,54 @@ describe('orchestrator hardening', () => {
     expect(
       getDiagnosticsSnapshot().logEntries.some((e) => e.kind === 'pipeline.marker_write_failed'),
     ).toBe(true)
+  })
+
+  // The deltas an aborted run could not reverse are still on disk. Settling the
+  // marker would hide them from recoverInFlightRuns, which selects on
+  // finished_at IS NULL — the only retry they ever get.
+  it('leaves an unreversible abort open so boot recovery still owns it', async () => {
+    const { db, ctx } = await makeHarness()
+    definePipeline({
+      kind: 'poisoned',
+      phases: [
+        {
+          name: 'p',
+          run: async function* (phase: PhaseContext) {
+            // target_table is free text resolved through the runtime registry, so an
+            // unregistered name makes this run's own reversal throw for real.
+            await phase.db.insert(deltas).values({
+              id: 'd_poison',
+              branchId: 'b1',
+              entryId: null,
+              actionId: phase.actionId,
+              logPosition: 900,
+              source: 'ai_classifier',
+              targetTable: 'not_a_registered_table',
+              targetId: 'x',
+              op: 'create',
+              undoPayload: null,
+              encodingVersion: 1,
+              createdAt: 1,
+            })
+            return {
+              status: 'failed',
+              error: { kind: 'phase-logic', detail: 'poisoned' },
+            } as PhaseResult
+          },
+        },
+      ],
+      ...base,
+    })
+
+    const result = expectRan(await runPipeline('poisoned', ctx))
+    expect(result.outcome).toBe('failed')
+    expect(generationStore.getTxState().runs.size).toBe(0)
+
+    // Open, not settled — the poison delta survived and boot must still see it.
+    const [marker] = await db.select().from(pipelineRuns)
+    expect(marker.finishedAt).toBeNull()
+    const report = await recoverInFlightRuns(ctx)
+    expect(report.failures).toHaveLength(1)
   })
 
   it('a marker-write failure on abort finishes cleanly without leaking state', async () => {

--- a/lib/pipeline/runtime/action-port.ts
+++ b/lib/pipeline/runtime/action-port.ts
@@ -1,12 +1,16 @@
 import type { MutationResult, PipelineAction } from '@/lib/actions/types'
-import type { DbCtx } from '@/lib/db'
+import type { DbCtx, SqlOp } from '@/lib/db'
 
 export type DeltaActionPort = {
   applyDeltaAction: (
     args: { action: PipelineAction; actionId: string; branchId: string; entryId?: string | null },
     ctx: DbCtx,
   ) => Promise<MutationResult>
-  reverseReplayDeltas: (actionId: string, ctx: DbCtx) => Promise<number>
+  reverseReplayDeltas: (
+    actionId: string,
+    ctx: DbCtx,
+    settleOps?: (deltaCount: number) => readonly SqlOp[],
+  ) => Promise<number>
   // Returns the reversal-failure detail when `e` is a committed-aware
   // DeltaReplayError, or undefined for any other thrown value.
   describeReplayError: (e: unknown) => string | undefined

--- a/lib/pipeline/runtime/orchestrator.ts
+++ b/lib/pipeline/runtime/orchestrator.ts
@@ -300,28 +300,35 @@ async function abortRun(
   run.abortController.abort()
   let outcome: 'aborted' | 'failed' = cause.reason === 'user-cancel' ? 'aborted' : 'failed'
   let error = cause.error
+  const markerOp = (settled: 'aborted' | 'failed') =>
+    ctx.db
+      .update(pipelineRuns)
+      .set({ finishedAt: Date.now(), outcome: settled })
+      .where(eq(pipelineRuns.runId, run.runId))
+  let reversalFailed = false
   try {
-    await reverseReplayDeltas(run.actionId, ctx)
+    // The marker rides the reversal's transaction: settled separately, a failure
+    // between the two strands an open orphan over reversed deltas, and boot's
+    // replay is not idempotent — undoing a `delete` re-inserts and conflicts.
+    await reverseReplayDeltas(run.actionId, ctx, () => [markerOp(outcome).toSQL()])
   } catch (e) {
     const detail = describeReplayError(e)
     if (detail === undefined) throw e
     error = { kind: 'orchestrator', detail: `reverse-replay failed: ${detail}` }
     outcome = 'failed'
+    reversalFailed = true
   }
   generationStore.abortRun(run.runId)
-  try {
-    await ctx.db
-      .update(pipelineRuns)
-      .set({ finishedAt: Date.now(), outcome })
-      .where(eq(pipelineRuns.runId, run.runId))
-  } catch (e) {
-    // Deltas are already reversed; a failed marker leaves an orphan that boot
-    // recovery re-reverses idempotently. Finish cleanly regardless.
-    logger.error(
-      'pipeline.marker_write_failed',
-      { runId: run.runId, outcome, error: String(e) },
-      { actionId: run.actionId },
-    )
+  if (reversalFailed) {
+    try {
+      await markerOp(outcome)
+    } catch (e) {
+      logger.error(
+        'pipeline.marker_write_failed',
+        { runId: run.runId, outcome, error: String(e) },
+        { actionId: run.actionId },
+      )
+    }
   }
   turnCaptureSink.endTurn(run.actionId, outcome, cause.reason)
   logger.error(

--- a/lib/pipeline/runtime/orchestrator.ts
+++ b/lib/pipeline/runtime/orchestrator.ts
@@ -319,17 +319,16 @@ async function abortRun(
     reversalFailed = true
   }
   generationStore.abortRun(run.runId)
-  if (reversalFailed) {
-    try {
-      await markerOp(outcome)
-    } catch (e) {
-      logger.error(
-        'pipeline.marker_write_failed',
-        { runId: run.runId, outcome, error: String(e) },
-        { actionId: run.actionId },
-      )
-    }
-  }
+  // A failed reversal leaves its writes on disk, and `finished_at IS NULL` is the
+  // only thing that hands them to boot recovery — settling the marker here would
+  // strand them with no retry at all. Nothing user-facing reads pipeline_runs; the
+  // outcome the user sees rides `run_complete` on the event bus, still 'failed'.
+  if (reversalFailed)
+    logger.warn(
+      'pipeline.orphan_left_for_recovery',
+      { runId: run.runId, outcome },
+      { actionId: run.actionId },
+    )
   turnCaptureSink.endTurn(run.actionId, outcome, cause.reason)
   logger.error(
     'pipeline.run_aborted',

--- a/lib/pipeline/runtime/recovery.ts
+++ b/lib/pipeline/runtime/recovery.ts
@@ -12,7 +12,13 @@ export type RecoveredRun = {
   storyId: string | null
   deltas: number
 }
-export type RecoveryFailure = { runId: string; kind: string; error: unknown }
+export type RecoveryFailure = {
+  runId: string
+  kind: string
+  actionId: string
+  storyId: string | null
+  error: unknown
+}
 export type RecoveryReport = { reversed: RecoveredRun[]; failures: RecoveryFailure[] }
 
 // Never throws — boot must not be blocked by orphan recovery; per-orphan
@@ -29,15 +35,19 @@ export async function recoverInFlightRuns(ctx: DbCtx): Promise<RecoveryReport> {
 
   for (const orphan of orphans) {
     try {
-      const count = await reverseReplayDeltas(orphan.actionId, ctx)
-      if (count === 0) {
-        await ctx.db.delete(pipelineRuns).where(eq(pipelineRuns.runId, orphan.runId))
-        continue
-      }
-      await ctx.db
-        .update(pipelineRuns)
-        .set({ finishedAt: Date.now(), outcome: 'recovered' })
-        .where(eq(pipelineRuns.runId, orphan.runId))
+      // Settling the marker rides the reversal's own transaction: the replay is not
+      // idempotent (undoing a `delete` re-inserts), so an orphan left open over
+      // already-reversed deltas fails deterministically on every later boot.
+      const count = await reverseReplayDeltas(orphan.actionId, ctx, (deltaCount) => [
+        deltaCount === 0
+          ? ctx.db.delete(pipelineRuns).where(eq(pipelineRuns.runId, orphan.runId)).toSQL()
+          : ctx.db
+              .update(pipelineRuns)
+              .set({ finishedAt: Date.now(), outcome: 'recovered' })
+              .where(eq(pipelineRuns.runId, orphan.runId))
+              .toSQL(),
+      ])
+      if (count === 0) continue
       reversed.push({
         runId: orphan.runId,
         kind: orphan.kind,
@@ -50,7 +60,13 @@ export async function recoverInFlightRuns(ctx: DbCtx): Promise<RecoveryReport> {
       // Boot must never be blocked: any per-orphan failure (a DeltaReplayError, or
       // a transient DB error on the marker write) is logged and left for next boot.
       // TODO: consider a stronger resolution to not polute the data, ie. deletion of orphaned data
-      failures.push({ runId: orphan.runId, kind: orphan.kind, error: e })
+      failures.push({
+        runId: orphan.runId,
+        kind: orphan.kind,
+        actionId: orphan.actionId,
+        storyId: orphan.storyId,
+        error: e,
+      })
       logger.error('pipeline.recovery_failed', {
         runId: orphan.runId,
         kind: orphan.kind,

--- a/lib/recovery/copy.test.ts
+++ b/lib/recovery/copy.test.ts
@@ -140,4 +140,13 @@ describe('formatRecoveryTitle', () => {
   it('claims recovery when something was', () => {
     expect(formatRecoveryTitle(report(recovered('per-turn', 'story_1')))).toBe('Story recovered')
   })
+
+  it('does not claim recovery when a reversal succeeded alongside one that failed', () => {
+    expect(
+      formatRecoveryTitle({
+        reversed: [recovered('per-turn', 'story_1')],
+        failures: [failed('periodic-classifier', 'story_2')],
+      }),
+    ).toBe('Recovery incomplete')
+  })
 })

--- a/lib/recovery/copy.test.ts
+++ b/lib/recovery/copy.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest'
 
-import type { RecoveredRun, RecoveryReport } from '@/lib/pipeline'
+import type { RecoveredRun, RecoveryFailure, RecoveryReport } from '@/lib/pipeline'
 
-import { formatRecoveryReport } from './copy'
+import { formatRecoveryReport, formatRecoveryTitle } from './copy'
 
 function recovered(kind: string, storyId: string | null): RecoveredRun {
   return {
@@ -16,6 +16,20 @@ function recovered(kind: string, storyId: string | null): RecoveredRun {
 
 function report(...reversed: RecoveredRun[]): RecoveryReport {
   return { reversed, failures: [] }
+}
+
+function failed(kind: string, storyId: string | null): RecoveryFailure {
+  return {
+    runId: `run_${kind}`,
+    kind,
+    actionId: `action_${kind}`,
+    storyId,
+    error: new Error('could not reverse'),
+  }
+}
+
+function failureReport(...failures: RecoveryFailure[]): RecoveryReport {
+  return { reversed: [], failures }
 }
 
 describe('formatRecoveryReport', () => {
@@ -77,5 +91,53 @@ describe('formatRecoveryReport', () => {
     ).toBe(
       'An interrupted shutdown was detected in Mornstone. An incomplete background update was reverted to keep the story consistent.',
     )
+  })
+})
+
+describe('failure copy', () => {
+  it('promises the pause only for a classifier orphan, which is the kind that causes one', () => {
+    expect(
+      formatRecoveryReport(failureReport(failed('periodic-classifier', 'story_1')), {
+        story_1: 'Mornstone',
+      }),
+    ).toContain('Memory updates for this story are paused')
+  })
+
+  it('describes the fault without promising a pause for other kinds', () => {
+    const text = formatRecoveryReport(failureReport(failed('per-turn', 'story_1')), {
+      story_1: 'Mornstone',
+    })
+    expect(text).toContain('Mornstone')
+    expect(text).not.toContain('paused')
+  })
+
+  it('falls back to unnamed copy when the story id resolves to no title', () => {
+    expect(formatRecoveryReport(failureReport(failed('periodic-classifier', null)), {})).toContain(
+      'that story',
+    )
+  })
+
+  it('reports reversed runs and failures together', () => {
+    const text = formatRecoveryReport(
+      {
+        reversed: [recovered('per-turn', 'story_1')],
+        failures: [failed('periodic-classifier', 'story_1')],
+      },
+      { story_1: 'Mornstone' },
+    )
+    expect(text).toContain('was reverted')
+    expect(text).toContain('are paused')
+  })
+})
+
+describe('formatRecoveryTitle', () => {
+  it('does not claim recovery when nothing was reversed', () => {
+    expect(formatRecoveryTitle(failureReport(failed('periodic-classifier', 'story_1')))).toBe(
+      'Recovery incomplete',
+    )
+  })
+
+  it('claims recovery when something was', () => {
+    expect(formatRecoveryTitle(report(recovered('per-turn', 'story_1')))).toBe('Story recovered')
   })
 })

--- a/lib/recovery/copy.ts
+++ b/lib/recovery/copy.ts
@@ -1,5 +1,5 @@
 import { t } from '@/lib/i18n'
-import type { RecoveredRun, RecoveryReport } from '@/lib/pipeline'
+import type { RecoveredRun, RecoveryFailure, RecoveryReport } from '@/lib/pipeline'
 
 export type RecoveryStoryNames = Readonly<Record<string, string>>
 
@@ -24,11 +24,32 @@ function formatRun(run: RecoveredRun, storyName: string | undefined): string {
   }
 }
 
+// The classifier writes `state: 'running'` before it emits any delta, so an orphan
+// of that kind which would not reverse is necessarily a branch boot held back —
+// this is the one failure that can promise the pause rather than describe the fault.
+function formatFailure(failure: RecoveryFailure, storyName: string | undefined): string {
+  const paused = failure.kind === 'periodic-classifier'
+  if (paused)
+    return storyName
+      ? t('crashRecovery.memoryPausedNamed', { storyName })
+      : t('crashRecovery.memoryPausedUnnamed')
+  return storyName
+    ? t('crashRecovery.incompleteNamed', { storyName })
+    : t('crashRecovery.incompleteUnnamed')
+}
+
+/** "Story recovered" over-claims when nothing could be reversed. */
+export function formatRecoveryTitle(report: RecoveryReport): string {
+  return report.reversed.length > 0 ? t('crashRecovery.title') : t('crashRecovery.titleIncomplete')
+}
+
 export function formatRecoveryReport(
   report: RecoveryReport,
   storyNames: RecoveryStoryNames,
 ): string {
-  return report.reversed
-    .map((run) => formatRun(run, run.storyId === null ? undefined : storyNames[run.storyId]))
-    .join(' ')
+  const named = (storyId: string | null) => (storyId === null ? undefined : storyNames[storyId])
+  return [
+    ...report.reversed.map((run) => formatRun(run, named(run.storyId))),
+    ...report.failures.map((failure) => formatFailure(failure, named(failure.storyId))),
+  ].join(' ')
 }

--- a/lib/recovery/copy.ts
+++ b/lib/recovery/copy.ts
@@ -38,9 +38,11 @@ function formatFailure(failure: RecoveryFailure, storyName: string | undefined):
     : t('crashRecovery.incompleteUnnamed')
 }
 
-/** "Story recovered" over-claims when nothing could be reversed. */
+/** "Story recovered" over-claims while any orphan's writes are still on disk. */
 export function formatRecoveryTitle(report: RecoveryReport): string {
-  return report.reversed.length > 0 ? t('crashRecovery.title') : t('crashRecovery.titleIncomplete')
+  return report.reversed.length > 0 && report.failures.length === 0
+    ? t('crashRecovery.title')
+    : t('crashRecovery.titleIncomplete')
 }
 
 export function formatRecoveryReport(

--- a/lib/recovery/index.ts
+++ b/lib/recovery/index.ts
@@ -1,5 +1,5 @@
 export { announceStorySettingsResetConfirmation } from './accessibility'
-export { formatRecoveryReport } from './copy'
+export { formatRecoveryReport, formatRecoveryTitle } from './copy'
 export type { RecoveryStoryNames } from './copy'
 export { getDatabaseFileRevealAction } from './database-file'
 export { loadRecoveryStoryNames } from './story-names'

--- a/lib/recovery/story-names.ts
+++ b/lib/recovery/story-names.ts
@@ -10,7 +10,7 @@ export async function loadRecoveryStoryNames(
   db: DbCtx['db'],
 ): Promise<RecoveryStoryNames> {
   const storyIds = new Set<string>()
-  for (const run of report.reversed) {
+  for (const run of [...report.reversed, ...report.failures]) {
     if (run.storyId !== null) storyIds.add(run.storyId)
   }
 

--- a/lib/stores/ui/recovery-report.test.ts
+++ b/lib/stores/ui/recovery-report.test.ts
@@ -20,11 +20,29 @@ const reversedReport: RecoveryReport = {
 describe('recoveryReportStore', () => {
   beforeEach(() => recoveryReportStore.__reset())
 
-  it('ignores reports without reversed runs even when recovery failures exist', () => {
-    recoveryReportStore.publish({
+  // A failure is the degradation worth reporting: the orphan's writes stay on disk
+  // and a classifier orphan leaves its branch held back from the cadence.
+  it('publishes a report that only has failures', () => {
+    const failureReport = {
       reversed: [],
-      failures: [{ runId: 'r-failed', kind: 'per-turn', error: new Error('failed') }],
-    })
+      failures: [
+        {
+          runId: 'r-failed',
+          kind: 'periodic-classifier',
+          actionId: 'act_failed',
+          storyId: 's1',
+          error: new Error('failed'),
+        },
+      ],
+    }
+
+    recoveryReportStore.publish(failureReport)
+
+    expect(recoveryReportStore.getSnapshot().pendingRecoveryReport).toBe(failureReport)
+  })
+
+  it('ignores a report with nothing reversed and nothing failed', () => {
+    recoveryReportStore.publish({ reversed: [], failures: [] })
 
     expect(recoveryReportStore.getSnapshot()).toEqual({
       pendingRecoveryReport: null,

--- a/lib/stores/ui/recovery-report.ts
+++ b/lib/stores/ui/recovery-report.ts
@@ -16,7 +16,7 @@ const store = createStore<RecoveryReportSnapshot>()(() => INITIAL_SNAPSHOT)
 
 export const recoveryReportStore = {
   publish: (report: RecoveryReport): void => {
-    if (report.reversed.length === 0) return
+    if (report.reversed.length === 0 && report.failures.length === 0) return
     store.setState({ pendingRecoveryReport: report })
   },
   claim: (): RecoveryReport | null => {

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -40,7 +40,12 @@
     "periodicClassifierNamed": "An interrupted shutdown was detected in {{storyName}}. A background memory update was reverted; your story content is intact.",
     "periodicClassifierUnnamed": "An interrupted shutdown was detected. A background memory update was reverted; your story content is intact.",
     "genericNamed": "An interrupted shutdown was detected in {{storyName}}. An incomplete background update was reverted to keep the story consistent.",
-    "genericUnnamed": "An interrupted shutdown was detected. An incomplete background update was reverted to keep the story consistent."
+    "genericUnnamed": "An interrupted shutdown was detected. An incomplete background update was reverted to keep the story consistent.",
+    "titleIncomplete": "Recovery incomplete",
+    "memoryPausedNamed": "An interrupted background memory update in {{storyName}} could not be undone. Memory updates for this story are paused so nothing is duplicated — your story content is intact, and restarting the app retries automatically.",
+    "memoryPausedUnnamed": "An interrupted background memory update could not be undone. Memory updates for that story are paused so nothing is duplicated — your story content is intact, and restarting the app retries automatically.",
+    "incompleteNamed": "An interrupted background update in {{storyName}} could not be undone. Your story content is intact, and restarting the app retries automatically.",
+    "incompleteUnnamed": "An interrupted background update could not be undone. Your story content is intact, and restarting the app retries automatically."
   },
   "chrome": {
     "appSettings": "App Settings",

--- a/locales/en/wizard.json
+++ b/locales/en/wizard.json
@@ -20,7 +20,14 @@
     "heading": "How does this story begin?",
     "emptyHint": "Generate with ✨, or start typing below.",
     "placeholder": "Write the opening, or generate one with ✨.",
-    "sceneMetadata": "Scene metadata: {{value}}",
+    "scene": {
+      "cast": "Cast in scene",
+      "location": "Location",
+      "noCast": "Add a character or item on the Cast step to tag the opening scene.",
+      "noLocations": "Add a location on the Cast step to set where the opening happens.",
+      "noLocationChosen": "Not set",
+      "hint": "Optional. Grounds the first turn in who is present and where; the classifier keeps it current from turn 2."
+    },
     "replaceConfirm": {
       "title": "Replace the opening?",
       "body": "The opening currently in the field will be lost.",

--- a/locales/en/wizard.json
+++ b/locales/en/wizard.json
@@ -306,6 +306,12 @@
     "leadUnsetRemovedToast": "Lead unset — the lead was removed from the cast.",
     "importRefsDropped_one": "1 reference couldn't be matched and was left blank.",
     "importRefsDropped_other": "{{count}} references couldn't be matched and were left blank.",
+    "unresolvedRef": {
+      "factionMissing": "Suggested faction “{{name}}” is not in your cast.",
+      "factionUnattached": "“{{name}}” is in your cast — attach it in the editor.",
+      "parentMissing": "Suggested parent location “{{name}}” is not in your cast.",
+      "parentUnattached": "“{{name}}” is in your cast — attach it in the editor."
+    },
     "leadNotice": {
       "mode": "Adventure mode needs a lead character. Mark one active character as lead to continue.",
       "narration": "First- and second-person narration need a lead character. Mark one active character as lead to continue."

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -50,6 +50,7 @@ export default defineConfig({
         optimizeDeps: { include: ['i18next', 'react-i18next'] },
         test: {
           name: 'storybook',
+          setupFiles: ['./.storybook/vitest.setup.ts'],
           browser: {
             enabled: true,
             headless: true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added editable scene tags for opening entries, including cast entities and locations.
  - Added warnings for missing or unattached factions and parent locations in cast rows.
  - Android back presses now dismiss open bottom sheets.

- **Bug Fixes**
  - Improved compact row alignment, lore-row title positioning, and tooltip interaction.
  - Selecting factions or parent locations clears outdated unresolved references.
  - Recovery screens now report incomplete recovery and paused memory updates more clearly.

- **Tests**
  - Expanded coverage for scene tags, cast warnings, styling, alignment, and recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->