### PR TITLE
Prompt packs: update one from a file, and un-freeze the built-in pack

### DIFF
--- a/docs/architecture/prompts.md
+++ b/docs/architecture/prompts.md
@@ -64,6 +64,39 @@ distinction at every call site. The refresh skips any row where the two differ. 
 content's own hash against the baseline instead, as it once did, reads every user edit as a stale default
 and reverts it on the next app start.
 
+### Three States, and Refreshing the Built-in Pack
+
+The two hashes carry more than "edited or not". Comparing `baseline_hash` against the hash of what the code
+ships **now** separates a customisation from a template that has genuinely fallen behind:
+
+| | `content_hash` vs `baseline_hash` | `baseline_hash` vs hash of shipped text | |
+| ---------------- | ------------ | ------ | ------------------------------------------------ |
+| **Current** | equal | equal | the startup refresh keeps it up to date |
+| **Customised** | differ | equal | the user edited it; nothing newer has shipped |
+| **Behind** | differ | differ | the user edited it **and** newer text has shipped |
+
+`classifyTemplate` in `services/packs/staleness.ts` is the predicate; both halves are needed, since
+`isUntouched` alone counts customisations as stale and the baseline comparison alone flags every row of a
+pack whose baseline was never the shipped text. It survives edit → ship → edit, because only a baseline
+write moves `baseline_hash` and the refresh never touches an edited row. A row the editor *created*
+carries `baseline_hash = ''` and so reads as behind — a known false positive, which the UI mitigates by
+naming every affected template before anything is written.
+
+Pack Settings reports both counts for `default-pack` and offers `packService.refreshTemplates`, at one of
+two scopes. **The classification informs the user; it does not decide for them.** Prompts reference shared
+conventions and a user's edits usually span several templates written to agree with each other, so
+replacing only the subset that happens to be behind can leave half a coherent set of edits sitting against
+the other half's replacement. `'behind'` takes only what the app has changed since; `'edited'` takes every
+edit, which is what restores coherence and is also the deliberate revert-to-stock the app otherwise lacks.
+
+Refreshed rows are written as their own baseline, so they resume receiving shipped updates — the same
+effect the per-template "Reset to default" button has.
+
+**Only `default-pack` can be refreshed.** A custom pack's baseline is not the shipped text: for an imported
+pack it is the file its author wrote, so taking "the shipped version" there would replace their prompts
+with Aventuras' own. (The per-template reset button predates this and *is* offered on every pack, imported
+ones included.)
+
 ### Updating a Pack From a File
 
 A custom pack is otherwise frozen at the baseline it was created from, so replacing its contents with a

--- a/docs/architecture/prompts.md
+++ b/docs/architecture/prompts.md
@@ -64,6 +64,43 @@ distinction at every call site. The refresh skips any row where the two differ. 
 content's own hash against the baseline instead, as it once did, reads every user edit as a stale default
 and reverts it on the next app start.
 
+### Updating a Pack From a File
+
+A custom pack is otherwise frozen at the baseline it was created from, so replacing its contents with a
+newer `.prompt.json` is the only way to update one. `importExportService.updatePackFromFile` does that
+**in place**: the `preset_packs` row is updated, never deleted, and only `pack_templates` and
+`pack_variables` are cleared and rewritten, in one transaction (`database.replacePackContents`).
+
+What that preserves is the point of doing it this way:
+
+- **The pack id**, so `stories.pack_id` still resolves. It is `ON DELETE RESTRICT`, so a delete-and-recreate
+  could not run at all while a story used the pack.
+- **Runtime variable definitions.** `pack_runtime_variables` is `ON DELETE CASCADE`; dropping the pack row
+  takes the definitions with it while entity `metadata.runtimeVars` keeps holding values keyed by their
+  ids — unreachable and unfixable. The export format carries no runtime variables, so a file that says
+  nothing about them changes nothing about them.
+- **The pack's name**, which is the user's label. Description and author come from the file.
+- **A story's `custom_variable_values`**, which are keyed by variable name, so answers survive wherever the
+  file keeps a name.
+
+What it discards is every edit to that pack's templates — which is the operation, and why the confirmation
+counts them first. That count uses `isUntouched` (did the user change this?), not
+`getModifiedTemplates` (does this differ from what ships today?); the second also flags templates the user
+never touched but a later app version has improved.
+
+Rows are written with `isBaseline: true` — the file *is* this pack's baseline. **That is why `default-pack`
+is excluded**: marking every row as its own baseline makes them all read as untouched, so
+`refreshDefaultPackTemplates` would decide the shipped prompts had changed and overwrite the whole import
+on the next launch. Importing over the built-in pack would appear to work until the next restart.
+
+Templates the file omits are gone from the pack; resolution falls through to `default-pack` and then the
+code baseline, and `backfillMissingTemplates` re-inserts them on the next start. This is deliberate — an
+updated pack should match what a fresh import of the same file produces, not carry ghosts of its previous
+self.
+
+Importing a file always creates a *new* pack. A name collision offers a copy or a cancel, never an
+overwrite: replacing a pack is reached from that pack, not from a name that happens to match.
+
 ## Prompt Ordering and Prefix Caching
 
 Inference servers reuse the KV cache for the longest prefix a request shares with the previous one, and

