### PR TITLE
Feat/save and regen

### DIFF
--- a/components/compounds/entry-card.stories.tsx
+++ b/components/compounds/entry-card.stories.tsx
@@ -177,6 +177,21 @@ export const EditMode: StoryT = {
   },
 }
 
+/** The head turn's action: the reply below it answers text that is being rewritten. */
+export const EditModeWithRegen: StoryT = {
+  ...wrap,
+  args: {
+    ...baseProps,
+    kind: 'user_action',
+    content: 'I draw my sword and step toward the figure in the doorway.',
+    editing: true,
+    onContentChange: fn(),
+    onCommitEdit: fn(),
+    onCommitEditAndRegen: fn(),
+    onCancelEdit: fn(),
+  },
+}
+
 /**
  * The gate is held: the row's controls refuse, the prose does not change
  * shade. Reading is never gated (principles.md → What's not gated), and the

--- a/components/compounds/entry-card.tsx
+++ b/components/compounds/entry-card.tsx
@@ -150,6 +150,9 @@ type EntryCardProps = {
   editing?: boolean
   onContentChange?: (next: string) => void
   onCommitEdit?: () => void
+  /** Commit, then re-answer this entry. Presence gates the button — only the head
+   *  turn's `user_action` has a reply a regenerate can replace without cascading. */
+  onCommitEditAndRegen?: () => void
   onCancelEdit?: () => void
 
   className?: string
@@ -736,6 +739,7 @@ export function EntryCard({
   editing,
   onContentChange,
   onCommitEdit,
+  onCommitEditAndRegen,
   onCancelEdit,
   className,
 }: EntryCardProps) {
@@ -918,10 +922,21 @@ export function EntryCard({
               if (e.nativeEvent.key === 'Escape') onCancelEdit?.()
             }}
           />
-          <View className="flex-row justify-end gap-2">
+          <View className="flex-row flex-wrap justify-end gap-2">
             <Button variant="ghost" size="sm" onPress={onCancelEdit} disabled={disabled}>
               <Text>{t('cancel')}</Text>
             </Button>
+            {onCommitEditAndRegen != null ? (
+              <Button
+                variant="secondary"
+                size="sm"
+                onPress={onCommitEditAndRegen}
+                disabled={disabled}
+              >
+                <Icon as={RefreshCw} size="sm" />
+                <Text>{t('reader:entryCard.saveAndRegenerate')}</Text>
+              </Button>
+            ) : null}
             <Button variant="primary" size="sm" onPress={onCommitEdit} disabled={disabled}>
               <Text>{t('save')}</Text>
             </Button>

--- a/components/reader/reader-surface.stories.tsx
+++ b/components/reader/reader-surface.stories.tsx
@@ -240,7 +240,7 @@ export const SaveAndRegenerateHeldByFailedWrite: Story = {
   },
 }
 
