### PR TITLE
Mobile sidebar: drop the app-wide swipe handler, close on panel navigation

### DIFF
--- a/src/lib/components/layout/AppShell.svelte
+++ b/src/lib/components/layout/AppShell.svelte
@@ -34,15 +34,8 @@
 
   const log = createLogger('AppShell')
 
-  // Swipe handlers for mobile sidebar toggle
-  function handleSwipeLeft() {
+  function handleEdgeSwipeLeft() {
     if (story.currentStory && !ui.sidebarOpen) {
-      ui.toggleSidebar()
-    }
-  }
-
-  function handleSwipeRight() {
-    if (ui.sidebarOpen) {
       ui.toggleSidebar()
     }
   }
@@ -209,14 +202,7 @@
   onresize={handleWindowResize}
 />
 
-<div
-  class="app-shell bg-surface-900 relative flex h-screen w-screen flex-col"
-  use:swipe={{
-    onSwipeRight: handleSwipeRight,
-    onSwipeLeft: handleSwipeLeft,
-    threshold: 50,
-  }}
->
+<div class="app-shell bg-surface-900 relative flex h-screen w-screen flex-col">
   <!-- Profile Warning Banner (shown when API profiles need updating) -->
   <ProfileWarningBanner />
 
@@ -235,7 +221,7 @@
     {#if !ui.sidebarOpen && story.currentStory}
       <div
         class="swipe-edge-zone"
-        use:swipe={{ onSwipeLeft: handleSwipeLeft, threshold: 30 }}
+        use:swipe={{ onSwipeLeft: handleEdgeSwipeLeft, threshold: 30 }}
       ></div>
     {/if}
 

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -136,7 +136,10 @@
       'lorebook'
         ? '!bg-primary/10 !text-primary'
         : ''}"
-      onclick={() => ui.setActivePanel('lorebook')}
+      onclick={() => {
+        ui.setActivePanel('lorebook')
+        ui.closeSidebarOnMobile()
+      }}
       title="Lorebook"
     >
       <BookMarked class="h-4 w-4" />
@@ -148,7 +151,10 @@
       'memory'
         ? '!bg-primary/10 !text-primary'
         : ''}"
-      onclick={() => ui.setActivePanel('memory')}
+      onclick={() => {
+        ui.setActivePanel('memory')
+        ui.closeSidebarOnMobile()
+      }}
       title="Memory"
     >
       <Brain class="h-4 w-4" />


### PR DESCRIPTION
## What

Two fixes to how the sidebar behaves on the mobile/overlay breakpoint.

**Drop the app-wide swipe handler.** `AppShell` registered `use:swipe` on the whole shell, so every horizontal swipe anywhere in the app was a candidate sidebar toggle. That stole gestures from content that legitimately scrolls sideways (AI reasoning rendered as a code block), and it collided with the sidebar's own tab strip: one right-swipe fired both handlers, so changing tabs also closed the panel.

What survives is gesture handling that owns its own region. The narrow right-edge zone still opens the sidebar — a small, deliberate target that does not overlap content. Inside the sidebar, `Sidebar.svelte` keeps its own swipe binding: right goes to the previous tab, or closes the panel when there is no previous tab. Tapping outside the overlay still dismisses it.

**Close the sidebar after panel navigation.** Choosing Lorebook or Memory from the sidebar's bottom nav now calls `ui.closeSidebarOnMobile()`, so the view you just picked is actually visible instead of sitting behind the overlay. On desktop, where the sidebar is not an overlay, this is a no-op.

## Checks

`npm run check`, `npm test` and `npm run lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)