--- a/src/lib/components/vault/VaultPanel.svelte
+++ b/src/lib/components/vault/VaultPanel.svelte
@@ -390,11 +390,7 @@
   async function handleImportConfirm(strategy: ConflictStrategy) {
     if (!importValidation?.pack) return
     try {
-      const newPackId = await importExportService.applyImport(
-        importValidation.pack,
-        strategy,
-        importConflictPack ?? undefined,
-      )
+      const newPackId = await importExportService.applyImport(importValidation.pack, strategy)
       if (newPackId) {
         ui.showToast('Pack imported successfully', 'info')
       }

--- a/src/lib/components/vault/prompts/ImportPreviewDialog.svelte
+++ b/src/lib/components/vault/prompts/ImportPreviewDialog.svelte
@@ -109,7 +109,9 @@
             <AlertTriangle class="h-4 w-4" />
             <Alert.Title>Name conflict</Alert.Title>
             <Alert.Description>
-              A pack named "{conflictPack.name}" already exists. Choose how to proceed.
+              A pack named "{conflictPack.name}" already exists. Importing creates a separate copy.
+              To replace that pack's contents with this file, use its "Update from file" action
+              instead.
             </Alert.Description>
           </Alert.Root>
         {/if}
@@ -118,10 +120,7 @@
       <ResponsiveModal.Footer class="border-t px-6 py-4">
         {#if conflictPack}
           <Button variant="ghost" onclick={onCancel}>Cancel</Button>
-          <Button variant="outline" onclick={() => onConfirm('rename')}>Import as Copy</Button>
-          <Button variant="destructive" onclick={() => onConfirm('replace')}
-            >Replace Existing</Button
-          >
+          <Button onclick={() => onConfirm('rename')}>Import as Copy</Button>
         {:else}
           <Button variant="outline" onclick={onCancel}>Cancel</Button>
           <Button onclick={() => onConfirm('rename')}>Import</Button>

--- a/src/lib/components/vault/prompts/PromptPackCard.svelte
+++ b/src/lib/components/vault/prompts/PromptPackCard.svelte
@@ -3,7 +3,7 @@
   import { Card, CardContent } from '$lib/components/ui/card'
   import { Badge } from '$lib/components/ui/badge'
   import { Button } from '$lib/components/ui/button'
-  import { Download, Trash2, Lock } from '@lucide/svelte'
+  import { Download, Trash2, Lock, RefreshCw } from '@lucide/svelte'
   import { stripToPlainText } from '$lib/utils/markdown'
 
   interface Props {
@@ -12,10 +12,12 @@
     usageCount: number
     onclick: () => void
     onExport?: () => void
+    onUpdateFromFile?: () => void
     onDelete?: () => void
   }
 
-  let { pack, modifiedCount, usageCount, onclick, onExport, onDelete }: Props = $props()
+  let { pack, modifiedCount, usageCount, onclick, onExport, onUpdateFromFile, onDelete }: Props =
+    $props()
 </script>
 
 <button type="button" class="w-full text-left" {onclick}>
@@ -42,7 +44,7 @@
             <Button
               variant="ghost"
               size="icon"
-              class="h-8 w-8 opacity-0 transition-opacity group-hover:opacity-100"
+              class="h-8 w-8 transition-opacity sm:opacity-0 sm:group-hover:opacity-100"
               onclick={(e: MouseEvent) => {
                 e.stopPropagation()
                 onExport?.()
@@ -52,11 +54,25 @@
               <Download class="h-4 w-4" />
             </Button>
           {/if}
+          {#if !pack.isDefault && onUpdateFromFile}
+            <Button
+              variant="ghost"
+              size="icon"
+              class="h-8 w-8 transition-opacity sm:opacity-0 sm:group-hover:opacity-100"
+              onclick={(e: MouseEvent) => {
+                e.stopPropagation()
+                onUpdateFromFile?.()
+              }}
+              title="Update from file"
+            >
+              <RefreshCw class="h-4 w-4" />
+            </Button>
+          {/if}
           {#if !pack.isDefault && onDelete}
             <Button
               variant="ghost"
               size="icon"
-              class="text-destructive h-8 w-8 opacity-0 transition-opacity group-hover:opacity-100"
+              class="text-destructive h-8 w-8 transition-opacity sm:opacity-0 sm:group-hover:opacity-100"
               onclick={(e: MouseEvent) => {
                 e.stopPropagation()
                 onDelete?.()

--- a/src/lib/components/vault/prompts/PromptPackEditor.svelte
+++ b/src/lib/components/vault/prompts/PromptPackEditor.svelte
@@ -3,6 +3,9 @@
   import type { FullPack } from '$lib/services/packs/types'
   import { allSamples } from './sampleContext'
   import { packService } from '$lib/services/packs/pack-service'
+  import type { ClassifiedTemplates, RefreshScope } from '$lib/services/packs/staleness'
+  import { ui } from '$lib/stores/ui.svelte'
+  import { errMessage } from '$lib/utils/error'
   import { createIsMobile } from '$lib/hooks/is-mobile.svelte'
   import TemplateGroupList from './TemplateGroupList.svelte'
   import TemplateEditor from './TemplateEditor.svelte'
@@ -20,6 +23,7 @@
   import { Label } from '$lib/components/ui/label'
   import { renderDescription } from '$lib/utils/markdown'
   import TestVariablesModal from './TestVariablesModal.svelte'
+  import RefreshTemplatesDialog from './RefreshTemplatesDialog.svelte'
   import {
     ChevronLeft,
     Menu,
@@ -104,10 +108,53 @@
     loading = true
     try {
       fullPack = await packService.getFullPack(packId)
+      await loadClassification()
     } catch (error) {
       console.error('[PromptPackEditor] Failed to load pack:', error)
     } finally {
       loading = false
+    }
+  }
+
+  // Which of the built-in pack's templates carry edits, and which of those the app has
+  // shipped newer text for. Null until loaded; empty groups mean the pack matches shipped.
+  let classified = $state<ClassifiedTemplates | null>(null)
+  let refreshDialogOpen = $state(false)
+  let refreshing = $state(false)
+
+  let editedCount = $derived(
+    (classified?.behind.length ?? 0) + (classified?.customised.length ?? 0),
+  )
+  let behindCount = $derived(classified?.behind.length ?? 0)
+
+  async function loadClassification() {
+    if (!fullPack?.pack.isDefault) {
+      classified = null
+      return
+    }
+    try {
+      classified = await packService.classifyPackTemplates(packId)
+    } catch (error) {
+      console.error('[PromptPackEditor] Failed to classify templates:', error)
+      classified = null
+    }
+  }
+
+  async function handleRefresh(scope: RefreshScope) {
+    refreshing = true
+    try {
+      const count = await packService.refreshTemplates(packId, scope)
+      ui.showToast(count === 1 ? '1 template replaced' : `${count} templates replaced`, 'info')
+      refreshDialogOpen = false
+      // The action lives in Pack Settings, which only renders with no template open, so
+      // there is no editor holding stale content to reload.
+      await refreshPack()
+      await loadClassification()
+    } catch (e) {
+      console.error('Refresh failed:', e)
+      ui.showToast(`Refresh failed: ${errMessage(e)}`, 'error')
+    } finally {
+      refreshing = false
     }
   }
 
@@ -530,6 +577,46 @@
                 {/if}
               </div>
 
+              {#if fullPack.pack.isDefault && classified}
+                <div class="flex flex-col gap-3 rounded-lg border p-4">
+                  <div class="flex flex-col gap-1">
+                    <h4 class="text-sm font-medium">Shipped prompts</h4>
+                    {#if editedCount === 0}
+                      <p class="text-muted-foreground text-sm">
+                        Every template matches the prompts this version of the app ships.
+                      </p>
+                    {:else}
+                      <p class="text-muted-foreground text-sm">
+                        {editedCount}
+                        {editedCount === 1 ? 'template carries' : 'templates carry'} your edits,
+                        {#if behindCount === 0}
+                          and the app ships nothing newer for any of them.
+                        {:else}
+                          {behindCount} of {editedCount === 1 ? 'which is' : 'them are'} behind newer
+                          shipped text.
+                        {/if}
+                      </p>
+                      <p class="text-muted-foreground text-xs">
+                        An edited template stops receiving shipped improvements until it is
+                        replaced.
+                      </p>
+                    {/if}
+                  </div>
+                  <div>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      class="h-7 gap-1.5 text-xs"
+                      disabled={editedCount === 0}
+                      onclick={() => (refreshDialogOpen = true)}
+                    >
+                      <RotateCcw class="h-3.5 w-3.5" />
+                      Refresh from shipped prompts
+                    </Button>
+                  </div>
+                </div>
+              {/if}
+
               {#if editingSettings}
                 <!-- Edit mode -->
                 <div class="space-y-4">
@@ -635,6 +722,15 @@
   {testValues}
   onOpenChange={(open) => (showTestVars = open)}
   onTestValuesChange={handleTestValuesChange}
+/>
+
+<RefreshTemplatesDialog
+  open={refreshDialogOpen}
+  packName={fullPack?.pack.name ?? ''}
+  {classified}
+  {refreshing}
+  onConfirm={handleRefresh}
+  onCancel={() => (refreshDialogOpen = false)}
 />
 
 <!-- Dirty guard dialog -->

--- a/src/lib/components/vault/prompts/PromptPackList.svelte
+++ b/src/lib/components/vault/prompts/PromptPackList.svelte
@@ -2,7 +2,11 @@
   import type { PresetPack } from '$lib/services/packs/types'
   import { packService } from '$lib/services/packs/pack-service'
   import { database } from '$lib/services/database'
-  import { importExportService } from '$lib/services/packs/import-export'
+  import {
+    importExportService,
+    type ImportValidationResult,
+  } from '$lib/services/packs/import-export'
+  import type { PackUpdateSummary } from '$lib/services/packs/update-summary'
   import { ui } from '$lib/stores/ui.svelte'
   import { errMessage } from '$lib/utils/error'
   import { Skeleton } from '$lib/components/ui/skeleton'
@@ -11,6 +15,8 @@
   import { fade } from 'svelte/transition'
   import PromptPackCard from './PromptPackCard.svelte'
   import CreatePackDialog from './CreatePackDialog.svelte'
+  import ImportPreviewDialog from './ImportPreviewDialog.svelte'
+  import UpdatePackDialog from './UpdatePackDialog.svelte'
 
   interface Props {
     onOpenPack: (packId: string) => void
@@ -27,6 +33,14 @@
   // Delete confirmation state
   let deleteTarget = $state<PresetPack | null>(null)
   let deleting = $state(false)
+
+  // Update-from-file state
+  let updateTarget = $state<PresetPack | null>(null)
+  let updateValidation = $state<ImportValidationResult | null>(null)
+  let updateSummary = $state<PackUpdateSummary | null>(null)
+  let updateErrors = $state<ImportValidationResult | null>(null)
+  let updating = $state(false)
+  let exportingBeforeUpdate = $state(false)
 
   async function loadPacks() {
     loading = true
@@ -80,6 +94,62 @@
     }
   }
 
+  async function handleUpdateFromFile(pack: PresetPack) {
+    const content = await importExportService.pickAndReadImportFile()
+    if (!content) return
+
+    const result = importExportService.validateImport(content)
+    if (!result.valid || !result.pack) {
+      updateErrors = result
+      return
+    }
+
+    try {
+      updateSummary = await importExportService.summarizeUpdate(pack.id, result.pack)
+      updateValidation = result
+      updateTarget = pack
+    } catch (e) {
+      console.error('[PromptPackList] Failed to summarize update:', e)
+      ui.showToast(`Could not read pack: ${errMessage(e)}`, 'error')
+    }
+  }
+
+  function closeUpdateDialog() {
+    updateTarget = null
+    updateValidation = null
+    updateSummary = null
+  }
+
+  async function handleExportBeforeUpdate() {
+    if (!updateTarget) return
+    exportingBeforeUpdate = true
+    try {
+      const success = await importExportService.exportPack(updateTarget.id)
+      if (success) ui.showToast('Pack exported successfully', 'info')
+    } catch (e) {
+      console.error('Export failed:', e)
+      ui.showToast(`Export failed: ${errMessage(e)}`, 'error')
+    } finally {
+      exportingBeforeUpdate = false
+    }
+  }
+
+  async function handleConfirmUpdate() {
+    if (!updateTarget || !updateValidation?.pack) return
+    updating = true
+    try {
+      await importExportService.updatePackFromFile(updateTarget.id, updateValidation.pack)
+      ui.showToast(`Updated "${updateTarget.name}"`, 'info')
+      closeUpdateDialog()
+      await loadPacks()
+    } catch (e) {
+      console.error('Update failed:', e)
+      ui.showToast(`Update failed: ${errMessage(e)}`, 'error')
+    } finally {
+      updating = false
+    }
+  }
+
   async function handleConfirmDelete() {
     if (!deleteTarget) return
     deleting = true
@@ -123,6 +193,7 @@
         usageCount={usageCounts.get(pack.id) ?? 0}
         onclick={() => onOpenPack(pack.id)}
         onExport={() => handleExportPack(pack.id)}
+        onUpdateFromFile={pack.isDefault ? undefined : () => handleUpdateFromFile(pack)}
         onDelete={pack.isDefault
           ? undefined
           : () => {
@@ -137,6 +208,32 @@
   open={showCreateDialog}
   onOpenChange={(v) => (showCreateDialog = v)}
   onCreated={handlePackCreated}
+/>
+
+<UpdatePackDialog
+  open={!!updateTarget}
+  pack={updateTarget}
+  packData={updateValidation?.pack ?? null}
+  summary={updateSummary}
+  exporting={exportingBeforeUpdate}
+  {updating}
+  onExportFirst={handleExportBeforeUpdate}
+  onConfirm={handleConfirmUpdate}
+  onCancel={closeUpdateDialog}
+/>
+
+<!-- A file that fails validation never reaches the update confirmation; its errors are
+     reported through the import preview's error state. -->
+<ImportPreviewDialog
+  open={!!updateErrors}
+  validationResult={updateErrors}
+  conflictPack={null}
+  onConfirm={() => {
+    updateErrors = null
+  }}
+  onCancel={() => {
+    updateErrors = null
+  }}
 />
 
 <!-- Delete confirmation -->

--- a/src/lib/components/vault/prompts/RefreshTemplatesDialog.svelte
+++ b/src/lib/components/vault/prompts/RefreshTemplatesDialog.svelte
@@ -1,0 +1,111 @@
+<script lang="ts">
+  import type { ClassifiedTemplates, RefreshScope } from '$lib/services/packs/staleness'
+  import * as ResponsiveModal from '$lib/components/ui/responsive-modal'
+  import { Button } from '$lib/components/ui/button'
+  import { Badge } from '$lib/components/ui/badge'
+  import { ScrollArea } from '$lib/components/ui/scroll-area'
+  import { describeTemplate } from './templateGroups'
+
+  interface Props {
+    open: boolean
+    packName: string
+    classified: ClassifiedTemplates | null
+    refreshing: boolean
+    onConfirm: (scope: RefreshScope) => void
+    onCancel: () => void
+  }
+
+  let { open, packName, classified, refreshing, onConfirm, onCancel }: Props = $props()
+
+  function listed(templateIds: string[]) {
+    return templateIds
+      .map((templateId) => ({ templateId, described: describeTemplate(templateId) }))
+      .filter((entry) => entry.described !== null)
+      .map((entry) => ({
+        templateId: entry.templateId,
+        label: entry.described!.isUserHalf
+          ? `${entry.described!.name} (user half)`
+          : entry.described!.name,
+        group: entry.described!.group,
+      }))
+      .sort((a, b) => a.group.localeCompare(b.group) || a.label.localeCompare(b.label))
+  }
+
+  let behind = $derived(listed(classified?.behind ?? []))
+  let customised = $derived(listed(classified?.customised ?? []))
+  let total = $derived(behind.length + customised.length)
+</script>
+
+<ResponsiveModal.Root
+  {open}
+  onOpenChange={(v) => {
+    if (!v) onCancel()
+  }}
+>
+  <ResponsiveModal.Content class="p-0 sm:max-w-lg">
+    <ResponsiveModal.Header class="border-b px-6 py-4">
+      <ResponsiveModal.Title>Refresh "{packName}" from the shipped prompts</ResponsiveModal.Title>
+      <ResponsiveModal.Description>
+        Your version of each template you choose is replaced by the one this version of the app
+        ships. Templates you have not edited are untouched either way.
+      </ResponsiveModal.Description>
+    </ResponsiveModal.Header>
+
+    <ScrollArea class="max-h-72">
+      <div class="flex flex-col gap-4 px-6 py-4">
+        {#if behind.length > 0}
+          <div class="flex flex-col gap-2">
+            <div class="flex items-center gap-2">
+              <h4 class="text-sm font-medium">Behind newer shipped text</h4>
+              <Badge variant="secondary">{behind.length}</Badge>
+            </div>
+            <p class="text-muted-foreground text-xs">
+              You edited these, and the app has changed them since.
+            </p>
+            <ul class="flex flex-col gap-1 text-sm">
+              {#each behind as entry (entry.templateId)}
+                <li class="flex items-baseline gap-2">
+                  <span class="text-muted-foreground shrink-0 text-xs">{entry.group}</span>
+                  <span>{entry.label}</span>
+                </li>
+              {/each}
+            </ul>
+          </div>
+        {/if}
+
+        {#if customised.length > 0}
+          <div class="flex flex-col gap-2">
+            <div class="flex items-center gap-2">
+              <h4 class="text-sm font-medium">Customised</h4>
+              <Badge variant="secondary">{customised.length}</Badge>
+            </div>
+            <p class="text-muted-foreground text-xs">
+              You edited these and the app ships nothing newer for them. Replacing these discards
+              your version for no change.
+            </p>
+            <ul class="flex flex-col gap-1 text-sm">
+              {#each customised as entry (entry.templateId)}
+                <li class="flex items-baseline gap-2">
+                  <span class="text-muted-foreground shrink-0 text-xs">{entry.group}</span>
+                  <span>{entry.label}</span>
+                </li>
+              {/each}
+            </ul>
+          </div>
+        {/if}
+      </div>
+    </ScrollArea>
+
+    <ResponsiveModal.Footer class="border-t px-6 py-4">
+      <Button variant="ghost" onclick={onCancel} disabled={refreshing}>Cancel</Button>
+      {#if behind.length > 0}
+        <Button variant="outline" onclick={() => onConfirm('behind')} disabled={refreshing}>
+          Replace the {behind.length} behind
+        </Button>
+      {/if}
+      <Button variant="destructive" onclick={() => onConfirm('edited')} disabled={refreshing}>
+        {refreshing ? 'Replacing…' : `Replace all ${total} edited`}
+      </Button>
+    </ResponsiveModal.Footer>
+  </ResponsiveModal.Content>
+</ResponsiveModal.Root>

--- a/src/lib/components/vault/prompts/UpdatePackDialog.svelte
+++ b/src/lib/components/vault/prompts/UpdatePackDialog.svelte
@@ -1,0 +1,117 @@
+<script lang="ts">
+  import type { PackUpdateSummary } from '$lib/services/packs/update-summary'
+  import type { PackExport } from '$lib/services/packs/validation'
+  import type { PresetPack } from '$lib/services/packs/types'
+  import * as ResponsiveModal from '$lib/components/ui/responsive-modal'
+  import { Button } from '$lib/components/ui/button'
+  import { Badge } from '$lib/components/ui/badge'
+  import * as Alert from '$lib/components/ui/alert'
+  import { AlertTriangle, Download } from '@lucide/svelte'
+
+  interface Props {
+    open: boolean
+    pack: PresetPack | null
+    packData: PackExport | null
+    summary: PackUpdateSummary | null
+    exporting: boolean
+    updating: boolean
+    onExportFirst: () => void
+    onConfirm: () => void
+    onCancel: () => void
+  }
+
+  let {
+    open,
+    pack,
+    packData,
+    summary,
+    exporting,
+    updating,
+    onExportFirst,
+    onConfirm,
+    onCancel,
+  }: Props = $props()
+
+  let stories = $derived(summary?.storyCount ?? 0)
+  let edited = $derived(summary?.editedTemplates ?? 0)
+</script>
+
+<ResponsiveModal.Root
+  {open}
+  onOpenChange={(v) => {
+    if (!v) onCancel()
+  }}
+>
+  <ResponsiveModal.Content class="p-0 sm:max-w-lg">
+    <ResponsiveModal.Header class="border-b px-6 py-4">
+      <ResponsiveModal.Title>Update "{pack?.name}" from file?</ResponsiveModal.Title>
+      <ResponsiveModal.Description>
+        The pack keeps its name and every story stays bound to it. Its templates and variables are
+        replaced by the file's.
+      </ResponsiveModal.Description>
+    </ResponsiveModal.Header>
+
+    {#if pack && packData && summary}
+      <div class="flex flex-col gap-3 px-6 py-4">
+        <div class="flex items-center gap-2">
+          <Badge variant="secondary">{packData.templates.length} templates</Badge>
+          <Badge variant="secondary">{packData.variables.length} variables</Badge>
+          {#if packData.author}
+            <span class="text-muted-foreground text-sm">By {packData.author}</span>
+          {/if}
+        </div>
+
+        {#if edited > 0}
+          <Alert.Root variant="destructive">
+            <AlertTriangle class="h-4 w-4" />
+            <Alert.Title>
+              {edited}
+              {edited === 1 ? 'template carries' : 'templates carry'} your edits
+            </Alert.Title>
+            <Alert.Description>
+              {edited === 1 ? 'It' : 'They'} will be replaced by the file's version. Export the pack first
+              if you want to keep {edited === 1 ? 'it' : 'them'}.
+            </Alert.Description>
+          </Alert.Root>
+        {/if}
+
+        <ul class="text-muted-foreground flex list-disc flex-col gap-1 pl-5 text-sm">
+          <li>
+            {#if stories === 0}
+              No story uses this pack.
+            {:else}
+              {stories}
+              {stories === 1 ? 'story' : 'stories'} will use the new prompts from
+              {stories === 1 ? 'its' : 'their'} next turn.
+            {/if}
+          </li>
+          {#if summary.addedVariables.length > 0}
+            <li>
+              Variables added: <span class="font-mono text-xs"
+                >{summary.addedVariables.join(', ')}</span
+              >
+            </li>
+          {/if}
+          {#if summary.removedVariables.length > 0}
+            <li>
+              Variables removed:
+              <span class="font-mono text-xs">{summary.removedVariables.join(', ')}</span>
+            </li>
+          {/if}
+          <li>Per-entity runtime variable values are not affected.</li>
+        </ul>
+      </div>
+
+      <ResponsiveModal.Footer class="border-t px-6 py-4">
+        <Button variant="ghost" onclick={onCancel} disabled={updating}>Cancel</Button>
+        <Button variant="outline" onclick={onExportFirst} disabled={exporting || updating}>
+          <Download class="mr-2 h-4 w-4" />
+          {exporting ? 'Exporting…' : 'Export current pack'}
+        </Button>
+        <Button variant="destructive" onclick={onConfirm} disabled={updating}>
+          {updating ? 'Updating…' : 'Update'}
+        </Button>
+      </ResponsiveModal.Footer>
+    {/if}
+  </ResponsiveModal.Content>
+</ResponsiveModal.Root>

--- a/src/lib/components/vault/prompts/templateGroups.test.ts
+++ b/src/lib/components/vault/prompts/templateGroups.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { describeTemplate } from './templateGroups'
+
+describe('describeTemplate', () => {
+  it('names a system template and its group', () => {
+    expect(describeTemplate('adventure')).toEqual({
+      name: 'Adventure Mode',
+      group: 'Story Generation',
+      isUserHalf: false,
+    })
+  })
+
+  it('resolves a user half to its prompt and marks it', () => {
+    const described = describeTemplate('adventure-user')
+
+    expect(described).not.toBeNull()
+    expect(described!.name).toBe('Adventure Mode')
+    expect(described!.group).toBe('Story Generation')
+    expect(described!.isUserHalf).toBe(true)
+  })
+
+  it('returns null for an id the app no longer ships', () => {
+    expect(describeTemplate('retired-prompt')).toBeNull()
+    expect(describeTemplate('retired-prompt-user')).toBeNull()
+  })
+})

--- a/src/lib/components/vault/prompts/templateGroups.ts
+++ b/src/lib/components/vault/prompts/templateGroups.ts
@@ -113,3 +113,29 @@ export function getTemplateGroups(): TemplateGroup[] {
 export function getTemplateGroup(templateId: string): string {
   return TEMPLATE_GROUP_MAP[templateId] ?? 'Other'
 }
+
+/** A stored template row named for a reader rather than by its id. */
+export interface TemplateDescription {
+  /** The prompt's display name. */
+  name: string
+  /** The group it is listed under. */
+  group: string
+  /** Whether this row is the prompt's user-message half rather than its system half. */
+  isUserHalf: boolean
+}
+
+/**
+ * Describe a stored template id.
+ *
+ * A `<id>-user` row has no `PROMPT_TEMPLATES` entry of its own, so it resolves its base id
+ * and is marked as that prompt's user half. `null` for an id the app no longer ships.
+ */
+export function describeTemplate(templateId: string): TemplateDescription | null {
+  const isUserHalf = templateId.endsWith('-user')
+  const baseId = isUserHalf ? templateId.slice(0, -'-user'.length) : templateId
+
+  const template = PROMPT_TEMPLATES.find((t) => t.id === baseId)
+  if (!template) return null
+
+  return { name: template.name, group: getTemplateGroup(baseId), isUserHalf }
+}

--- a/src/lib/services/database.ts
+++ b/src/lib/services/database.ts
@@ -38,7 +38,10 @@ import type {
   EnumOption,
 } from '$lib/services/packs/types'
 import { hashContent } from '$lib/services/packs/hash'
-import { packReplacementStatements } from '$lib/services/packs/replace-statements'
+import {
+  packReplacementStatements,
+  shippedTemplateStatements,
+} from '$lib/services/packs/replace-statements'
 import type { PackExport } from '$lib/services/packs/validation'
 
 /**
@@ -3702,6 +3705,20 @@ class DatabaseService {
         now: Date.now(),
       }),
     )
+  }
+
+  /**
+   * Return a pack's templates to the text the app ships, atomically.
+   *
+   * A partially applied refresh would leave the user unable to tell which of their edits
+   * survived, so the batch either lands or does not.
+   */
+  async refreshPackTemplatesToShipped(
+    packId: string,
+    rows: { templateId: string; content: string; contentHash: string }[],
+  ): Promise<void> {
+    if (rows.length === 0) return
+    await this.transaction(shippedTemplateStatements({ packId, rows, now: Date.now() }))
   }
 
   async canDeletePack(packId: string): Promise<boolean> {

--- a/src/lib/services/database.ts
+++ b/src/lib/services/database.ts
@@ -38,6 +38,8 @@ import type {
   EnumOption,
 } from '$lib/services/packs/types'
 import { hashContent } from '$lib/services/packs/hash'
+import { packReplacementStatements } from '$lib/services/packs/replace-statements'
+import type { PackExport } from '$lib/services/packs/validation'
 
 /**
  * A runtime variable's slot in an entity's metadata JSON.
@@ -3671,6 +3673,35 @@ class DatabaseService {
   async deletePack(id: string): Promise<void> {
     const db = await this.getDb()
     await db.execute('DELETE FROM preset_packs WHERE id = ? AND is_default = 0', [id])
+  }
+
+  /**
+   * Replace a pack's templates and variables with a file's, atomically.
+   *
+   * The pack row is updated rather than replaced, so stories keep their `pack_id` and the
+   * runtime variable definitions their entities are keyed to stay where they are. The name
+   * is the user's and is left alone; the file supplies description and author.
+   *
+   * Half of this landing is a pack that is part its old self and part the file's, which
+   * every story bound to it would then narrate from.
+   */
+  async replacePackContents(
+    packId: string,
+    packData: PackExport,
+    hashes: Map<string, string>,
+  ): Promise<void> {
+    await this.transaction(
+      packReplacementStatements({
+        packId,
+        packData,
+        hashes,
+        ids: {
+          templates: packData.templates.map(() => crypto.randomUUID()),
+          variables: packData.variables.map(() => crypto.randomUUID()),
+        },
+        now: Date.now(),
+      }),
+    )
   }
 
   async canDeletePack(packId: string): Promise<boolean> {

--- a/src/lib/services/packs/import-export.test.ts
+++ b/src/lib/services/packs/import-export.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { PackExport } from './validation'
+import type { PresetPack } from './types'
+
+vi.mock('@tauri-apps/plugin-dialog', () => ({ open: vi.fn() }))
+vi.mock('@tauri-apps/plugin-fs', () => ({ writeTextFile: vi.fn(), readTextFile: vi.fn() }))
+vi.mock('$lib/services/exportTarget', () => ({ resolveSaveTarget: vi.fn() }))
+vi.mock('$lib/services/templates/engine', () => ({
+  templateEngine: { parseTemplate: vi.fn(() => ({ success: true })) },
+}))
+
+const replacePackContents = vi.fn()
+const getPack = vi.fn()
+
+vi.mock('$lib/services/database', () => ({
+  database: {
+    replacePackContents: (...args: unknown[]) => replacePackContents(...args),
+    getPackTemplates: vi.fn(async () => []),
+    getPackVariables: vi.fn(async () => []),
+    getPackUsageCount: vi.fn(async () => 0),
+  },
+}))
+
+vi.mock('./pack-service', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./pack-service')>()
+  return {
+    ...actual,
+    packService: { getPack: (...args: unknown[]) => getPack(...args) },
+  }
+})
+
+const { importExportService } = await import('./import-export')
+
+function presetPack(overrides: Partial<PresetPack> = {}): PresetPack {
+  return {
+    id: 'pack-1',
+    name: 'Grimdark Narrator',
+    description: null,
+    author: null,
+    isDefault: false,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  }
+}
+
+const packData: PackExport = {
+  version: 1,
+  name: 'Grimdark Narrator',
+  templates: [
+    { templateId: 'adventure', content: 'tell a story' },
+    { templateId: 'adventure-user', content: 'the user says' },
+  ],
+  variables: [],
+}
+
+describe('updatePackFromFile', () => {
+  beforeEach(() => {
+    replacePackContents.mockReset()
+    getPack.mockReset()
+  })
+
+  it('hashes every template before the single write', async () => {
+    getPack.mockResolvedValue(presetPack())
+
+    await importExportService.updatePackFromFile('pack-1', packData)
+
+    expect(replacePackContents).toHaveBeenCalledTimes(1)
+    const [packId, data, hashes] = replacePackContents.mock.calls[0] as [
+      string,
+      PackExport,
+      Map<string, string>,
+    ]
+    expect(packId).toBe('pack-1')
+    expect(data).toBe(packData)
+    expect([...hashes.keys()].sort()).toEqual(['adventure', 'adventure-user'])
+    for (const hash of hashes.values()) {
+      expect(hash).toMatch(/^[0-9a-f]{64}$/)
+    }
+  })
+
+  it('refuses the built-in pack and writes nothing', async () => {
+    getPack.mockResolvedValue(presetPack({ id: 'default-pack', isDefault: true }))
+
+    await expect(importExportService.updatePackFromFile('default-pack', packData)).rejects.toThrow(
+      /built-in pack cannot be updated/,
+    )
+    expect(replacePackContents).not.toHaveBeenCalled()
+  })
+
+  it('refuses a pack that does not exist', async () => {
+    getPack.mockResolvedValue(null)
+
+    await expect(importExportService.updatePackFromFile('gone', packData)).rejects.toThrow(
+      /Pack not found/,
+    )
+    expect(replacePackContents).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/services/packs/import-export.ts
+++ b/src/lib/services/packs/import-export.ts
@@ -5,6 +5,8 @@ import { packService } from './pack-service'
 import { database } from '$lib/services/database'
 import { validatePackImport, type PackExport } from './validation'
 import { templateEngine } from '$lib/services/templates/engine'
+import { hashContent } from './hash'
+import { packUpdateSummary, type PackUpdateSummary } from './update-summary'
 import type { PresetPack } from './types'
 
 interface TemplateError {
@@ -19,7 +21,12 @@ export interface ImportValidationResult {
   pack?: PackExport
 }
 
-export type ConflictStrategy = 'replace' | 'rename' | 'cancel'
+/**
+ * How a name collision on import is settled. Replacing an existing pack is not one of
+ * them: that is `updatePackFromFile`, reached from the pack itself rather than from a name
+ * that happens to match.
+ */
+export type ConflictStrategy = 'rename' | 'cancel'
 
 class ImportExportService {
   async exportPack(packId: string): Promise<boolean> {
@@ -120,25 +127,46 @@ class ImportExportService {
     return allPacks.find((p) => p.name.toLowerCase() === lowerName) ?? null
   }
 
-  async applyImport(
-    packData: PackExport,
-    strategy: ConflictStrategy,
-    existingPack?: PresetPack,
-  ): Promise<string | null> {
-    if (strategy === 'cancel') return null
+  /** What updating `packId` from this file would discard, for the confirmation. */
+  async summarizeUpdate(packId: string, packData: PackExport): Promise<PackUpdateSummary> {
+    const [currentTemplates, currentVariables, storyCount] = await Promise.all([
+      database.getPackTemplates(packId),
+      database.getPackVariables(packId),
+      database.getPackUsageCount(packId),
+    ])
 
-    if (strategy === 'replace' && existingPack) {
-      if (existingPack.isDefault) {
-        throw new Error('Cannot replace the default pack')
-      }
-      const usageCount = await database.getPackUsageCount(existingPack.id)
-      if (usageCount > 0) {
-        throw new Error(
-          `Cannot replace pack "${existingPack.name}" — it is used by ${usageCount} ${usageCount === 1 ? 'story' : 'stories'}. Reassign them first.`,
-        )
-      }
-      await database.deletePack(existingPack.id)
+    return packUpdateSummary({ currentTemplates, currentVariables, packData, storyCount })
+  }
+
+  /**
+   * Replace an existing pack's contents with a file's, keeping its id and its name.
+   *
+   * The built-in pack is excluded because `PackService.refreshDefaultPackTemplates` rewrites
+   * it from the app's own templates on startup: an import writes rows as their own baseline,
+   * so every one of them would read as untouched and be overwritten on the next launch.
+   */
+  async updatePackFromFile(packId: string, packData: PackExport): Promise<void> {
+    const pack = await packService.getPack(packId)
+    if (!pack) throw new Error('Pack not found')
+    if (pack.isDefault) {
+      throw new Error(
+        'The built-in pack cannot be updated from a file — it is rewritten from the app’s own templates on every launch.',
+      )
     }
+
+    const hashes = new Map(
+      await Promise.all(
+        packData.templates.map(
+          async (t) => [t.templateId, await hashContent(t.content)] as [string, string],
+        ),
+      ),
+    )
+
+    await database.replacePackContents(packId, packData, hashes)
+  }
+
+  async applyImport(packData: PackExport, strategy: ConflictStrategy): Promise<string | null> {
+    if (strategy === 'cancel') return null
 
     let finalName = packData.name
     if (strategy === 'rename') {

--- a/src/lib/services/packs/pack-refresh.test.ts
+++ b/src/lib/services/packs/pack-refresh.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { hashContent } from './hash'
+import type { PackTemplate, PresetPack } from './types'
+
+const getPack = vi.fn()
+const getPackTemplates = vi.fn()
+const refreshPackTemplatesToShipped = vi.fn()
+
+vi.mock('$lib/services/database', () => ({
+  database: {
+    getPack: (...a: unknown[]) => getPack(...a),
+    getPackTemplates: (...a: unknown[]) => getPackTemplates(...a),
+    refreshPackTemplatesToShipped: (...a: unknown[]) => refreshPackTemplatesToShipped(...a),
+  },
+}))
+
+const { packService } = await import('./pack-service')
+const { PROMPT_TEMPLATES } = await import('$lib/services/prompts/templates')
+
+const SHIPPED = PROMPT_TEMPLATES[0]
+const OTHER = PROMPT_TEMPLATES[1]
+
+function row(templateId: string, contentHash: string, baselineHash: string): PackTemplate {
+  return {
+    id: `row-${templateId}`,
+    packId: 'default-pack',
+    templateId,
+    content: 'whatever is stored',
+    contentHash,
+    baselineHash,
+    createdAt: 0,
+    updatedAt: 0,
+  }
+}
+
+function pack(overrides: Partial<PresetPack> = {}): PresetPack {
+  return {
+    id: 'default-pack',
+    name: 'Default',
+    description: null,
+    author: null,
+    isDefault: true,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  }
+}
+
+let shippedHash = ''
+let otherHash = ''
+
+beforeEach(async () => {
+  getPack.mockReset()
+  getPackTemplates.mockReset()
+  refreshPackTemplatesToShipped.mockReset()
+  getPack.mockResolvedValue(pack())
+  shippedHash = await hashContent(SHIPPED.content)
+  otherHash = await hashContent(OTHER.content)
+})
+
+describe('classifyPackTemplates', () => {
+  it('splits the edited rows and ignores the rest', async () => {
+    getPackTemplates.mockResolvedValue([
+      // behind: edited, and the shipped text has moved since
+      row(SHIPPED.id, 'mine', 'a-previous-shipped-hash'),
+      // customised: edited, but the shipped text is what they diverged from
+      row(OTHER.id, 'mine', otherHash),
+      // a row the app no longer ships
+      row('retired-prompt', 'mine', 'anything'),
+    ])
+
+    const result = await packService.classifyPackTemplates('default-pack')
+
+    expect(result).toEqual({ behind: [SHIPPED.id], customised: [OTHER.id] })
+  })
+
+  it('reports nothing for a pack whose rows are all untouched', async () => {
+    getPackTemplates.mockResolvedValue([row(SHIPPED.id, shippedHash, shippedHash)])
+
+    expect(await packService.classifyPackTemplates('default-pack')).toEqual({
+      behind: [],
+      customised: [],
+    })
+  })
+})
+
+describe('refreshTemplates', () => {
+  function mixedPack() {
+    getPackTemplates.mockResolvedValue([
+      row(SHIPPED.id, 'mine', 'a-previous-shipped-hash'),
+      row(OTHER.id, 'mine', otherHash),
+    ])
+  }
+
+  it('writes only the behind rows at the behind scope', async () => {
+    mixedPack()
+
+    const count = await packService.refreshTemplates('default-pack', 'behind')
+
+    expect(count).toBe(1)
+    const [, rows] = refreshPackTemplatesToShipped.mock.calls[0] as [
+      string,
+      { templateId: string; content: string; contentHash: string }[],
+    ]
+    expect(rows.map((r) => r.templateId)).toEqual([SHIPPED.id])
+    expect(rows[0].content).toBe(SHIPPED.content)
+    expect(rows[0].contentHash).toBe(shippedHash)
+  })
+
+  it('writes both states at the edited scope', async () => {
+    mixedPack()
+
+    const count = await packService.refreshTemplates('default-pack', 'edited')
+
+    expect(count).toBe(2)
+    const [, rows] = refreshPackTemplatesToShipped.mock.calls[0] as [
+      string,
+      { templateId: string }[],
+    ]
+    expect(rows.map((r) => r.templateId).sort()).toEqual([OTHER.id, SHIPPED.id].sort())
+  })
+
+  it('writes nothing when no template is edited', async () => {
+    getPackTemplates.mockResolvedValue([row(SHIPPED.id, shippedHash, shippedHash)])
+
+    expect(await packService.refreshTemplates('default-pack', 'edited')).toBe(0)
+    expect(refreshPackTemplatesToShipped).not.toHaveBeenCalled()
+  })
+
+  it('refuses a pack that is not the built-in one', async () => {
+    getPack.mockResolvedValue(pack({ id: 'custom', isDefault: false }))
+
+    await expect(packService.refreshTemplates('custom', 'edited')).rejects.toThrow(
+      /Only the built-in pack/,
+    )
+    expect(refreshPackTemplatesToShipped).not.toHaveBeenCalled()
+  })
+
+  it('refuses a pack that does not exist', async () => {
+    getPack.mockResolvedValue(null)
+
+    await expect(packService.refreshTemplates('gone', 'edited')).rejects.toThrow(/Pack not found/)
+    expect(refreshPackTemplatesToShipped).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/services/packs/pack-service.ts
+++ b/src/lib/services/packs/pack-service.ts
@@ -1,22 +1,15 @@
 import { database } from '$lib/services/database'
 import { PROMPT_TEMPLATES } from '$lib/services/prompts/templates'
 import { hashContent } from './hash'
+import {
+  classifyTemplates,
+  isUntouched,
+  type ClassifiedTemplates,
+  type RefreshScope,
+} from './staleness'
 import type { PresetPack, FullPack, PackTemplate } from './types'
 
-/**
- * Has this template been left exactly as the app last wrote it?
- *
- * `baselineHash` moves only on a write from the code baseline, so content that still hashes
- * to it has never been through the template editor. Anything else is the user's work.
- *
- * The startup refresh needs this because it cannot otherwise tell "the app ships a newer
- * default" from "the user changed this": both show up as a stored hash that differs from the
- * current baseline. It used to compare against the stored content's own hash, so it read
- * every edit as a stale default and reverted it -- on every single app start.
- */
-export function isUntouched(template: Pick<PackTemplate, 'contentHash' | 'baselineHash'>): boolean {
-  return template.contentHash === template.baselineHash
-}
+export { isUntouched } from './staleness'
 
 /**
  * Pack Service
@@ -207,6 +200,65 @@ class PackService {
     updates: { name?: string; description?: string | null; author?: string | null },
   ): Promise<void> {
     await database.updatePack(id, updates)
+  }
+
+  /**
+   * Split a pack's edited templates by whether the app has shipped newer text for them.
+   *
+   * Returned as template ids; the caller names them for display. Ids the app no longer ships
+   * appear in neither group -- there is nothing to compare them against.
+   */
+  async classifyPackTemplates(packId: string): Promise<ClassifiedTemplates> {
+    const rows = await database.getPackTemplates(packId)
+
+    const shippedHashes = new Map(
+      await Promise.all(
+        rows.map(async (row) => {
+          const shipped = this.getDefaultContent(row.templateId)
+          return [row.templateId, shipped === null ? undefined : await hashContent(shipped)] as [
+            string,
+            string | undefined,
+          ]
+        }),
+      ).then((entries) => entries.filter((e): e is [string, string] => e[1] !== undefined)),
+    )
+
+    return classifyTemplates(rows, shippedHashes)
+  }
+
+  /**
+   * Return a pack's edited templates to the shipped text, at the scope the user chose.
+   *
+   * `'behind'` takes only the templates the app has changed since; `'edited'` takes every
+   * edit, which is what keeps a set of related customisations coherent rather than leaving
+   * half of it against the other half's replacement.
+   *
+   * Restricted to the default pack: a custom pack's baseline is not the shipped text -- for
+   * an imported pack it is the file its author wrote, so this would overwrite their prompts
+   * rather than restore anything.
+   */
+  async refreshTemplates(packId: string, scope: RefreshScope): Promise<number> {
+    const pack = await database.getPack(packId)
+    if (!pack) throw new Error('Pack not found')
+    if (!pack.isDefault) {
+      throw new Error(
+        'Only the built-in pack can be refreshed from the shipped prompts — a custom pack’s templates came from its author, not from the app.',
+      )
+    }
+
+    const { behind, customised } = await this.classifyPackTemplates(packId)
+    const templateIds = scope === 'behind' ? behind : [...behind, ...customised]
+    if (templateIds.length === 0) return 0
+
+    const rows = await Promise.all(
+      templateIds.map(async (templateId) => {
+        const content = this.getDefaultContent(templateId)!
+        return { templateId, content, contentHash: await hashContent(content) }
+      }),
+    )
+
+    await database.refreshPackTemplatesToShipped(packId, rows)
+    return rows.length
   }
 
   /** Delete a pack. Default pack and packs in use by stories cannot be deleted. */

--- a/src/lib/services/packs/replace-statements.test.ts
+++ b/src/lib/services/packs/replace-statements.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest'
+import {
+  packTemplateStatement,
+  packVariableStatement,
+  packReplacementStatements,
+} from './replace-statements'
+import type { PackExport } from './validation'
+
+function pack(overrides: Partial<PackExport> = {}): PackExport {
+  return {
+    version: 1,
+    name: 'Grimdark Narrator',
+    templates: [{ templateId: 'adventure', content: 'tell a story' }],
+    variables: [],
+    ...overrides,
+  }
+}
+
+describe('packTemplateStatement', () => {
+  it('records the file as the row baseline', () => {
+    const { sql, params } = packTemplateStatement({
+      id: 'row-1',
+      packId: 'pack-1',
+      templateId: 'adventure',
+      content: 'tell a story',
+      contentHash: 'abc123',
+      now: 1000,
+    })
+
+    expect(sql).toContain('INSERT INTO pack_templates')
+    expect(params).toEqual([
+      'row-1',
+      'pack-1',
+      'adventure',
+      'tell a story',
+      'abc123',
+      'abc123',
+      1000,
+      1000,
+    ])
+    // content_hash and baseline_hash are positions 4 and 5: equal means "untouched", which is
+    // what the pack is until the user edits it.
+    expect(params[4]).toBe(params[5])
+  })
+})
+
+describe('packVariableStatement', () => {
+  it('writes NULL, never undefined, for absent optional fields', () => {
+    const { params } = packVariableStatement({
+      id: 'var-1',
+      packId: 'pack-1',
+      variable: {
+        variableName: 'tone',
+        displayName: 'Tone',
+        variableType: 'text',
+        isRequired: false,
+      },
+      sortOrder: 3,
+      now: 1000,
+    })
+
+    expect(params).not.toContain(undefined)
+    expect(params).toEqual([
+      'var-1',
+      'pack-1',
+      'tone',
+      'Tone',
+      null,
+      'text',
+      0,
+      3,
+      null,
+      null,
+      1000,
+    ])
+  })
+
+  it('serializes enum options and keeps the file sort order', () => {
+    const { params } = packVariableStatement({
+      id: 'var-1',
+      packId: 'pack-1',
+      variable: {
+        variableName: 'tone',
+        displayName: 'Tone',
+        description: 'How it reads',
+        variableType: 'enum',
+        isRequired: true,
+        sortOrder: 7,
+        defaultValue: 'grim',
+        enumOptions: [{ label: 'Grim', value: 'grim' }],
+      },
+      sortOrder: 3,
+      now: 1000,
+    })
+
+    expect(params[4]).toBe('How it reads')
+    expect(params[6]).toBe(1)
+    expect(params[7]).toBe(7)
+    expect(params[9]).toBe(JSON.stringify([{ label: 'Grim', value: 'grim' }]))
+  })
+})
+
+describe('packReplacementStatements', () => {
+  const base = {
+    packId: 'pack-1',
+    hashes: new Map([['adventure', 'abc123']]),
+    ids: { templates: ['row-1'], variables: [] },
+    now: 1000,
+  }
+
+  it('updates the pack row and clears its children without deleting the pack', () => {
+    const statements = packReplacementStatements({ ...base, packData: pack() })
+    const sql = statements.map((s) => s.sql).join('\n')
+
+    expect(sql).toContain('UPDATE preset_packs')
+    expect(sql).toContain('DELETE FROM pack_templates')
+    expect(sql).toContain('DELETE FROM pack_variables')
+    expect(sql).not.toContain('DELETE FROM preset_packs')
+    // Deleting the pack row would cascade these away and strand every entity value keyed to
+    // them; the file carries no runtime variables to put back.
+    expect(sql).not.toContain('pack_runtime_variables')
+  })
+
+  it('leaves the pack name alone', () => {
+    const statements = packReplacementStatements({ ...base, packData: pack() })
+    const update = statements[0]
+
+    expect(update.sql).not.toContain('name')
+    expect(update.params).not.toContain('Grimdark Narrator')
+  })
+
+  it('passes no undefined parameter when description and author are absent', () => {
+    const statements = packReplacementStatements({
+      ...base,
+      packData: pack({
+        variables: [
+          { variableName: 'tone', displayName: 'Tone', variableType: 'text', isRequired: false },
+        ],
+      }),
+      ids: { templates: ['row-1'], variables: ['var-1'] },
+    })
+
+    for (const statement of statements) {
+      expect(statement.params).not.toContain(undefined)
+    }
+  })
+
+  it('clears the children before inserting the replacements', () => {
+    const statements = packReplacementStatements({ ...base, packData: pack() })
+    const lastDelete = statements.findLastIndex((s) => s.sql.startsWith('DELETE'))
+    const firstInsert = statements.findIndex((s) => s.sql.startsWith('INSERT'))
+
+    expect(firstInsert).toBeGreaterThan(lastDelete)
+  })
+
+  it('refuses a template it has no hash for', () => {
+    expect(() =>
+      packReplacementStatements({
+        ...base,
+        packData: pack({ templates: [{ templateId: 'unhashed', content: 'x' }] }),
+      }),
+    ).toThrow(/no hash for template unhashed/)
+  })
+
+  it('refuses an id list that does not cover every row', () => {
+    expect(() =>
+      packReplacementStatements({
+        ...base,
+        packData: pack(),
+        ids: { templates: [], variables: [] },
+      }),
+    ).toThrow(/one id required per template/)
+  })
+})

--- a/src/lib/services/packs/replace-statements.test.ts
+++ b/src/lib/services/packs/replace-statements.test.ts
@@ -3,6 +3,8 @@ import {
   packTemplateStatement,
   packVariableStatement,
   packReplacementStatements,
+  shippedTemplateStatement,
+  shippedTemplateStatements,
 } from './replace-statements'
 import type { PackExport } from './validation'
 
@@ -170,5 +172,59 @@ describe('packReplacementStatements', () => {
         ids: { templates: [], variables: [] },
       }),
     ).toThrow(/one id required per template/)
+  })
+})
+
+describe('shippedTemplateStatement', () => {
+  it('updates an existing row and marks it untouched again', () => {
+    const { sql, params } = shippedTemplateStatement({
+      packId: 'pack-1',
+      templateId: 'adventure',
+      content: 'the shipped text',
+      contentHash: 'shipped-hash',
+      now: 1000,
+    })
+
+    expect(sql).toContain('UPDATE pack_templates')
+    expect(sql).not.toContain('INSERT')
+    expect(sql).toContain('WHERE pack_id = ? AND template_id = ?')
+    expect(params).toEqual([
+      'the shipped text',
+      'shipped-hash',
+      'shipped-hash',
+      1000,
+      'pack-1',
+      'adventure',
+    ])
+    // content_hash and baseline_hash both come from the shipped text, so the startup refresh
+    // takes future changes to this row again.
+    expect(params[1]).toBe(params[2])
+  })
+})
+
+describe('shippedTemplateStatements', () => {
+  const rows = [
+    { templateId: 'adventure', content: 'a', contentHash: 'ha' },
+    { templateId: 'classifier', content: 'b', contentHash: 'hb' },
+  ]
+
+  it('emits one statement per row and touches nothing else', () => {
+    const statements = shippedTemplateStatements({ packId: 'pack-1', rows, now: 1000 })
+    const sql = statements.map((s) => s.sql).join(' ')
+
+    expect(statements).toHaveLength(2)
+    expect(sql).not.toContain('pack_variables')
+    expect(sql).not.toContain('preset_packs')
+    expect(sql).not.toContain('pack_runtime_variables')
+    expect(sql).not.toContain('DELETE')
+  })
+
+  it('scopes every statement to the one pack', () => {
+    const statements = shippedTemplateStatements({ packId: 'pack-1', rows, now: 1000 })
+
+    for (const statement of statements) {
+      expect(statement.params).toContain('pack-1')
+      expect(statement.params).not.toContain(undefined)
+    }
   })
 })

--- a/src/lib/services/packs/replace-statements.ts
+++ b/src/lib/services/packs/replace-statements.ts
@@ -42,6 +42,47 @@ export function packTemplateStatement(args: {
 }
 
 /**
+ * Return one existing template row to the text the app ships.
+ *
+ * All three hash-bearing columns come from the shipped text, so the row reads as untouched
+ * again and the startup refresh takes future changes to it.
+ *
+ * An UPDATE rather than the insert-or-replace the general writer uses: this only ever runs
+ * on rows already read from the pack, so it cannot create one for a template the pack does
+ * not have.
+ */
+export function shippedTemplateStatement(args: {
+  packId: string
+  templateId: string
+  content: string
+  contentHash: string
+  now: number
+}): Statement {
+  return {
+    sql: 'UPDATE pack_templates SET content = ?, content_hash = ?, baseline_hash = ?, updated_at = ? WHERE pack_id = ? AND template_id = ?',
+    params: [
+      args.content,
+      args.contentHash,
+      args.contentHash,
+      args.now,
+      args.packId,
+      args.templateId,
+    ],
+  }
+}
+
+/** The statements returning a set of a pack's templates to the shipped text, as one batch. */
+export function shippedTemplateStatements(args: {
+  packId: string
+  rows: { templateId: string; content: string; contentHash: string }[]
+  now: number
+}): Statement[] {
+  return args.rows.map((row) =>
+    shippedTemplateStatement({ packId: args.packId, ...row, now: args.now }),
+  )
+}
+
+/**
  * One variable row of a replaced pack.
  *
  * Every optional field lands as an explicit NULL: `transaction` rejects `undefined` rather

--- a/src/lib/services/packs/replace-statements.ts
+++ b/src/lib/services/packs/replace-statements.ts
@@ -1,0 +1,135 @@
+import type { PackExport } from './validation'
+
+/** A statement in the form `database.transaction` takes. */
+export interface Statement {
+  sql: string
+  params: unknown[]
+}
+
+const TEMPLATE_SQL = `INSERT INTO pack_templates (id, pack_id, template_id, content, content_hash, baseline_hash, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+
+const VARIABLE_SQL = `INSERT INTO pack_variables (id, pack_id, variable_name, display_name, description, variable_type, is_required, sort_order, default_value, enum_options, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+
+/**
+ * One template row of a replaced pack.
+ *
+ * `baseline_hash` equals `content_hash`: the file is this pack's baseline, so what has to
+ * survive a later refresh is whatever the user edits afterwards, not the file itself.
+ */
+export function packTemplateStatement(args: {
+  id: string
+  packId: string
+  templateId: string
+  content: string
+  contentHash: string
+  now: number
+}): Statement {
+  return {
+    sql: TEMPLATE_SQL,
+    params: [
+      args.id,
+      args.packId,
+      args.templateId,
+      args.content,
+      args.contentHash,
+      args.contentHash,
+      args.now,
+      args.now,
+    ],
+  }
+}
+
+/**
+ * One variable row of a replaced pack.
+ *
+ * Every optional field lands as an explicit NULL: `transaction` rejects `undefined` rather
+ * than guess what it meant.
+ */
+export function packVariableStatement(args: {
+  id: string
+  packId: string
+  variable: PackExport['variables'][number]
+  sortOrder: number
+  now: number
+}): Statement {
+  const { variable } = args
+  return {
+    sql: VARIABLE_SQL,
+    params: [
+      args.id,
+      args.packId,
+      variable.variableName,
+      variable.displayName,
+      variable.description ?? null,
+      variable.variableType,
+      variable.isRequired ? 1 : 0,
+      variable.sortOrder ?? args.sortOrder,
+      variable.defaultValue ?? null,
+      variable.enumOptions ? JSON.stringify(variable.enumOptions) : null,
+      args.now,
+    ],
+  }
+}
+
+/**
+ * Every statement that turns a pack's contents into the file's, in order.
+ *
+ * The pack row is updated, never deleted: `stories.pack_id` is `ON DELETE RESTRICT` and
+ * `pack_runtime_variables` is `ON DELETE CASCADE`, so removing it would either fail or
+ * strand the per-entity values keyed to those definitions. The name is the user's label and
+ * stays theirs.
+ *
+ * `hashes` is keyed by template id and must cover every template in `packData`.
+ */
+export function packReplacementStatements(args: {
+  packId: string
+  packData: PackExport
+  hashes: Map<string, string>
+  ids: { templates: string[]; variables: string[] }
+  now: number
+}): Statement[] {
+  const { packId, packData, hashes, ids, now } = args
+
+  if (ids.templates.length !== packData.templates.length) {
+    throw new Error('packReplacementStatements: one id required per template')
+  }
+  if (ids.variables.length !== packData.variables.length) {
+    throw new Error('packReplacementStatements: one id required per variable')
+  }
+
+  const statements: Statement[] = [
+    {
+      sql: 'UPDATE preset_packs SET description = ?, author = ?, updated_at = ? WHERE id = ?',
+      params: [packData.description ?? null, packData.author ?? null, now, packId],
+    },
+    { sql: 'DELETE FROM pack_templates WHERE pack_id = ?', params: [packId] },
+    { sql: 'DELETE FROM pack_variables WHERE pack_id = ?', params: [packId] },
+  ]
+
+  packData.templates.forEach((template, i) => {
+    const contentHash = hashes.get(template.templateId)
+    if (contentHash === undefined) {
+      throw new Error(`packReplacementStatements: no hash for template ${template.templateId}`)
+    }
+    statements.push(
+      packTemplateStatement({
+        id: ids.templates[i],
+        packId,
+        templateId: template.templateId,
+        content: template.content,
+        contentHash,
+        now,
+      }),
+    )
+  })
+
+  packData.variables.forEach((variable, i) => {
+    statements.push(
+      packVariableStatement({ id: ids.variables[i], packId, variable, sortOrder: i, now }),
+    )
+  })
+
+  return statements
+}

--- a/src/lib/services/packs/staleness.test.ts
+++ b/src/lib/services/packs/staleness.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest'
+import { classifyTemplate, classifyTemplates } from './staleness'
+
+const SHIPPED = 'shipped-hash'
+
+function row(templateId: string, contentHash: string, baselineHash: string) {
+  return { templateId, contentHash, baselineHash }
+}
+
+describe('classifyTemplate', () => {
+  it('reads an untouched row as current', () => {
+    expect(classifyTemplate(row('adventure', SHIPPED, SHIPPED), SHIPPED)).toBe('current')
+  })
+
+  it('reads an edited row whose baseline is the shipped text as customised', () => {
+    expect(classifyTemplate(row('adventure', 'mine', SHIPPED), SHIPPED)).toBe('customised')
+  })
+
+  it('reads an edited row whose baseline predates the shipped text as behind', () => {
+    expect(classifyTemplate(row('adventure', 'mine', 'older-shipped'), SHIPPED)).toBe('behind')
+  })
+
+  it('still reads as behind after a second edit', () => {
+    // Only a baseline write moves baselineHash, and the refresh never touches an edited row,
+    // so it stays pinned to the shipped text the user first diverged from.
+    expect(classifyTemplate(row('adventure', 'mine-again', 'older-shipped'), SHIPPED)).toBe(
+      'behind',
+    )
+  })
+
+  it('reads a row the editor created as behind', () => {
+    // baselineHash '' matches no shipped hash. A known false positive, named in the listing.
+    expect(classifyTemplate(row('adventure', 'mine', ''), SHIPPED)).toBe('behind')
+  })
+
+  it('returns null for a template the app no longer ships', () => {
+    expect(classifyTemplate(row('retired', 'mine', 'older'), undefined)).toBeNull()
+  })
+
+  it('reads an untouched row as current even before the startup refresh reaches it', () => {
+    expect(classifyTemplate(row('adventure', 'older', 'older'), SHIPPED)).toBe('current')
+  })
+})
+
+describe('classifyTemplates', () => {
+  const shippedHashes = new Map([
+    ['adventure', SHIPPED],
+    ['adventure-user', SHIPPED],
+    ['classifier', SHIPPED],
+  ])
+
+  it('splits the edited rows and drops the rest', () => {
+    const result = classifyTemplates(
+      [
+        row('adventure', 'mine', 'older-shipped'),
+        row('adventure-user', 'mine', SHIPPED),
+        row('classifier', SHIPPED, SHIPPED),
+      ],
+      shippedHashes,
+    )
+
+    expect(result).toEqual({ behind: ['adventure'], customised: ['adventure-user'] })
+  })
+
+  it('excludes a row whose id the app no longer ships from both groups', () => {
+    const result = classifyTemplates([row('retired', 'mine', 'older-shipped')], shippedHashes)
+
+    expect(result).toEqual({ behind: [], customised: [] })
+  })
+
+  it('judges a user half independently of its system half', () => {
+    const result = classifyTemplates(
+      [row('adventure', SHIPPED, SHIPPED), row('adventure-user', 'mine', 'older-shipped')],
+      shippedHashes,
+    )
+
+    expect(result).toEqual({ behind: ['adventure-user'], customised: [] })
+  })
+})

--- a/src/lib/services/packs/staleness.test.ts
+++ b/src/lib/services/packs/staleness.test.ts
@@ -28,9 +28,10 @@ describe('classifyTemplate', () => {
     )
   })
 
-  it('reads a row the editor created as behind', () => {
-    // baselineHash '' matches no shipped hash. A known false positive, named in the listing.
-    expect(classifyTemplate(row('adventure', 'mine', ''), SHIPPED)).toBe('behind')
+  it('reads a row with no baseline as customised, not behind', () => {
+    // Nothing shipped is newer than a row the app never supplied, so the `behind` scope --
+    // which promises to take only what the app has changed since -- must not overwrite it.
+    expect(classifyTemplate(row('adventure', 'mine', ''), SHIPPED)).toBe('customised')
   })
 
   it('returns null for a template the app no longer ships', () => {
@@ -60,6 +61,12 @@ describe('classifyTemplates', () => {
     )
 
     expect(result).toEqual({ behind: ['adventure'], customised: ['adventure-user'] })
+  })
+
+  it('keeps a row with no baseline out of the behind group', () => {
+    const result = classifyTemplates([row('adventure', 'mine', '')], shippedHashes)
+
+    expect(result).toEqual({ behind: [], customised: ['adventure'] })
   })
 
   it('excludes a row whose id the app no longer ships from both groups', () => {

--- a/src/lib/services/packs/staleness.ts
+++ b/src/lib/services/packs/staleness.ts
@@ -1,0 +1,67 @@
+import type { PackTemplate } from './types'
+
+/**
+ * Has this template been left exactly as the app last wrote it?
+ *
+ * `baselineHash` moves only on a write from the code baseline, so content that still hashes
+ * to it has never been through the template editor. Anything else is the user's work.
+ *
+ * The startup refresh needs this because it cannot otherwise tell "the app ships a newer
+ * default" from "the user changed this": both show up as a stored hash that differs from the
+ * current baseline. It used to compare against the stored content's own hash, so it read
+ * every edit as a stale default and reverted it -- on every single app start.
+ */
+export function isUntouched(template: Pick<PackTemplate, 'contentHash' | 'baselineHash'>): boolean {
+  return template.contentHash === template.baselineHash
+}
+
+/** Which of a pack's edited templates a refresh replaces. */
+export type RefreshScope = 'behind' | 'edited'
+
+/** Where a stored template sits relative to the text the app ships. */
+export type TemplateState = 'current' | 'customised' | 'behind'
+
+/** The rows of a pack that carry a user edit, split by whether newer text has shipped. */
+export interface ClassifiedTemplates {
+  behind: string[]
+  customised: string[]
+}
+
+type Row = Pick<PackTemplate, 'templateId' | 'contentHash' | 'baselineHash'>
+
+/**
+ * Classify one row against the shipped text's hash.
+ *
+ * `baselineHash` is the hash of the shipped text this row was last written from, so it
+ * separates "the user changed this" from "the app has changed it since". Both halves are
+ * needed: `isUntouched` alone counts customisations as stale, and the baseline comparison
+ * alone flags every row of a pack whose baseline was never the shipped text.
+ *
+ * `null` when the app no longer ships this id -- there is nothing to compare against and
+ * nothing to bring the row forward to.
+ *
+ * A row the editor created carries `baselineHash: ''`, which matches no shipped hash and so
+ * reads as behind. The listing names it before anything is written.
+ */
+export function classifyTemplate(row: Row, shippedHash: string | undefined): TemplateState | null {
+  if (shippedHash === undefined) return null
+  if (isUntouched(row)) return 'current'
+  return row.baselineHash === shippedHash ? 'customised' : 'behind'
+}
+
+/** The same over a pack's rows, keeping only the edited ones. */
+export function classifyTemplates(
+  rows: Row[],
+  shippedHashes: Map<string, string>,
+): ClassifiedTemplates {
+  const behind: string[] = []
+  const customised: string[] = []
+
+  for (const row of rows) {
+    const state = classifyTemplate(row, shippedHashes.get(row.templateId))
+    if (state === 'behind') behind.push(row.templateId)
+    else if (state === 'customised') customised.push(row.templateId)
+  }
+
+  return { behind, customised }
+}

--- a/src/lib/services/packs/staleness.ts
+++ b/src/lib/services/packs/staleness.ts
@@ -40,12 +40,16 @@ type Row = Pick<PackTemplate, 'templateId' | 'contentHash' | 'baselineHash'>
  * `null` when the app no longer ships this id -- there is nothing to compare against and
  * nothing to bring the row forward to.
  *
- * A row the editor created carries `baselineHash: ''`, which matches no shipped hash and so
- * reads as behind. The listing names it before anything is written.
+ * An empty `baselineHash` is a row written with no baseline to keep, so nothing shipped is
+ * newer than it and it is not behind anything. It classifies as customised, which keeps it
+ * out of the `behind` scope: that scope's promise is that it only takes what the app has
+ * changed since, and overwriting content the app never supplied would break it. The `edited`
+ * scope still replaces the row, because there the user has asked for exactly that.
  */
 export function classifyTemplate(row: Row, shippedHash: string | undefined): TemplateState | null {
   if (shippedHash === undefined) return null
   if (isUntouched(row)) return 'current'
+  if (row.baselineHash === '') return 'customised'
   return row.baselineHash === shippedHash ? 'customised' : 'behind'
 }
 

--- a/src/lib/services/packs/update-summary.test.ts
+++ b/src/lib/services/packs/update-summary.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { packUpdateSummary } from './update-summary'
+import type { PackExport } from './validation'
+
+function variable(variableName: string): PackExport['variables'][number] {
+  return { variableName, displayName: variableName, variableType: 'text', isRequired: false }
+}
+
+function pack(variableNames: string[]): PackExport {
+  return {
+    version: 1,
+    name: 'Grimdark Narrator',
+    templates: [],
+    variables: variableNames.map(variable),
+  }
+}
+
+describe('packUpdateSummary', () => {
+  it('counts a template the user edited and not one left alone', () => {
+    const summary = packUpdateSummary({
+      currentTemplates: [
+        { contentHash: 'aaa', baselineHash: 'aaa' },
+        { contentHash: 'edited', baselineHash: 'aaa' },
+        // A row created by the editor keeps no baseline, so it reads as edited.
+        { contentHash: 'bbb', baselineHash: '' },
+      ],
+      currentVariables: [],
+      packData: pack([]),
+      storyCount: 0,
+    })
+
+    expect(summary.editedTemplates).toBe(2)
+  })
+
+  it('reports variables added, removed, and unchanged', () => {
+    const summary = packUpdateSummary({
+      currentTemplates: [],
+      currentVariables: [{ variableName: 'tone' }, { variableName: 'era' }],
+      packData: pack(['tone', 'pov']),
+      storyCount: 0,
+    })
+
+    expect(summary.addedVariables).toEqual(['pov'])
+    expect(summary.removedVariables).toEqual(['era'])
+  })
+
+  it('reports no variable change when the file defines the same set', () => {
+    const summary = packUpdateSummary({
+      currentTemplates: [],
+      currentVariables: [{ variableName: 'tone' }],
+      packData: pack(['tone']),
+      storyCount: 0,
+    })
+
+    expect(summary.addedVariables).toEqual([])
+    expect(summary.removedVariables).toEqual([])
+  })
+
+  it('passes the story count through', () => {
+    const summary = packUpdateSummary({
+      currentTemplates: [],
+      currentVariables: [],
+      packData: pack([]),
+      storyCount: 3,
+    })
+
+    expect(summary.storyCount).toBe(3)
+  })
+})

--- a/src/lib/services/packs/update-summary.ts
+++ b/src/lib/services/packs/update-summary.ts
@@ -1,0 +1,41 @@
+import { isUntouched } from './pack-service'
+import type { PackExport } from './validation'
+import type { CustomVariable, PackTemplate } from './types'
+
+/** What an update is about to cost, for the confirmation that precedes it. */
+export interface PackUpdateSummary {
+  /** Templates carrying a user edit the update will discard. */
+  editedTemplates: number
+  /** Stories that will narrate from the file's templates on their next turn. */
+  storyCount: number
+  /** Variable names the file introduces. */
+  addedVariables: string[]
+  /** Variable names the file drops. */
+  removedVariables: string[]
+}
+
+/**
+ * Compare a pack against the file about to replace it.
+ *
+ * Edits are counted with `isUntouched` -- "did the user change this?" -- not against the
+ * app's current shipped text, which also flags templates the user never touched but a later
+ * app version has since improved.
+ */
+export function packUpdateSummary(args: {
+  currentTemplates: Pick<PackTemplate, 'contentHash' | 'baselineHash'>[]
+  currentVariables: Pick<CustomVariable, 'variableName'>[]
+  packData: PackExport
+  storyCount: number
+}): PackUpdateSummary {
+  const { currentTemplates, currentVariables, packData, storyCount } = args
+
+  const current = new Set(currentVariables.map((v) => v.variableName))
+  const incoming = new Set(packData.variables.map((v) => v.variableName))
+
+  return {
+    editedTemplates: currentTemplates.filter((t) => !isUntouched(t)).length,
+    storyCount,
+    addedVariables: [...incoming].filter((name) => !current.has(name)),
+    removedVariables: [...current].filter((name) => !incoming.has(name)),
+  }
+}


### PR DESCRIPTION
Two changes to how a prompt pack's contents are replaced. They are separate features on one branch because they are two halves of the same problem: **an existing pack has no way to receive newer prompts.**

- A **custom** pack is frozen at the baseline it was created from. `backfillMissingTemplates` inserts template ids a later version *adds*, but never updates content. Importing a newer `.prompt.json` over the pack was the only cure, and it refused exactly when the pack mattered.
- A **built-in** pack template you have edited is frozen too. `refreshDefaultPackTemplates` skips any row whose `content_hash` and `baseline_hash` differ, so shipped improvements to that prompt never arrive, silently, on every launch. Nothing in the UI said so.

## 1. Update a prompt pack from a file, in place

`applyImport`'s `replace` meant delete-then-create under a fresh UUID, which `stories.pack_id` (`ON DELETE RESTRICT`) forbids while any story uses the pack. Replacing the pack's **contents** instead of the pack removes the obstacle rather than working around it:

- The `preset_packs` row is updated, never deleted, so stories keep their `pack_id` and pick up the new prompts on their next turn. `resolveTemplate` reads the database per call, so there is no cache to invalidate.
- **Runtime variable definitions are untouched.** `pack_runtime_variables` is `ON DELETE CASCADE`; dropping the pack row would take the definitions with it while entity `metadata.runtimeVars` kept holding values keyed to them. The export format carries no runtime variables, so a file that says nothing about them changes nothing about them.
- One transaction. Half of this landing is a pack that is part its old self and part the file's, which every story bound to it would then narrate from.
- The entry point is the pack's own card, so the target is chosen before the file and no name matching is involved. The pack keeps its name — `preset_packs` has `UNIQUE(name)`, so taking the file's name could collide — and takes description and author from the file.
- A confirmation states the cost first: templates carrying edits, stories affected, variables added and removed. It offers to export the pack before overwriting it, which makes an irreversible operation recoverable for one existing call.
- **`ConflictStrategy` loses `'replace'`.** With a deliberate path available, overwriting a pack because a name happened to match is a footgun. `applyImport` sheds its `existingPack` parameter, both throws, and the `deletePack` call — the change is net-subtractive here.
- `default-pack` is excluded, for a new reason: an import writes rows as their own baseline, so every one would read as untouched and the startup refresh would overwrite the whole import on the next launch.

## 2. Refresh the built-in pack's edited templates

`baseline_hash` already holds the hash of the shipped text a row was written from, which is enough to separate three states without storing any text:

| | `content_hash` vs `baseline_hash` | `baseline_hash` vs hash of shipped text | |
| --- | --- | --- | --- |
| **Current** | equal | equal | the startup refresh keeps it up to date |
| **Customised** | differ | equal | edited; nothing newer has shipped |
| **Behind** | differ | differ | edited **and** newer text has shipped since |

Pack Settings now reports both counts for the built-in pack and offers a refresh at one of two scopes.

**The classification informs the user rather than deciding for them.** Prompts reference shared conventions and a user's edits usually span several templates written to agree with each other, so replacing only the behind subset can leave half a coherent set of edits sitting against the other half's replacement. `'behind'` takes what the app has changed since; `'edited'` takes every edit, which restores coherence and is also the deliberate revert-to-stock the app otherwise lacked.

The dialog lists every affected template by display name and group before anything is written — which also makes visible the one known false positive, a row the editor created carrying `baseline_hash = ''`.

Restricted to the built-in pack. A custom pack's baseline is not the shipped text: for an imported pack it is the file its author wrote, so the predicate is unreliable there and the operation would replace the author's prompts with ours.

## Also

- **Android:** the pack card's Export and Delete buttons used `opacity-0 group-hover:opacity-100`. Tailwind v4 gates `group-hover:` behind `@media (hover: hover)`, so on a touch device they stayed fully transparent while remaining tappable — invisible controls. Now on the `sm:`-qualified form already used in `BranchPanel`. Ten further sites share the bug and are left for a separate sweep.
- `isUntouched` moves to a new `staleness` module which owns the hash comparisons; `pack-service` re-exports it, so existing callers are unchanged.
- `docs/architecture/prompts.md` gains sections for both features.

## Testing

`npm run check`, `npm test` (1306 passing) and `npm run lint` all clean. 23 new unit tests across the statement builders, the classifier, the display-name resolver, and the service guards.

Both features were also exercised end to end in the running app, including a story bound to a pack across an in-place update (binding kept, runtime variable values still displayed) and both refresh scopes against a simulated shipped change.

## Notes for review

- No migration. Every table and column already exists (030, 031, 032).
- Interaction with #446, considered and accepted: an update takes `author` from the file, and `matchPack` uses name + author. Changing a pack's author therefore downgrades a previously exported story from an `exact` match to `name-only`, so re-import prompts instead of binding silently. That is the correct outcome — the pack's identity really did change.
- Several unrelated defects were found in passing and deliberately not fixed here; they are recorded rather than dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Update user-created prompt packs directly from an imported file.
  * Review affected templates, variables, and stories before confirming updates.
  * Export the current pack before replacing its contents.
  * Refresh outdated or customized templates in the default pack.
  * View improved template status information in Pack Settings.
* **Changes**
  * Conflicting imports are now added as copies; use “Update from file” to replace an existing pack.
  * Pack actions are more accessible on small screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->