### PR TITLE
Add Incognito Keyboard option for Android

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,11 @@
 # wry substitutes this into the generated RustWebView.kt ({{class-extension}}); the generated
 # file is gitignored (src-tauri/gen/android/app/.gitignore), so the incognito-keyboard override
 # has to be injected here. See docs/development/release.md for the full mechanism.
+#
+# The substitution itself is undocumented wry internals, not a public API: verified against
+# wry 0.55.1's build.rs (CLASS_EXTENSION/CLASS_INIT loop over src/android/kotlin/*.kt, around
+# build.rs:39-76). If an env upgrade bumps wry and this override stops appearing in the
+# generated RustWebView.kt, that build script is the first place to check for a rename.
 [env]
 WRY_RUSTWEBVIEW_CLASS_EXTENSION = """
   override fun onCreateInputConnection(outAttrs: android.view.inputmethod.EditorInfo): android.view.inputmethod.InputConnection? {

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,11 @@
+# wry substitutes this into the generated RustWebView.kt ({{class-extension}}); the generated
+# file is gitignored (src-tauri/gen/android/app/.gitignore), so the incognito-keyboard override
+# has to be injected here. See docs/development/release.md for the full mechanism.
+[env]
+WRY_RUSTWEBVIEW_CLASS_EXTENSION = """
+  override fun onCreateInputConnection(outAttrs: android.view.inputmethod.EditorInfo): android.view.inputmethod.InputConnection? {
+    val ic = super.onCreateInputConnection(outAttrs)
+    com.karelian.aventura.IncognitoIme.apply(outAttrs)
+    return ic
+  }
+"""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,6 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
-
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -126,6 +125,9 @@ jobs:
           NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
           ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
         run: npx tauri android build
+
+      - name: Verify incognito-keyboard injection
+        run: node scripts/check_wry_injection.js
 
       - name: Decode keystore
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,6 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
-
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -121,6 +120,9 @@ jobs:
           NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
           ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
         run: npx tauri android build
+
+      - name: Verify incognito-keyboard injection
+        run: node scripts/check_wry_injection.js
 
       - name: Decode keystore
         env:

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -164,6 +164,17 @@ The unsigned release APK will be at:
 src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release-unsigned.apk
 ```
 
+**Injecting Kotlin into the generated WebView.** wry generates
+`src-tauri/gen/android/app/src/main/java/com/karelian/aventura/generated/RustWebView.kt` fresh on
+every build — it's gitignored and must never be hand-edited. wry's `build.rs` substitutes an
+env var named `WRY_<FILE_STEM>_CLASS_EXTENSION` (file stem uppercased, e.g.
+`WRY_RUSTWEBVIEW_CLASS_EXTENSION` for `RustWebView.kt`) into a `{{class-extension}}` placeholder in
+that file. The repo-root `.cargo/config.toml` sets this to inject a one-line
+`onCreateInputConnection` override (used for the incognito-keyboard setting) that delegates to a
+normal, git-tracked Kotlin class. `cargo`'s config discovery walks up from the build's working
+directory, so this only works because both `npx tauri android ...` and `./compileApk.sh` run with
+the repo root as their working directory — confirmed by tracing `BuildTask.kt`'s `workingDir`.
+
 ### Signing APK
 
 ```bash

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -175,6 +175,12 @@ normal, git-tracked Kotlin class. `cargo`'s config discovery walks up from the b
 directory, so this only works because both `npx tauri android ...` and `./compileApk.sh` run with
 the repo root as their working directory — confirmed by tracing `BuildTask.kt`'s `workingDir`.
 
+This substitution is undocumented wry internals, not a public API — verified by reading
+`wry-0.55.1`'s `build.rs` directly (search the vendored crate's registry checkout for
+`CLASS_EXTENSION` if this ever needs re-verifying after a wry bump). If the override silently
+stops appearing in the generated `RustWebView.kt`, that build script — not any docs page — is
+where the renamed placeholder or env var will be found.
+
 ### Signing APK
 
 ```bash

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -181,6 +181,11 @@ This substitution is undocumented wry internals, not a public API — verified b
 stops appearing in the generated `RustWebView.kt`, that build script — not any docs page — is
 where the renamed placeholder or env var will be found.
 
+`scripts/check_wry_injection.js` runs after `tauri android build` in both Android CI jobs and
+fails the build if the lines `.cargo/config.toml` injects are absent from the generated
+`RustWebView.kt`, so a wry bump that breaks the substitution stops the release instead of
+shipping a dead setting.
+
 ### Signing APK
 
 ```bash

--- a/scripts/check_wry_injection.js
+++ b/scripts/check_wry_injection.js
@@ -1,0 +1,71 @@
+/**
+ * Fail the build if wry stopped injecting the incognito-keyboard override into the generated
+ * `RustWebView.kt`.
+ *
+ * The override is fed in through `.cargo/config.toml`'s `WRY_RUSTWEBVIEW_CLASS_EXTENSION` env
+ * var, which wry substitutes into a `{{class-extension}}` placeholder in a gitignored,
+ * regenerated-every-build file. That substitution is undocumented wry internals: a wry bump
+ * that renames the env var or placeholder makes the override silently vanish, and the APK
+ * still builds. Run this after `tauri android build` so that regression fails CI instead of
+ * shipping a dead setting. See docs/development/release.md.
+ *
+ * Usage: node scripts/check_wry_injection.js [path/to/RustWebView.kt]
+ */
+
+import { readFileSync, existsSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const rootDir = resolve(__dirname, '..')
+
+const configPath = resolve(rootDir, '.cargo/config.toml')
+const generatedPath =
+  process.argv[2] ??
+  resolve(
+    rootDir,
+    'src-tauri/gen/android/app/src/main/java/com/karelian/aventura/generated/RustWebView.kt',
+  )
+
+function fail(message) {
+  console.error(`check_wry_injection: ${message}`)
+  process.exit(1)
+}
+
+const config = readFileSync(configPath, 'utf8')
+const block = config.match(/WRY_RUSTWEBVIEW_CLASS_EXTENSION\s*=\s*"""\r?\n([\s\S]*?)"""/)?.[1]
+if (!block) {
+  fail(`WRY_RUSTWEBVIEW_CLASS_EXTENSION not found in ${configPath} — nothing to verify against`)
+}
+
+// Anchor the check to whatever the config injects today, so an edit to the snippet is
+// tracked automatically rather than drifting from a hardcoded copy.
+const required = block
+  .split('\n')
+  .map((line) => line.trim())
+  .filter((line) => line.length > 0)
+
+for (const marker of ['onCreateInputConnection', 'IncognitoIme.apply(outAttrs)']) {
+  if (!required.some((line) => line.includes(marker))) {
+    fail(`${configPath} no longer injects \`${marker}\` — the incognito-keyboard hook was removed`)
+  }
+}
+
+if (!existsSync(generatedPath)) {
+  fail(
+    `${generatedPath} does not exist — run \`npx tauri android build\` first, or pass the path as an argument`,
+  )
+}
+
+const generated = readFileSync(generatedPath, 'utf8')
+const missing = required.filter((line) => !generated.includes(line))
+if (missing.length > 0) {
+  fail(
+    `${generatedPath} is missing the injected class extension:\n` +
+      missing.map((line) => `  - ${line}`).join('\n') +
+      `\n\nwry likely renamed the CLASS_EXTENSION env var or placeholder in a version bump; ` +
+      `check wry's build.rs (see docs/development/release.md).`,
+  )
+}
+
+console.log('check_wry_injection: incognito-keyboard override present in generated RustWebView.kt')

--- a/src-tauri/gen/android/app/src/main/java/com/karelian/aventura/IncognitoIme.kt
+++ b/src-tauri/gen/android/app/src/main/java/com/karelian/aventura/IncognitoIme.kt
@@ -1,0 +1,12 @@
+package com.karelian.aventura
+
+import android.view.inputmethod.EditorInfo
+
+/** Set from the JS bridge; read on the IME thread when an input connection is created. */
+object IncognitoIme {
+  @Volatile var enabled: Boolean = false
+
+  fun apply(outAttrs: EditorInfo) {
+    if (enabled) outAttrs.imeOptions = outAttrs.imeOptions or EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING
+  }
+}

--- a/src-tauri/gen/android/app/src/main/java/com/karelian/aventura/MainActivity.kt
+++ b/src-tauri/gen/android/app/src/main/java/com/karelian/aventura/MainActivity.kt
@@ -1,7 +1,9 @@
 package com.karelian.aventura
 
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.view.inputmethod.InputMethodManager
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import androidx.activity.OnBackPressedCallback
@@ -91,6 +93,17 @@ class MainActivity : TauriActivity() {
       val l = kotlin.math.ceil(bars.left / d).toInt()
       val r = kotlin.math.ceil(bars.right / d).toInt()
       return """{"top":$t,"bottom":$b,"left":$l,"right":$r}"""
+    }
+
+    /** Toggles IME_FLAG_NO_PERSONALIZED_LEARNING for future input connections. */
+    @JavascriptInterface
+    fun setIncognitoKeyboard(enabled: Boolean) {
+      IncognitoIme.enabled = enabled
+      val wv = webView ?: return
+      wv.post {
+        val imm = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        imm.restartInput(wv)
+      }
     }
   }
 }

--- a/src/lib/components/settings/tabs/interface.svelte
+++ b/src/lib/components/settings/tabs/interface.svelte
@@ -18,7 +18,10 @@
   import { getSupportedLanguages } from '$lib/services/ai/utils/TranslationService'
   import { updaterService, UpdateError } from '$lib/services/updater'
   import { updateNotifier } from '$lib/stores/updateNotifier.svelte'
+  import { isAndroid } from '$lib/utils/platform'
   import { RefreshCw, Loader2, Languages, Plus, X, Trash2 } from '@lucide/svelte'
+
+  const showIncognitoKeyboard = isAndroid()
 
   /**
    * What the swatch and the preview should show. An empty stored colour means "the
@@ -464,6 +467,22 @@
       onCheckedChange={(v) => settings.setShowScrollToBottom(v)}
     />
   </div>
+
+  {#if showIncognitoKeyboard}
+    <!-- Incognito Keyboard Toggle -->
+    <div class="flex items-center justify-between">
+      <div>
+        <Label>Incognito Keyboard</Label>
+        <p class="text-muted-foreground text-xs">
+          Ask the keyboard not to learn from what you type. Not all keyboards honour this.
+        </p>
+      </div>
+      <Switch
+        checked={settings.uiSettings.incognitoKeyboard}
+        onCheckedChange={(v) => settings.setIncognitoKeyboard(v)}
+      />
+    </div>
+  {/if}
 
   <!-- Translation Section -->
   <div class="space-y-3">

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -40,6 +40,7 @@ import { getTheme } from '../../themes/themes'
 import { LLM_TIMEOUT_DEFAULT, LLM_TIMEOUT_MIN, LLM_TIMEOUT_MAX } from '$lib/constants/timeout'
 import { SvelteSet, SvelteMap } from 'svelte/reactivity'
 import { dedupeTextModels } from '$lib/utils/dedupeTextModels'
+import { applyIncognitoKeyboard } from '$lib/utils/platform'
 import type { ImageGenerationServiceSettings, TimelineFillSettings } from '$lib/services/ai'
 import { debug } from './debug.svelte'
 import { modelHealth } from './modelHealth.svelte'
@@ -1198,6 +1199,7 @@ export function getDefaultUISettings(): UISettings {
     storyMaxWidth: '3xl',
     highlightDialogue: false,
     dialogueColor: '',
+    incognitoKeyboard: false,
   }
 }
 
@@ -1580,6 +1582,11 @@ class SettingsStore {
       const dialogueColor = await database.getSetting('dialogue_color')
       if (dialogueColor !== null) this.uiSettings.dialogueColor = dialogueColor
       this.applyDialogueHighlight()
+
+      const incognitoKeyboard = await database.getSetting('incognito_keyboard')
+      if (incognitoKeyboard !== null)
+        this.uiSettings.incognitoKeyboard = incognitoKeyboard === 'true'
+      applyIncognitoKeyboard(this.uiSettings.incognitoKeyboard)
 
       const debugMode = await database.getSetting('debug_mode')
       if (debugMode !== null) debug.isActive = this.uiSettings.debugMode = debugMode === 'true'
@@ -2654,6 +2661,12 @@ class SettingsStore {
     await database.setSetting('story_max_width', width)
   }
 
+  async setIncognitoKeyboard(enabled: boolean) {
+    this.uiSettings.incognitoKeyboard = enabled
+    await database.setSetting('incognito_keyboard', enabled.toString())
+    applyIncognitoKeyboard(enabled)
+  }
+
   /**
    * Publish the dialogue colour to CSS. The toggle and the colour live on the root
    * element, not in the rendered markup: the `<span class="dialogue-line">` wrappers
@@ -3120,6 +3133,8 @@ class SettingsStore {
     await database.setSetting('highlight_dialogue', this.uiSettings.highlightDialogue.toString())
     await database.setSetting('dialogue_color', this.uiSettings.dialogueColor)
     this.applyDialogueHighlight()
+    await database.setSetting('incognito_keyboard', this.uiSettings.incognitoKeyboard.toString())
+    applyIncognitoKeyboard(this.uiSettings.incognitoKeyboard)
     await database.setSetting(
       'advanced_manual_mode',
       this.advancedRequestSettings.manualMode.toString(),

--- a/src/lib/types/android.d.ts
+++ b/src/lib/types/android.d.ts
@@ -14,6 +14,8 @@ interface AndroidBridge {
   startGenerationService(): void
   /** Stop the foreground service after generation completes / fails / is aborted. */
   stopGenerationService(): void
+  /** Toggle IME_FLAG_NO_PERSONALIZED_LEARNING on the WebView's input connections. */
+  setIncognitoKeyboard(enabled: boolean): void
 }
 
 interface Window {

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -739,6 +739,8 @@ export interface UISettings {
    * CSS fallback rather than picking a colour on the user's behalf.
    */
   dialogueColor: string
+  /** Android-only: ask the keyboard not to learn from what is typed. */
+  incognitoKeyboard: boolean
 }
 
 /**

--- a/src/lib/utils/platform.ts
+++ b/src/lib/utils/platform.ts
@@ -22,3 +22,13 @@ export function supportsHover(): boolean {
   if (typeof window.matchMedia !== 'function') return !isAndroid()
   return !window.matchMedia('(hover: none)').matches
 }
+
+/** No-op off Android. Asks the WebView's keyboard not to learn from what is typed. */
+export function applyIncognitoKeyboard(enabled: boolean): void {
+  if (!isAndroid()) return
+  try {
+    window.AndroidBridge?.setIncognitoKeyboard(enabled)
+  } catch (e) {
+    console.warn('[platform] Failed to set incognito keyboard:', e)
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Android-only **Incognito Keyboard** setting in Interface preferences.
  * The setting is saved, restored, reset with other preferences, and applied immediately.
  * When enabled, Android input fields prevent personalized keyboard learning.
  * On non-Android platforms, the setting is hidden and has no effect.

* **Reliability**
  * Added automated checks to verify Incognito Keyboard support is included in Android builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->