-/** Every earlier turn keeps Save / Cancel: regenerating there destroys the entries after it. */
+/** Only the head turn's action gets the third button; every other row keeps Save / Cancel. */
 export const SaveAndRegenerateAbsentOffHead: Story = {
   args: { rows: HEAD_TURN_ROWS, tailEntryId: 'e3' },
   play: async () => {

--- a/components/reader/reader-surface.stories.tsx
+++ b/components/reader/reader-surface.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite'
-import { expect, fn, screen, userEvent, waitFor } from 'storybook/test'
+import { expect, fn, screen, userEvent, waitFor, within } from 'storybook/test'
 
 import { EARTH_GREGORIAN } from '@/lib/calendar'
 import type { StoryEntry } from '@/lib/db'
@@ -86,6 +86,27 @@ const noopHandlers = {
   onFixSystemEntry: async () => {},
 }
 
+const HEAD_TURN_ROWS = ROWS.slice(0, 3)
+const EDITED_ACTION = 'I step through the frame of the second painting.'
+
+function entryRow(id: string): HTMLElement {
+  const row = document.querySelector(`[data-entry-row="${id}"]`)
+  if (!(row instanceof HTMLElement)) throw new Error(`no row for ${id}`)
+  return row
+}
+
+async function startEditingHeadAction() {
+  await userEvent.click(
+    within(entryRow('e2')).getByRole('button', { name: t('reader:entryCard.editEntry') }),
+  )
+  const textarea = await waitFor(() =>
+    screen.getByRole('textbox', { name: t('reader:entryCard.editContent') }),
+  )
+  await userEvent.clear(textarea)
+  await userEvent.type(textarea, EDITED_ACTION)
+  await waitFor(() => expect(textarea).toHaveValue(EDITED_ACTION))
+}
+
 const meta = {
   title: 'Compounds/Reader/ReaderSurface',
   component: ReaderSurface,
@@ -161,6 +182,79 @@ export const PhoneRequestsHostOverlay: Story = {
     await userEvent.click(screen.getByRole('button', { name: 'Edit time' }))
     await waitFor(() => expect(args.onRequestEditWorldTime).toHaveBeenCalledWith('e3'))
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  },
+}
+
+/**
+ * `Save & regenerate` is a compose seam the compound layer cannot reach: the
+ * commit must land before the run starts, because the pipeline re-reads its
+ * prompt from the branch tail rather than from anything threaded in.
+ */
+export const SaveAndRegenerateHeadTurn: Story = {
+  args: {
+    rows: HEAD_TURN_ROWS,
+    tailEntryId: 'e3',
+    onCommitEdit: fn(async () => ({ ok: true })),
+    onRegenerate: fn(async () => {}),
+  },
+  play: async ({ args }) => {
+    const order: string[] = []
+    ;(args.onCommitEdit as ReturnType<typeof fn>).mockImplementation(async () => {
+      order.push('commit')
+      return { ok: true }
+    })
+    ;(args.onRegenerate as ReturnType<typeof fn>).mockImplementation(async () => {
+      order.push('regenerate')
+    })
+
+    await startEditingHeadAction()
+    await userEvent.click(
+      screen.getByRole('button', { name: t('reader:entryCard.saveAndRegenerate') }),
+    )
+
+    await waitFor(() => expect(args.onRegenerate).toHaveBeenCalledWith('e3'))
+    expect(args.onCommitEdit).toHaveBeenCalledWith('e2', EDITED_ACTION)
+    expect(order).toEqual(['commit', 'regenerate'])
+  },
+}
+
+/** A refused write must not spend a generation on prose the branch never took. */
+export const SaveAndRegenerateHeldByFailedWrite: Story = {
+  args: {
+    rows: HEAD_TURN_ROWS,
+    tailEntryId: 'e3',
+    onCommitEdit: fn(async () => ({ ok: false })),
+    onRegenerate: fn(async () => {}),
+  },
+  play: async ({ args }) => {
+    await startEditingHeadAction()
+    await userEvent.click(
+      screen.getByRole('button', { name: t('reader:entryCard.saveAndRegenerate') }),
+    )
+
+    await waitFor(() => expect(args.onCommitEdit).toHaveBeenCalledWith('e2', EDITED_ACTION))
+    expect(args.onRegenerate).not.toHaveBeenCalled()
+    expect(screen.getByRole('textbox', { name: t('reader:entryCard.editContent') })).toHaveValue(
+      EDITED_ACTION,
+    )
+  },
+}
+
+/** Every earlier turn keeps Save / Cancel: regenerating there destroys the entries after it. */
+export const SaveAndRegenerateAbsentOffHead: Story = {
+  args: { rows: HEAD_TURN_ROWS, tailEntryId: 'e3' },
+  play: async () => {
+    await userEvent.click(
+      within(entryRow('e1')).getByRole('button', { name: t('reader:entryCard.editEntry') }),
+    )
+    await waitFor(() =>
+      expect(
+        screen.getByRole('textbox', { name: t('reader:entryCard.editContent') }),
+      ).toBeVisible(),
+    )
+    expect(
+      screen.queryByRole('button', { name: t('reader:entryCard.saveAndRegenerate') }),
+    ).not.toBeInTheDocument()
   },
 }
 

--- a/components/reader/reader-surface.tsx
+++ b/components/reader/reader-surface.tsx
@@ -445,30 +445,29 @@ export function ReaderSurface({
     setEditingId(row.id)
     setEditDraft(row.content)
   }, [])
-  const commitEdit = useCallback(async () => {
+  // Shared by both commit buttons so the refusal policy has one home: a
+  // rejected commit keeps the draft open so typing isn't silently lost, and
+  // the host owns the error toast.
+  const commitDraft = useCallback(async (): Promise<boolean> => {
     const id = editingIdRef.current
-    if (id == null) return
-    // A rejected commit keeps the draft open so typing isn't silently lost;
-    // the host owns the error toast.
+    if (id == null) return false
     const result = await onCommitEdit(id, editDraftRef.current)
-    if (result?.ok) {
-      setEditingId(null)
-      setEditDraft('')
-    }
+    if (!result?.ok) return false
+    setEditingId(null)
+    setEditDraft('')
+    return true
   }, [onCommitEdit])
+  const commitEdit = useCallback(async () => {
+    await commitDraft()
+  }, [commitDraft])
   const commitEditAndRegen = useCallback(
     async (replyId: string) => {
-      const id = editingIdRef.current
-      if (id == null) return
-      const result = await onCommitEdit(id, editDraftRef.current)
-      if (!result?.ok) return
-      setEditingId(null)
-      setEditDraft('')
+      if (!(await commitDraft())) return
       // Regenerate second: the pipeline re-reads its prompt from the branch tail,
       // so the edit has to be committed before the run starts to be the one it reads.
       await onRegenerate(replyId)
     },
-    [onCommitEdit, onRegenerate],
+    [commitDraft, onRegenerate],
   )
   const cancelEdit = useCallback(() => {
     setEditingId(null)

--- a/components/reader/reader-surface.tsx
+++ b/components/reader/reader-surface.tsx
@@ -7,6 +7,7 @@ import {
   useEffect,
   useImperativeHandle,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
   type Ref,
@@ -25,6 +26,7 @@ import type { StoryEntry } from '@/lib/db'
 import { computeScrollMetrics, createAutoscrollMachine } from '@/lib/reader-scroll'
 
 import type { EditResult, ReaderSurfaceHandle, ReaderSurfaceProps } from './reader-document-types'
+import { resolveSaveAndRegenTurn } from './save-and-regen'
 import type { ResolvedEntity } from './scene-editing'
 
 const NEAR_BOTTOM_THRESHOLD_PX = 20
@@ -64,6 +66,9 @@ type ReaderRowProps = {
   onStartEdit: (row: StoryEntry) => void
   onContentChange: (text: string) => void
   onCommitEdit: () => void | Promise<void>
+  /** The reply this row produced, when this row is the head turn's action — null on every other row. */
+  regenTargetId: string | null
+  onCommitEditAndRegen: (replyId: string) => void | Promise<void>
   onCancelEdit: () => void
   onRequestRollback: (entryId: string) => Promise<void>
   onRegenerate: (entryId: string) => Promise<void>
@@ -97,6 +102,8 @@ const ReaderRow = memo(function ReaderRow({
   onStartEdit,
   onContentChange,
   onCommitEdit,
+  regenTargetId,
+  onCommitEditAndRegen,
   onCancelEdit,
   onRequestRollback,
   onRegenerate,
@@ -127,6 +134,9 @@ const ReaderRow = memo(function ReaderRow({
       onRegen={row.kind === 'ai_reply' ? () => void onRegenerate(row.id) : undefined}
       onContentChange={onContentChange}
       onCommitEdit={() => void onCommitEdit()}
+      onCommitEditAndRegen={
+        regenTargetId != null ? () => void onCommitEditAndRegen(regenTargetId) : undefined
+      }
       onCancelEdit={onCancelEdit}
       onDelete={
         isSystem || row.kind === 'opening' ? undefined : () => void onRequestRollback(row.id)
@@ -446,10 +456,25 @@ export function ReaderSurface({
       setEditDraft('')
     }
   }, [onCommitEdit])
+  const commitEditAndRegen = useCallback(
+    async (replyId: string) => {
+      const id = editingIdRef.current
+      if (id == null) return
+      const result = await onCommitEdit(id, editDraftRef.current)
+      if (!result?.ok) return
+      setEditingId(null)
+      setEditDraft('')
+      // Regenerate second: the pipeline re-reads its prompt from the branch tail,
+      // so the edit has to be committed before the run starts to be the one it reads.
+      await onRegenerate(replyId)
+    },
+    [onCommitEdit, onRegenerate],
+  )
   const cancelEdit = useCallback(() => {
     setEditingId(null)
     setEditDraft('')
   }, [])
+  const headTurn = useMemo(() => resolveSaveAndRegenTurn(rows, tailEntryId), [rows, tailEntryId])
 
   return (
     <div className="relative h-full">
@@ -497,6 +522,8 @@ export function ReaderSurface({
                 onStartEdit={startEdit}
                 onContentChange={setEditDraft}
                 onCommitEdit={commitEdit}
+                regenTargetId={row.id === headTurn?.originId ? headTurn.replyId : null}
+                onCommitEditAndRegen={commitEditAndRegen}
                 onCancelEdit={cancelEdit}
                 onRequestRollback={onRequestRollback}
                 onRegenerate={onRegenerate}

--- a/components/reader/save-and-regen.test.ts
+++ b/components/reader/save-and-regen.test.ts
@@ -14,7 +14,7 @@ describe('resolveSaveAndRegenTurn', () => {
     expect(resolveSaveAndRegenTurn(rows, 'e3')).toEqual({ originId: 'e2', replyId: 'e3' })
   })
 
-  it('offers nothing for an earlier turn whose reply is not the tail', () => {
+  it('pairs the tail reply with its own predecessor, not the first action', () => {
     const rows = [
       entry('e1', 'user_action'),
       entry('e2', 'ai_reply'),

--- a/components/reader/save-and-regen.test.ts
+++ b/components/reader/save-and-regen.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import type { StoryEntry } from '@/lib/db'
+
+import { resolveSaveAndRegenTurn } from './save-and-regen'
+
+function entry(id: string, kind: StoryEntry['kind']): StoryEntry {
+  return { id, branchId: 'b1', kind, content: 'x', position: 0 } as StoryEntry
+}
+
+describe('resolveSaveAndRegenTurn', () => {
+  it('pairs the tail reply with the user action that produced it', () => {
+    const rows = [entry('e1', 'opening'), entry('e2', 'user_action'), entry('e3', 'ai_reply')]
+    expect(resolveSaveAndRegenTurn(rows, 'e3')).toEqual({ originId: 'e2', replyId: 'e3' })
+  })
+
+  it('offers nothing for an earlier turn whose reply is not the tail', () => {
+    const rows = [
+      entry('e1', 'user_action'),
+      entry('e2', 'ai_reply'),
+      entry('e3', 'user_action'),
+      entry('e4', 'ai_reply'),
+    ]
+    expect(resolveSaveAndRegenTurn(rows, 'e4')?.originId).toBe('e3')
+  })
+
+  it('offers nothing when the tail is a standing user action with no reply', () => {
+    const rows = [entry('e1', 'ai_reply'), entry('e2', 'user_action')]
+    expect(resolveSaveAndRegenTurn(rows, 'e2')).toBeNull()
+  })
+
+  it('offers nothing when a system entry holds the tail over a standing action', () => {
+    const rows = [entry('e1', 'ai_reply'), entry('e2', 'user_action'), entry('e3', 'system')]
+    expect(resolveSaveAndRegenTurn(rows, 'e3')).toBeNull()
+  })
+
+  it('offers nothing when the tail reply follows the opening rather than an action', () => {
+    const rows = [entry('e1', 'opening'), entry('e2', 'ai_reply')]
+    expect(resolveSaveAndRegenTurn(rows, 'e2')).toBeNull()
+  })
+
+  it('offers nothing when the origin sits above the loaded window', () => {
+    const rows = [entry('e9', 'ai_reply')]
+    expect(resolveSaveAndRegenTurn(rows, 'e9')).toBeNull()
+  })
+
+  it('offers nothing on an empty branch', () => {
+    expect(resolveSaveAndRegenTurn([], null)).toBeNull()
+  })
+
+  it('offers nothing when the tail id is not in the loaded window', () => {
+    const rows = [entry('e1', 'user_action'), entry('e2', 'ai_reply')]
+    expect(resolveSaveAndRegenTurn(rows, 'e7')).toBeNull()
+  })
+})

--- a/components/reader/save-and-regen.ts
+++ b/components/reader/save-and-regen.ts
@@ -1,0 +1,24 @@
+import type { StoryEntry } from '@/lib/db'
+
+export type SaveAndRegenTurn = { originId: string; replyId: string }
+
+/**
+ * The head turn's `user_action` + `ai_reply` pair, or null when the tail is not
+ * a reply that can be re-answered. Scoped to the head because regenerating any
+ * earlier reply destroys every entry after it, which a Save button must not
+ * carry — the action cluster's ↻ owns that path behind its cascade confirm.
+ */
+export function resolveSaveAndRegenTurn(
+  rows: readonly StoryEntry[],
+  tailEntryId: string | null,
+): SaveAndRegenTurn | null {
+  if (tailEntryId == null) return null
+  const replyIndex = rows.findIndex((row) => row.id === tailEntryId)
+  const reply = rows[replyIndex]
+  if (reply == null || reply.kind !== 'ai_reply') return null
+  // regenerateTurn re-reads the prompt from the surviving tail, so the origin
+  // must be the reply's positional predecessor for the edit to be what it reads.
+  const origin = rows[replyIndex - 1]
+  if (origin == null || origin.kind !== 'user_action') return null
+  return { originId: origin.id, replyId: reply.id }
+}

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -55,9 +55,57 @@ for the placement rule.
   scene editor both reverse, the content edit does not. The exemption is a
   deliberate storage-economy decision, not an oversight — the open
   question is whether the UX is defensible as-is, wants an editor-local
-  undo stack, or wants the redo-clear narrowed. Surfaced 2026-07-23
-  alongside the world-state-block design but never scoped into it; that
-  pass shipped 2026-09-03 and left this untouched.
+  undo stack, wants the redo-clear narrowed, or wants the exemption
+  dropped outright and `content` delta-logged like every other column.
+  Delta-logging is the direction to argue first (developer, 2026-09-04);
+  it subsumes the other three, and the storage argument it has to beat is
+  weaker than it looks at the entry scale but wants pricing before it is
+  assumed away. Surfaced 2026-07-23 alongside the world-state-block
+  design but never scoped into it; that pass shipped 2026-09-03 and left
+  this untouched.
+
+  **A second consequence of writing no delta, found 2026-09-04:** a
+  content edit does not clamp the classifier watermark either, so it is
+  invisible to memory as well as to undo. `classifierWatermarkClampOps`
+  (`lib/actions/story-entries/prose-reversal.ts`) runs inside
+  `bracketProseReversal`, which only prose **reversals** enter;
+  `updateStoryEntryContent` is not one. With `processedThrough` already
+  past the edited entry, the periodic classifier never re-reads the
+  rewritten prose, and the happenings, awareness links and status flips
+  it derived from the text that is now gone simply stand. Distinct from
+  the involvements-drift item above — that one is about `sceneEntities`
+  contradicting recorded presence; this is the prose itself going stale
+  under facts derived from it.
+
+  The two halves share a fix. Delta-logging `content` makes the edit a
+  reversal-shaped operation, and the clamp is the natural companion to
+  that record. But it lands the edit in a category the
+  [reversal taxonomy](./explorations/2026-06-02-classifier-reversal-quiesce.md)
+  does not have: its discriminator is whether prose **appeared or
+  vanished**, and a content edit does neither — prose changed in place.
+  It wants the watermark clamp (the classifier must re-read the turn) but
+  not the positional suffix sweep (nothing downstream is structurally
+  invalid, only semantically stale), which is neither of the two rows the
+  table offers. Scoping this followup has to settle that third row.
+
+  **The machinery is mostly already there** (verified 2026-09-04), which
+  argues the hard part is the canon decision, not the implementation.
+  `reverse-replay.ts` restores a column-keyed `undoPayload` generically:
+  `content` carries no entry in `story_entries`' `columnSchemas` (only
+  `metadata` does), so it takes the plain whole-value restore path with
+  no new code. The dev seed dataset already carries exactly the delta a
+  content edit would write — `op: 'update'`, `source: 'user_edit'`,
+  `undoPayload: { content: … }` (`lib/db/devtools/seed-dataset.ts`) — so
+  the shape is seeded as though it exists. What is missing is an action
+  kind that writes one: `story_entries` registers only
+  `updateStoryEntryMetadata` for updates, and `updateStoryEntryContent`
+  bypasses the action layer entirely.
+
+  Reachable today on one path only:
+  [`Save & regenerate`](./ui/patterns/entry-card.md#save-and-regenerate)
+  routes through `regenerateTurn`, whose sweep clamps the watermark, so
+  the head turn's re-run does read the edited text. Every other content
+  edit — plain Save, at any depth — does not.
 
 - **Q3 needs an overhaul and a re-spec, not signal-by-signal patches.**
   [`retrieval.md → Q3`](./memory/retrieval.md#q3-heuristic-prose-extract)

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -101,11 +101,16 @@ for the placement rule.
   `updateStoryEntryMetadata` for updates, and `updateStoryEntryContent`
   bypasses the action layer entirely.
 
-  Reachable today on one path only:
-  [`Save & regenerate`](./ui/patterns/entry-card.md#save-and-regenerate)
-  routes through `regenerateTurn`, whose sweep clamps the watermark, so
-  the head turn's re-run does read the edited text. Every other content
-  edit — plain Save, at any depth — does not.
+  **No path closes it today**, including
+  [`Save & regenerate`](./ui/patterns/entry-card.md#save-and-regenerate).
+  Its sweep does clamp, but the clamp is keyed to the entry it removes:
+  `resolveSweep` passes the reply's position, so `processedThrough` lands
+  on `position(reply) - 1` — which is the edited `user_action`'s own
+  position. The next pass reads the new reply (positions strictly above
+  the watermark) and still skips the action whose prose changed. Verified
+  2026-09-04 against `classifierWatermarkClampOps` and the classifier's
+  window query; a content edit is uncovered at every depth, head turn
+  included.
 
 - **Q3 needs an overhaul and a re-spec, not signal-by-signal patches.**
   [`retrieval.md → Q3`](./memory/retrieval.md#q3-heuristic-prose-extract)

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -13,17 +13,6 @@ for the placement rule.
 
 ## UX
 
-- **"Save and regen" on content edits.** Editing a `user_action` after
-  its reply exists diverges the story silently — the reply answers text
-  that no longer exists — and that divergence is legitimate user
-  freedom, not a bug to detect. A second button beside Save makes it
-  self-documenting and hints that a regen may be wanted. Scoped to
-  **content** editing alone: on the
-  [scene editor](./ui/patterns/entry-card.md#scene-editor) the same button
-  defeats itself, since regenerating re-runs piggyback and overwrites the
-  scene edit just saved. Split out 2026-09-02 from the world-state-block
-  pass, which shipped without it.
-
 - **Happening involvements drift when scene membership is edited after
   the fact.** Involvements record who was present at an entry, so a later
   edit to that entry's `sceneEntities` can contradict them. Rolling back

--- a/docs/ui/patterns/entry-card.md
+++ b/docs/ui/patterns/entry-card.md
@@ -86,6 +86,7 @@ type EntryCardProps = {
   editing?: boolean
   onContentChange?: (next: string) => void
   onCommitEdit?: () => void
+  onCommitEditAndRegen?: () => void // presence renders the third button; host passes it on the head turn's user_action only
   onCancelEdit?: () => void
 
   className?: string
@@ -314,8 +315,8 @@ the scroll region the lists need.
 re-runs piggyback, which emits a fresh `<state>` and overwrites the
 scene edit that was just saved, so the pairing is self-defeating here.
 The affordance belongs to content editing on a `user_action`, where
-the reply genuinely answers text that no longer exists; it is tracked
-separately in [`followups.md`](../../followups.md#ux).
+the reply genuinely answers text that no longer exists — see
+[Save and regenerate](#save-and-regenerate).
 
 Failure handling matches the world-time overlay: a rejected or failed
 write keeps the overlay open with the edit intact and reports inline;
@@ -369,6 +370,34 @@ on Save / Cancel only dismisses the soft keyboard and the user
 needs a second tap to fire the button — RN's default
 `"never"` consumes the dismissal tap. The compound can't fix this
 on its own; the behavior is owned by the parent ScrollView.
+
+### Save and regenerate
+
+Editing a `user_action` whose reply already exists diverges the story
+silently: the reply answers text that no longer exists. That divergence is
+legitimate — a user may want exactly it — so it is not detected or warned
+about. A third button beside Save makes the alternative self-documenting:
+`Cancel / Save & regenerate / Save`, with Save still primary.
+
+**The head turn only.** The host passes `onCommitEditAndRegen` when the row
+is the `user_action` whose reply is the branch tail, and on no other row.
+Regenerating any earlier reply destroys every entry after it; a button
+labelled as a save must not carry that, and the action cluster's `↻` already
+owns the deliberate destructive path behind its
+[cascade confirm](../screens/reader-composer/reader-composer.md#regenerate-confirmation).
+So the button is absent on an `ai_reply` (regenerating it discards the edit
+just saved), on the opening, on any earlier turn, and whenever the tail is a
+standing `user_action` or a system entry — in each case there is no reply
+the edit can be re-answered into.
+
+**Commit, then run.** The two halves are sequential, not atomic: the
+pipeline re-reads its prompt from the branch tail rather than from anything
+threaded into the call, so the edit must be committed before the run starts
+to be the text it reads. A refused write stops there — the draft stays open
+and reports as it does for a plain Save, and no generation is spent on prose
+the branch never took. Once the write lands the editor closes and the
+regenerate goes through the same host path the `↻` takes, confirm gates
+included.
 
 ## World-time footer
 
@@ -514,7 +543,8 @@ compatible.
 Live demos for: user kind, ai kind (with reasoning expanded /
 collapsed), opening kind (no delete action), system kind (with
 detail expanded), streaming kind (reasoning-phase, reply-phase),
-edit mode (textarea), disabled state, world-time footer
+edit mode (textarea, with and without `Save & regenerate`),
+disabled state, world-time footer
 shown/hidden by kind, world-state panel (reported, fallback-layer
 badge, rejected location, clamped delta, parse failure with raw
 block, legacy row, unknown-entity chip), scene editor (tail entry

--- a/docs/ui/screens/reader-composer/reader-composer.md
+++ b/docs/ui/screens/reader-composer/reader-composer.md
@@ -243,6 +243,15 @@ rare enough that the confirm never turns routine. It reuses the
 cross-chapter copy, reframed as re-run rather than re-open: the
 chapter returns to in-progress and regenerates.
 
+### Save and regenerate on a content edit
+
+Editing the head turn's user entry offers a third button in the inline
+editor — `Cancel / Save & regenerate / Save` — that commits the edit and
+then regenerates the reply it produced, through this same confirmation
+path. Offered on that one entry only; the full rule and its rationale live
+in
+[EntryCard → Save and regenerate](../../patterns/entry-card.md#save-and-regenerate).
+
 ## Era flip
 
 Era flips are user-triggered narrative events writing one row to

--- a/e2e/locators/reader.ts
+++ b/e2e/locators/reader.ts
@@ -47,10 +47,14 @@ export const reader = {
     page.getByRole('textbox', { name: t('reader:entryCard.editContent') }),
   // Scoped to the entry rows, not the page: since 3.8 the reader hosts a second
   // Save button in the world-time overlay, which portals outside
-  // `[data-entry-row]`. The two overlays cannot both be open today, so an
-  // unscoped query still resolves — it is one strict-mode violation away.
+  // `[data-entry-row]`. exact:true is the other half — "Save & regenerate"
+  // renders beside this one on the head turn's user action.
   saveEdit: (page: Page): Locator =>
-    page.locator('[data-entry-row]').getByRole('button', { name: t('save') }),
+    page.locator('[data-entry-row]').getByRole('button', { name: t('save'), exact: true }),
+  saveAndRegenEdit: (page: Page): Locator =>
+    page
+      .locator('[data-entry-row]')
+      .getByRole('button', { name: t('reader:entryCard.saveAndRegenerate') }),
 
   // Per-entry world-time footer. Desktop tier hosts the edit form in a centred
   // Dialog; the phone tier bridges out to a native Sheet, which desktop-only

--- a/e2e/tests/reader-regenerate.spec.ts
+++ b/e2e/tests/reader-regenerate.spec.ts
@@ -24,6 +24,8 @@ import { reader } from '../locators/reader'
 const REPLY_1 = 'E2E-REGEN-R1 the courier reads the letter twice.'
 const REPLY_2 = 'E2E-REGEN-R2 the courier burns the letter unread.'
 const REPLY_3 = 'E2E-REGEN-R3 the courier hides the letter in a boot.'
+const REPLY_4 = 'E2E-REGEN-R4 the letter names a city that no longer exists.'
+const EDITED_ACTION = 'E2E-REGEN-U3 I open the satchel and read the letter aloud.'
 
 test.describe('reader — regenerate a reply', () => {
   test.describe.configure({ mode: 'serial' })
@@ -180,5 +182,40 @@ test.describe('reader — regenerate a reply', () => {
     await pollEntryGone(branch, 'E2E-REGEN-U2')
     await pollEntryGone(branch, 'E2E-REGEN-R3')
     expect(await entryIdByContent(branch, 'E2E-REGEN-U1')).toBe(userActionId)
+  })
+
+  // `Save & regenerate` on the head turn's action. The claim no cheaper layer
+  // can make: the run reads its prompt from the branch tail, so the commit has
+  // to land first for the new take to answer the edited text rather than the
+  // text it replaced.
+  test('save and regenerate re-answers the edited action', async () => {
+    const branch = await branchId()
+    const userActionId = await pollEntryId(branch, 'E2E-REGEN-U1')
+    await pollEntryId(branch, 'E2E-REGEN-R1')
+
+    mock.setNarrative(REPLY_4)
+    const before = mock.requests.length
+    await reader.row(app.window, userActionId).scrollIntoViewIfNeeded()
+    await reader.editEntry(app.window, userActionId).click()
+    await reader.editTextarea(app.window).fill(EDITED_ACTION)
+    await reader.saveAndRegenEdit(app.window).click()
+
+    await expect(app.window.getByText('E2E-REGEN-R4', { exact: false })).toBeVisible({
+      timeout: 30_000,
+    })
+
+    // The edit rewrote the standing row rather than creating one, and the take
+    // it diverged from is gone.
+    expect(await entryIdByContent(branch, 'E2E-REGEN-U3')).toBe(userActionId)
+    await pollEntryGone(branch, 'E2E-REGEN-R1')
+    await pollEntryId(branch, 'E2E-REGEN-R4')
+
+    // One generation, and it saw the edit. A commit ordered after the dispatch
+    // would still satisfy every assertion above.
+    const streamed = mock.requests.slice(before).filter((r) => r.streamed)
+    expect(streamed.length, 'narrative calls').toBe(1)
+    const prompt = JSON.stringify(streamed[0].body)
+    expect(prompt).toContain('E2E-REGEN-U3')
+    expect(prompt).not.toContain('E2E-REGEN-U1')
   })
 })

--- a/locales/en/reader.json
+++ b/locales/en/reader.json
@@ -95,6 +95,7 @@
     "tokensWithReasoning": "{{n}} tokens (+{{reasoning}} reasoning)",
     "editEntry": "Edit entry",
     "editContent": "Edit entry content",
+    "saveAndRegenerate": "Save & regenerate",
     "regenerate": "Regenerate",
     "branchFromHere": "Branch from here",
     "flipEra": "Flip era",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a **Save & regenerate** option when editing eligible reader entries.
  - Saves edited content before generating an updated response.
  - Preserves edits if saving fails and only regenerates after a successful save.
  - Displays the option only for the applicable entry.

- **Bug Fixes**
  - Improved button targeting so Save and Save & regenerate actions are distinguished correctly.

- **Tests**
  - Added coverage for save-and-regenerate behavior, failure handling, entry placement, and regenerated responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->