### PR TITLE
Fix/content edit invalidation scope

### DIFF
--- a/app/reader-composer/[branchId].tsx
+++ b/app/reader-composer/[branchId].tsx
@@ -291,11 +291,7 @@ export default function ReaderComposerRoute() {
     () => [...entityRows.values()].filter((e) => e.branchId === branchId),
     [entityRows, branchId],
   )
-  // The far end of the window is the live edge: entries only ever prepend, and nothing
-  // trims the other end yet. Every tail-derived affordance rides on that, because the
-  // action layer resolves the same head turn off the DB tail — so the forward load and
-  // the far-end trim cap (reader-composer.md -> Loaded-set model) have to drive this
-  // when they land, or those affordances start lying on a mid-window row.
+  // Entries only ever prepend and nothing trims the far end yet, so it is still the tail.
   const holdsLiveEdge = true
   const {
     entityNames,

--- a/app/reader-composer/[branchId].tsx
+++ b/app/reader-composer/[branchId].tsx
@@ -291,6 +291,12 @@ export default function ReaderComposerRoute() {
     () => [...entityRows.values()].filter((e) => e.branchId === branchId),
     [entityRows, branchId],
   )
+  // The far end of the window is the live edge: entries only ever prepend, and nothing
+  // trims the other end yet. Every tail-derived affordance rides on that, because the
+  // action layer resolves the same head turn off the DB tail — so the forward load and
+  // the far-end trim cap (reader-composer.md -> Loaded-set model) have to drive this
+  // when they land, or those affordances start lying on a mid-window row.
+  const holdsLiveEdge = true
   const {
     entityNames,
     sceneOptions,
@@ -299,7 +305,7 @@ export default function ReaderComposerRoute() {
     editScene,
     requestEditScene,
     closeSceneEdit,
-  } = useSceneEditing(branchId, entries, branchEntities, ctx)
+  } = useSceneEditing(branchId, entries, holdsLiveEdge, branchEntities, ctx)
 
   const [stripCollapsed, setStripCollapsed] = useState(false)
   const [stripError, setStripError] = useState<PipelineError | null>(null)

--- a/components/compounds/entry-card.stories.tsx
+++ b/components/compounds/entry-card.stories.tsx
@@ -192,6 +192,29 @@ export const EditModeWithRegen: StoryT = {
   },
 }
 
+/** Untouched draft: neither commit button has anything to save, and a regenerate that
+    saved nothing belongs to the reply's own control behind its cascade confirm. */
+export const EditModePristine: StoryT = {
+  ...wrap,
+  args: {
+    ...baseProps,
+    kind: 'user_action',
+    content: 'I draw my sword and step toward the figure in the doorway.',
+    editing: true,
+    editDirty: false,
+    onContentChange: fn(),
+    onCommitEdit: fn(),
+    onCommitEditAndRegen: fn(),
+    onCancelEdit: fn(),
+  },
+  play: async () => {
+    await expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /Save & regenerate/ })).toBeDisabled()
+    // Backing out of an untouched draft has to stay reachable.
+    expect(screen.getByRole('button', { name: 'Cancel' })).not.toBeDisabled()
+  },
+}
+
 /** Frozen scene on an earlier `user_action`: rollback is named, branching is not. */
 export const EditModeNoticeFrozenNoBranch: StoryT = {
   ...wrap,

--- a/components/compounds/entry-card.tsx
+++ b/components/compounds/entry-card.tsx
@@ -154,6 +154,10 @@ type EntryCardProps = {
   editing?: boolean
   /** Which divergence notice the editor carries; omitted renders none. */
   contentEditNotice?: ContentEditNotice
+  /** Whether the draft differs from the stored prose. Both commit buttons gate on it —
+   *  neither has anything to save otherwise. Defaults to dirty for hosts that pass no
+   *  draft of their own. */
+  editDirty?: boolean
   onContentChange?: (next: string) => void
   onCommitEdit?: () => void
   /** Commit, then re-answer this entry. Presence gates the button — only the head
@@ -744,6 +748,7 @@ export function EntryCard({
   disabledReason,
   editing,
   contentEditNotice,
+  editDirty = true,
   onContentChange,
   onCommitEdit,
   onCommitEditAndRegen,
@@ -946,13 +951,18 @@ export function EntryCard({
                 variant="secondary"
                 size="sm"
                 onPress={onCommitEditAndRegen}
-                disabled={disabled}
+                disabled={disabled || !editDirty}
               >
                 <Icon as={RefreshCw} size="sm" />
                 <Text>{t('reader:entryCard.saveAndRegenerate')}</Text>
               </Button>
             ) : null}
-            <Button variant="primary" size="sm" onPress={onCommitEdit} disabled={disabled}>
+            <Button
+              variant="primary"
+              size="sm"
+              onPress={onCommitEdit}
+              disabled={disabled || !editDirty}
+            >
               <Text>{t('save')}</Text>
             </Button>
           </View>

--- a/components/reader/content-edit-notice.test.ts
+++ b/components/reader/content-edit-notice.test.ts
@@ -35,12 +35,15 @@ describe('contentEditNoticeKey', () => {
     )
   })
 
-  it('keeps the branch clause on kinds whose action cluster carries one', () => {
+  it('keeps both clauses on an ai_reply, whose cluster carries branch and delete', () => {
     expect(contentEditNoticeKey('scene-frozen', 'ai_reply')).toBe(
       'reader:entryCard.editNoticeFrozen',
     )
+  })
+
+  it('drops the rollback clause on the opening, which is the rollback floor', () => {
     expect(contentEditNoticeKey('scene-frozen', 'opening')).toBe(
-      'reader:entryCard.editNoticeFrozen',
+      'reader:entryCard.editNoticeFrozenNoRollback',
     )
   })
 

--- a/components/reader/content-edit-notice.ts
+++ b/components/reader/content-edit-notice.ts
@@ -6,6 +6,7 @@ export type ContentEditNoticeKey =
   | 'reader:entryCard.editNoticeSceneHere'
   | 'reader:entryCard.editNoticeFrozen'
   | 'reader:entryCard.editNoticeFrozenNoBranch'
+  | 'reader:entryCard.editNoticeFrozenNoRollback'
 
 /**
  * Which divergence notice a row's content editor carries, or null when it carries
@@ -27,15 +28,17 @@ export function resolveContentEditNotice(args: {
 }
 
 /**
- * A `user_action` drops the branch clause: that kind carries no branch action, and
- * naming a control the card does not have is the failure the notice exists to prevent.
+ * Each kind is offered only the remedies its own action cluster carries: naming a
+ * control the card does not have is the failure the notice exists to prevent. A
+ * `user_action` drops the branch clause, and the opening drops the rollback clause --
+ * it is the rollback floor, so that half can never become true for it.
  */
 export function contentEditNoticeKey(
   notice: ContentEditNotice,
   kind: EntryKind,
 ): ContentEditNoticeKey {
   if (notice === 'scene-here') return 'reader:entryCard.editNoticeSceneHere'
-  return kind === 'user_action'
-    ? 'reader:entryCard.editNoticeFrozenNoBranch'
-    : 'reader:entryCard.editNoticeFrozen'
+  if (kind === 'user_action') return 'reader:entryCard.editNoticeFrozenNoBranch'
+  if (kind === 'opening') return 'reader:entryCard.editNoticeFrozenNoRollback'
+  return 'reader:entryCard.editNoticeFrozen'
 }

--- a/components/reader/reader-surface.tsx
+++ b/components/reader/reader-surface.tsx
@@ -137,6 +137,7 @@ const ReaderRow = memo(function ReaderRow({
       disabled={editBlocked}
       editing={editing}
       contentEditNotice={contentEditNotice ?? undefined}
+      editDirty={editing && editContent !== row.content}
       onEdit={isSystem ? undefined : () => onStartEdit(row)}
       onRegen={row.kind === 'ai_reply' ? () => void onRegenerate(row.id) : undefined}
       onContentChange={onContentChange}

--- a/components/reader/scene-editing.test.tsx
+++ b/components/reader/scene-editing.test.tsx
@@ -49,9 +49,13 @@ afterEach(() => {
   vi.restoreAllMocks()
 })
 
-function render(entries: StoryEntry[], entities: readonly Entity[] = ENTITIES) {
+function render(
+  entries: StoryEntry[],
+  entities: readonly Entity[] = ENTITIES,
+  holdsLiveEdge = true,
+) {
   return renderHook(
-    ({ rows }: { rows: StoryEntry[] }) => useSceneEditing('b1', rows, entities, CTX),
+    ({ rows }: { rows: StoryEntry[] }) => useSceneEditing('b1', rows, holdsLiveEdge, entities, CTX),
     { initialProps: { rows: entries } },
   )
 }
@@ -86,6 +90,13 @@ describe('useSceneEditing → tail rule', () => {
 
   it('has no tail on an empty branch', () => {
     const { result } = render([])
+    expect(result.current.tailEntryId).toBeNull()
+  })
+
+  it('has no tail when the window stops short of the live edge', () => {
+    // The action layer resolves the head turn off the DB tail, so a window that no
+    // longer reaches it must offer nothing rather than name its own last row.
+    const { result } = render(ENTRIES, ENTITIES, false)
     expect(result.current.tailEntryId).toBeNull()
   })
 })

--- a/components/reader/scene-editing.ts
+++ b/components/reader/scene-editing.ts
@@ -14,7 +14,8 @@ export type SceneEditing = {
    *  counterparties, and a rejected location alike. */
   entityNames: ResolvedEntity[]
   sceneOptions: SceneOptions
-  /** The only entry whose scene fields are editable; null when the branch is empty. */
+  /** The only entry whose scene fields are editable; null when the branch is empty or
+   *  the loaded window stops short of the live edge. */
   tailEntryId: string | null
   /** The entry whose host Sheet is open, with the scene it was opened on. */
   sceneEdit: {
@@ -33,11 +34,13 @@ export type SceneEditing = {
  * document, the candidate pool for the editor's selects, the tail rule, and the
  * phone tier's bridged-out Sheet.
  *
- * `entries` MUST be in ascending position order — the tail is read off the end.
+ * `entries` MUST be in ascending position order — the tail is read off the end — and
+ * `holdsLiveEdge` MUST be false whenever that end is not the branch's own tail.
  */
 export function useSceneEditing(
   branchId: string,
   entries: StoryEntry[],
+  holdsLiveEdge: boolean,
   entities: readonly Entity[],
   ctx: DbCtx,
 ): SceneEditing {
@@ -60,8 +63,13 @@ export function useSceneEditing(
   )
 
   // The tail rule lives here, not in the card: only this entry gets edit handlers, so
-  // every other card renders no control at all rather than a disabled one.
-  const tailEntryId = entries.at(-1)?.id ?? null
+  // every other card renders no control at all rather than a disabled one. Gated on the
+  // window reaching the live edge because the action layer resolves the same head turn
+  // off the DB tail (resolveInvalidationScope): a window that stopped short would offer
+  // scene editing, Save & regenerate and the self-heals notice on a mid-window row
+  // whose edit the action layer treats as frozen, which is silent drift under
+  // reassuring copy.
+  const tailEntryId = holdsLiveEdge ? (entries.at(-1)?.id ?? null) : null
 
   const [sceneEditId, setSceneEditId] = useState<string | null>(null)
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -2208,12 +2208,20 @@ delta. Consequences:
 - When branching from entry N, the new branch copies entry N's _current_
   text (edited or not). The edit propagates through the fork, which is
   the intended behaviour — text edits are user intent, not narrative
-  state that needs reversing.
-- **Memory is not a side-channel, though.** Prose is the classifier's only
-  input, so an edit invalidates every fact it took from the replaced text.
-  The edit reverses the deltas anchored to that entry under
-  `source='periodic_classifier'` and clamps `processedThrough` below it,
-  in the same transaction as the text write. Both halves are required: the
+  state that needs reversing. **Order matters for the frozen-scene remedy.**
+  Entry N is the new branch's tail, so branching first and editing there puts
+  the edit back on the head turn, where the invalidation below does run.
+  Editing first and branching after carries both the new text and the facts
+  derived from the old text into the fork, and the fork's
+  `processedThrough = min(parent.processedThrough, position(N))` marks entry N
+  processed, so nothing re-reads it. The notice's "branch from here" means
+  branch, then rewrite.
+- **Memory is not a side-channel, though — inside the head turn.** Prose is
+  the classifier's only input, so an edit invalidates every fact it took from
+  the replaced text. An edit inside the head turn reverses the deltas anchored
+  to the invalidated entries under `source='periodic_classifier'` and clamps
+  `processedThrough` below the edited entry, in the same transaction as the
+  text write. Both halves are required: the
   clamp alone re-derives beside the stale facts rather than replacing them,
   and chapter-close dedup will not merge the pair, because its cast-overlap
   threshold is sized for re-deriving the _same_ fact, not a contradicting
@@ -2222,6 +2230,25 @@ delta. Consequences:
   corrected by hand, and nothing here may undo that. The suffix sweep stays
   out: the entry and everything after it survive, since nothing downstream
   is structurally invalid.
+- **The head turn is the ceiling, and the invalidation set runs from the
+  edited entry to the tail.** The clamp makes the classifier re-read every
+  entry above it, so the reversal has to cover every one of them or the pass
+  re-derives beside facts that survived. That is what bounds where the pair
+  may run at all: below the head turn the re-read suffix is unbounded, and the
+  duplicates it produces land in chapters that are already closed — which
+  chapter-close dedup never revisits, since sub-job 3e only clusters within
+  the range it is closing
+  ([`chapter-close.md → 3e`](./memory/chapter-close.md#3e--happenings-consolidation)).
+  Those duplicates would be permanent, and they would be paid on every
+  reworded typo, so an edit below the head turn reverses nothing and clamps
+  nothing. It is a bare text write, and the frozen-scene notice
+  ([`entry-card.md → Divergence notices`](./ui/patterns/entry-card.md#divergence-notices))
+  owns telling the user the recorded state will not follow. Inside the head
+  turn the set degenerates correctly: editing the tail covers the tail alone,
+  and editing the `user_action` whose reply is the tail covers both, because
+  clamping below it re-reads the reply too. The second case is also what keeps
+  [Save and regenerate](./ui/patterns/entry-card.md#save-and-regenerate)
+  reading the edited action rather than skipping past it.
 - **The reversal set closes over the happening → link-row relation**, not
   over the anchor alone. Undoing a `create` is a plain row delete with no
   cascade — only the explicit `deleteHappening` action carries one — and a
@@ -2248,7 +2275,9 @@ delta. Consequences:
   cannot be clamped to. Re-derivation therefore sees the edited entry
   onward and not the earlier prose that helped produce it. Accepted over
   clamping a full window back, which would re-derive facts for unedited
-  turns beside their surviving originals.
+  turns beside their surviving originals. Below the head turn the question
+  does not arise: nothing is reversed, so the fact keeps whatever it was
+  synthesised from.
 
 **Wizard creation is exempt from the delta log.** The wizard's commit
 transaction writes the `stories` row, the initial `branches` row, the

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -2249,6 +2249,16 @@ delta. Consequences:
   clamping below it re-reads the reply too. The second case is also what keeps
   [Save and regenerate](./ui/patterns/entry-card.md#save-and-regenerate)
   reading the edited action rather than skipping past it.
+- **"Tail" there is the last non-`system` entry, not the last row.** A
+  failed turn reverses its own `user_action` and parks the failure
+  singleton above what is left, so the row beneath it is the `ai_reply`
+  the head turn already covers — and the classifier's own turn window
+  skips the kind, so that reply is still what the next pass re-reads.
+  Letting the failure entry close the head turn would freeze the branch's
+  real tail for as long as the error card stands, turning an edit there
+  into a bare write whose stale facts nothing re-reads. The frozen notice
+  compounds it, naming branch and rollback when dismissing the `system`
+  entry is what restores the edit.
 - **The reversal set closes over the happening → link-row relation**, not
   over the anchor alone. Undoing a `create` is a plain row delete with no
   cascade — only the explicit `deleteHappening` action carries one — and a

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -44,17 +44,25 @@ for the placement rule.
   design but never scoped into it; that pass shipped 2026-09-03 and left
   this untouched.
 
-  **The memory half of this is closed** (2026-09-04). A content edit used
-  to leave the classifier's facts standing on prose that was gone, because
-  it clamped no watermark; it now reverses the facts anchored to that entry
-  and clamps below it in the same transaction as the text write, resolved
-  at
+  **The memory half of this is closed** (2026-09-04, rescoped 2026-09-05). A
+  content edit used to leave the classifier's facts standing on prose that was
+  gone, because it clamped no watermark; inside the head turn it now reverses
+  the facts anchored to the entries it invalidates and clamps below the edited
+  entry in the same transaction as the text write, resolved at
   [`data-model.md → Entry mutability & rollback`](./data-model.md#entry-mutability--rollback).
   That closes the `Save & regenerate` gap with it: the content clamp lands
   below the edited `user_action`, and the regenerate sweep's own clamp only
   lowers, so the next pass reads the edited action rather than skipping it.
   The user-facing half shipped alongside as
   [entry-card.md → Divergence notices](./ui/patterns/entry-card.md#divergence-notices).
+
+  The first cut clamped unconditionally, which made an edit to entry 5 of a
+  5000-entry story re-read the whole suffix while reversing only entry 5 —
+  duplicating every surviving fact above it, permanently, since chapter-close
+  dedup only clusters inside the range it is closing. Bounded to the head turn
+  2026-09-05: below it a content edit reverses nothing and clamps nothing, and
+  the frozen-scene notice owns the drift. The remedy it names is real but
+  order-sensitive — branch first, rewrite on the new tail.
 
   What stays open is reversibility alone. Delta-logging `content` is
   separable from the fix above — the clamp and the reversal needed the edit
@@ -74,6 +82,20 @@ for the placement rule.
   kind that writes one: `story_entries` registers only
   `updateStoryEntryMetadata` for updates, and `updateStoryEntryContent`
   writes `content` outside the action layer.
+
+  **Two seams it does have to pay for** (verified 2026-09-05). Reversing a
+  content delta restores prose, which is classifier input, so the undo path
+  needs the same invalidation the forward path just gained — and `undo.ts`
+  hardcodes an empty clamp for group reversals, correct only while no group
+  action touches prose. `applyRedo` has no per-table hook at all. The
+  head-turn bound keeps this small: below it there is nothing to invalidate,
+  and a content delta stops being the undo target as soon as a turn lands on
+  top of it, so the hook is needed only for a delta still sitting on the head
+  turn. Second, the delta row has to be inserted in the same transaction as
+  the reversal, and there is no exported way to do that — `deltaRowOp` is
+  private and `applyDeltaAction` owns its own transaction. Also mandatory,
+  not optional: the delta must stamp `entry_id`, or a rollback above the
+  edited entry would sweep it and restore stale prose onto a surviving row.
 
 - **Q3 needs an overhaul and a re-spec, not signal-by-signal patches.**
   [`retrieval.md → Q3`](./memory/retrieval.md#q3-heuristic-prose-extract)

--- a/docs/implementation/roadmap.md
+++ b/docs/implementation/roadmap.md
@@ -550,9 +550,9 @@ reads work; M6.6 follows M6.1.
 M6.1 owns it and M6.6 sequences after, or authoring extracts the
 core as a pinned contract and M6.6 parallelizes too.
 
-Carried deferrals, routed out of [`triage.md`](./triage.md)
-2026-08-18, verified against the code first. Resolve with the slice
-each names.
+Carried deferrals — the first batch routed out of
+[`triage.md`](./triage.md) 2026-08-18, later ones filed straight here —
+verified against the code first. Resolve with the slice each names.
 
 - **M6.1 — The fork-exclusion guard is structural and goes stale the moment
   fork lands.** Branch fork is unimplemented (M6.1), so Slice 3.5 could
@@ -569,6 +569,24 @@ each names.
   branch fork, replace the structural scan with the both-sides
   behavioral test** the slice AC originally described. Surfaced by the
   Slice 3.5 Task 14 review (2026-08-09).
+- **M6.1 — steps 2 and 3 of the fork partition use different predicates,
+  so a foreground edit about a kept entry falls between them.** Step 2
+  copies deltas below `L` plus, above `L`, only `periodic_classifier`
+  deltas anchored to a kept entry; step 3 reverse-applies everything above
+  `L` except `entry_id IS NULL OR position(entry_id) >= position(N+1)` —
+  by anchor, whatever the source. A `user_edit` delta anchored at or below
+  `N` therefore matches neither: not copied, not rewound, just dropped.
+  State stays correct, since step 1 copies current rows and a rollback on
+  the new branch deletes the entry the edit sits on anyway, so this is a
+  history-fidelity gap against step 2's own claim that the fork "carries
+  the complete history up to the fork point." Reachable today in spec
+  terms via `metadata` edits (`updateStoryEntryMetadata`), and it widens
+  if `story_entries.content` is ever delta-logged
+  ([`followups.md`](../followups.md)). **Settle which predicate is
+  authoritative when M6.1 writes the partition** — most likely step 2
+  widening to any delta anchored to a kept entry, since step 3's
+  exclusion is already source-blind. Surfaced reviewing the content-edit
+  invalidation scope (2026-09-05).
 
 **Gates.** M5 (chapter-close writes that branches must respect
 need to exist first).

--- a/docs/memory/classifier.md
+++ b/docs/memory/classifier.md
@@ -267,7 +267,13 @@ chapter-close phase 0. A successful pass over `(processedThrough, E]` sets
 it — `processedThrough ← min(processedThrough, position(B) − 1)` for `B`
 the earliest removed entry (see
 [`data-model.md → Entry mutability & rollback → Survival anchor`](../data-model.md#survival-anchor))
-— so changed turns are re-processed without re-deriving spared facts. At
+— so changed turns are re-processed without re-deriving spared facts. A
+content edit removes no entry and clamps only inside the head turn, where
+`B` is the edited entry and the reversal covers everything the clamp
+re-reads; below it the edit leaves the watermark alone rather than force a
+re-read of an unbounded suffix whose facts survive
+([`data-model.md → Entry mutability & rollback`](../data-model.md#entry-mutability--rollback)).
+At
 fork from entry `N`, the new branch sets
 `processedThrough = min(parent.processedThrough, position(N))` and resets
 the rest of the status to idle.

--- a/docs/ui/patterns/entry-card.md
+++ b/docs/ui/patterns/entry-card.md
@@ -400,13 +400,26 @@ on its own; the behavior is owned by the parent ScrollView.
 
 ### Divergence notices
 
-Editing `content` never updates the state recorded from it. The
+Editing `content` never updates the scene metadata recorded from it. The
 classifier reads prose only — its window carries `promptProse(entry)`
-and no metadata — so a rewrite leaves happenings, involvements and
-awareness standing on text that is gone. Nothing detects that, and on
-an earlier entry nothing can be done about it either, because the
-[scene editor](#scene-editor) refuses every row but the tail. So the
-editor states it, and what it states depends on where the row sits.
+and no metadata — so a rewrite leaves the scene triple standing on text
+that is gone, and on an earlier entry nothing can be done about it
+either, because the [scene editor](#scene-editor) refuses every row but
+the tail. So the editor states it, and what it states depends on where
+the row sits.
+
+**The happening layer splits on the same axis.** Inside the head turn a
+content edit reverses the happenings, involvements and awareness derived
+from the entries it invalidates, and clamps the classifier watermark so
+the next pass rebuilds them from the new text — the two notices below are
+therefore not symmetric about what survives. Below the head turn none of
+that runs: the clamp would force a re-read of every entry above it, whose
+facts survive, and the duplicates would land in already-closed chapters
+that chapter-close dedup never revisits
+([`data-model.md → Entry mutability & rollback`](../../data-model.md#entry-mutability--rollback)).
+So on a frozen row the recorded state genuinely does not follow, in either
+direction, and the notice is the only thing standing between the user and
+silent drift.
 
 **On the tail** both halves are editable, so the notice is a nudge:
 
@@ -433,6 +446,24 @@ equivalent:
 > safe — but if this changes who was present or what happened, the
 > recorded world state won't follow. Branch from here, or roll back
 > (which deletes this entry and everything after).
+
+**"Branch from here" means branch, then rewrite.** Entry N is the new
+branch's tail, so the rewrite lands on the head turn there and invalidates
+normally. Done the other way round the fork copies the new text alongside
+the facts derived from the old, and its
+`processedThrough = min(parent.processedThrough, position(N))` marks the
+entry processed, so nothing re-reads it
+([data-model → Branch model](../../data-model.md#branch-model)). The
+notice does not spell the order out — it is offered mid-edit, where
+"branch" reads as "not here" — but the fork surface owns making the tail
+obvious when it lands.
+
+**The two branches of this notice are the behavioural boundary, not
+commentary on it.** `resolveContentEditNotice` derives them from
+`sceneEditable || hasSaveAndRegen`, which is exactly the head-turn
+membership the action layer gates invalidation on. The two must move
+together: a row that shows the nudge is a row whose edit self-heals, and a
+row that shows the frozen copy is a row whose edit does not.
 
 **An earlier `user_action` drops the branch clause.** That kind carries
 no branch action ([Per-kind structure](#per-kind-structure)) and

--- a/docs/ui/patterns/entry-card.md
+++ b/docs/ui/patterns/entry-card.md
@@ -483,6 +483,18 @@ send the user into that modal unprepared, which is the failure the
 notice exists to prevent — as is naming a control the card does not
 have.
 
+**The opening drops the rollback clause.** It is the rollback floor —
+the action layer rejects a rollback that targets it, and the card
+renders no delete ([Per-kind structure](#per-kind-structure)) — so that
+half of the remedy can never become true for it, unlike the branch
+clause, which the fork surface will make good. Branching is the only
+honest answer there:
+
+> Only the newest entry's scene details can be updated. Rewording is
+> safe — but if this changes who was present or what happened, the
+> recorded world state won't follow. Branching from here is the only
+> remedy — the opening can't be rolled back.
+
 **Placement is edit mode, not the card.** The notice renders inside the
 editor when the textarea opens, never as standing chrome on a non-tail
 card. Most of a branch is non-tail; a permanent banner there is

--- a/docs/ui/patterns/entry-card.md
+++ b/docs/ui/patterns/entry-card.md
@@ -516,6 +516,18 @@ just saved), on the opening, on any earlier turn, and whenever the tail is a
 standing `user_action` or a system entry — in each case there is no reply
 the edit can be re-answered into.
 
+**Both commit buttons gate on a dirty draft.** An untouched draft has nothing
+to save, and saving it anyway is not free: on the head turn the write reverses
+the entry's classifier facts and spends a pass rebuilding them identically, and
+on any row it clears the global redo stack for nothing. `Save & regenerate`
+disables alongside `Save` rather than degrading into a bare regenerate — that
+path is the reply's own `↻`, behind its
+[cascade confirm](../screens/reader-composer/reader-composer.md#regenerate-confirmation),
+and a button that saved nothing must not route around it. `Cancel` stays live,
+since backing out of an untouched draft has to stay reachable. The action layer
+carries the same compare as a backstop for any other caller, returning `ok`
+without writing.
+
 **Commit, then run.** The two halves are sequential, not atomic: the
 pipeline re-reads its prompt from the branch tail rather than from anything
 threaded into the call, so the edit must be committed before the run starts

--- a/lib/actions/story-entries/classifier-facts.ts
+++ b/lib/actions/story-entries/classifier-facts.ts
@@ -1,10 +1,44 @@
-import { and, eq, inArray } from 'drizzle-orm'
+import { and, desc, eq, inArray } from 'drizzle-orm'
 
-import { deltas, happeningAwareness, happeningInvolvements, type Delta } from '@/lib/db'
+import {
+  deltas,
+  happeningAwareness,
+  happeningInvolvements,
+  storyEntries,
+  type Delta,
+} from '@/lib/db'
 
 import type { DbCtx } from '../types'
 
 const CHILD_TABLES = ['happening_involvements', 'happening_awareness'] as const
+
+/**
+ * The entries a content edit invalidates, or null when it invalidates none.
+ *
+ * The clamp reopens every entry above it, so the reversal has to cover that whole
+ * window or the next pass re-derives beside facts that survived — which is what bounds
+ * both to the head turn (data-model.md -> Entry mutability & rollback). The same pair
+ * `resolveSaveAndRegenTurn` derives the editor's notice from; they must agree.
+ */
+export async function resolveInvalidationScope(
+  branchId: string,
+  editedId: string,
+  ctx: DbCtx,
+): Promise<string[] | null> {
+  const [tail, previous] = await ctx.db
+    .select({ id: storyEntries.id, kind: storyEntries.kind })
+    .from(storyEntries)
+    .where(eq(storyEntries.branchId, branchId))
+    .orderBy(desc(storyEntries.position))
+    .limit(2)
+  if (!tail) return null
+  if (tail.id === editedId) return [tail.id]
+  // Clamping below the head turn's origin reopens the reply too, so the reply's facts
+  // go with it or they re-derive twice.
+  if (previous?.id === editedId && previous.kind === 'user_action' && tail.kind === 'ai_reply')
+    return [previous.id, tail.id]
+  return null
+}
 
 /**
  * A first-introduction entity stays, even though the prose that introduced it is gone.
@@ -23,7 +57,7 @@ function isReversible(delta: Delta): boolean {
 
 /**
  * Every delta a content edit must reverse: the classifier facts anchored to the
- * edited entry, closed under the happening -> link-row relation.
+ * entries in its invalidation scope, closed under the happening -> link-row relation.
  *
  * The closure is load-bearing. Undoing a `create` is a plain row delete with no
  * cascade -- only the explicit `deleteHappening` action carries one -- and a link
@@ -39,9 +73,10 @@ function isReversible(delta: Delta): boolean {
  */
 export async function resolveClassifierFactDeltas(
   branchId: string,
-  entryId: string,
+  entryIds: readonly string[],
   ctx: DbCtx,
 ): Promise<Delta[]> {
+  if (entryIds.length === 0) return []
   const anchored = (
     (await ctx.db
       .select()
@@ -49,7 +84,7 @@ export async function resolveClassifierFactDeltas(
       .where(
         and(
           eq(deltas.branchId, branchId),
-          eq(deltas.entryId, entryId),
+          inArray(deltas.entryId, [...entryIds]),
           eq(deltas.source, 'periodic_classifier'),
         ),
       )) as Delta[]

--- a/lib/actions/story-entries/classifier-facts.ts
+++ b/lib/actions/story-entries/classifier-facts.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray } from 'drizzle-orm'
+import { and, desc, eq, inArray, ne } from 'drizzle-orm'
 
 import {
   deltas,
@@ -19,6 +19,13 @@ const CHILD_TABLES = ['happening_involvements', 'happening_awareness'] as const
  * window or the next pass re-derives beside facts that survived — which is what bounds
  * both to the head turn (data-model.md -> Entry mutability & rollback). The same pair
  * `resolveSaveAndRegenTurn` derives the editor's notice from; they must agree.
+ *
+ * A `system` row is transparent here because it is transparent to the classifier:
+ * `readLastTurns` skips the kind, so the reply beneath a failure entry is still the head
+ * turn the next pass re-reads. A failed turn reverses its own `user_action` and parks the
+ * singleton above the branch's real tail, so letting it close the scope would freeze that
+ * tail for as long as the error card stands, and an edit there would leave facts derived
+ * from replaced prose with nothing to re-read them.
  */
 export async function resolveInvalidationScope(
   branchId: string,
@@ -28,7 +35,7 @@ export async function resolveInvalidationScope(
   const [tail, previous] = await ctx.db
     .select({ id: storyEntries.id, kind: storyEntries.kind })
     .from(storyEntries)
-    .where(eq(storyEntries.branchId, branchId))
+    .where(and(eq(storyEntries.branchId, branchId), ne(storyEntries.kind, 'system')))
     .orderBy(desc(storyEntries.position))
     .limit(2)
   if (!tail) return null

--- a/lib/actions/story-entries/operational.test.ts
+++ b/lib/actions/story-entries/operational.test.ts
@@ -503,6 +503,46 @@ async function seedHeadTurn(db: Awaited<ReturnType<typeof createTestDb>>['db']) 
     )
 }
 
+// The same head turn under a failed follow-up: the turn reversed its own user_action
+// and left the failure singleton above the reply, which is still the branch's real tail.
+async function seedHeadTurnUnderFailure(db: Awaited<ReturnType<typeof createTestDb>>['db']) {
+  await db.insert(stories).values({ id: 's1', title: 'T', createdAt: 1, updatedAt: 1 })
+  await db.insert(branches).values({
+    id: 'b1',
+    storyId: 's1',
+    name: 'm',
+    createdAt: 1,
+    classifierStatus: classifierStatus(2),
+  })
+  const entries = [
+    { id: 'e1', position: 1, kind: 'user_action' as const, content: 'act' },
+    { id: 'e2', position: 2, kind: 'ai_reply' as const, content: 'reply' },
+    { id: 'e3', position: 3, kind: 'system' as const, content: 'generation failed' },
+  ].map((e) => ({ ...e, branchId: 'b1', createdAt: e.position }))
+  await db.insert(storyEntries).values(entries)
+  entriesStore.hydrate(
+    'b1',
+    entries.map((e) => ({ ...e, chapterId: null, metadata: null })),
+  )
+  await db.insert(happenings).values(
+    (['e1', 'e2'] as const).map((entryId, i) => ({
+      id: `hap_${i + 1}`,
+      branchId: 'b1',
+      title: `derived from ${entryId}`,
+      occurredAtEntryId: entryId,
+      createdAt: i + 1,
+      updatedAt: i + 1,
+    })),
+  )
+  await db
+    .insert(deltas)
+    .values(
+      (['e1', 'e2'] as const).map((entryId, i) =>
+        classifierDelta(`d_hap${i + 1}`, i + 1, 'happenings', `hap_${i + 1}`, entryId),
+      ),
+    )
+}
+
 describe('updateStoryEntryContent classifier invalidation', () => {
   it('takes link rows anchored to a different entry down with their happening', async () => {
     const { db, runInTransaction } = await createTestDb()
@@ -770,5 +810,40 @@ describe('updateStoryEntryContent invalidation scope', () => {
       .from(branches)
       .where(eq(branches.id, 'b1'))
     expect(branch.status?.processedThrough).toBe(2)
+  })
+
+  it('reads the head turn past a system tail rather than freezing under it', async () => {
+    const { db, runInTransaction } = await createTestDb()
+    const ctx = { db, runInTransaction }
+    await seedHeadTurnUnderFailure(db)
+
+    // e2 is the last row the classifier reads, so the failure entry above it must not
+    // turn this into a bare write whose stale facts nothing re-reads.
+    expect((await updateStoryEntryContent('b1', 'e2', 'rewritten reply', ctx)).status).toBe('ok')
+
+    const haps = await db.select().from(happenings).where(eq(happenings.branchId, 'b1'))
+    expect(haps.map((h) => h.id)).toEqual(['hap_1'])
+    const [branch] = await db
+      .select({ status: branches.classifierStatus })
+      .from(branches)
+      .where(eq(branches.id, 'b1'))
+    expect(branch.status?.processedThrough).toBe(1)
+  })
+
+  it('still covers the origin and its reply when a system entry sits above them', async () => {
+    const { db, runInTransaction } = await createTestDb()
+    const ctx = { db, runInTransaction }
+    await seedHeadTurnUnderFailure(db)
+
+    // Same two-entry arm as without the failure entry: clamping below e1 reopens e2.
+    expect((await updateStoryEntryContent('b1', 'e1', 'rewritten action', ctx)).status).toBe('ok')
+
+    const haps = await db.select().from(happenings).where(eq(happenings.branchId, 'b1'))
+    expect(haps).toHaveLength(0)
+    const [branch] = await db
+      .select({ status: branches.classifierStatus })
+      .from(branches)
+      .where(eq(branches.id, 'b1'))
+    expect(branch.status?.processedThrough).toBe(0)
   })
 })

--- a/lib/actions/story-entries/operational.test.ts
+++ b/lib/actions/story-entries/operational.test.ts
@@ -716,6 +716,27 @@ describe('updateStoryEntryContent invalidation scope', () => {
     expect(branch.status?.processedThrough).toBe(2)
   })
 
+  it('no-ops an unchanged save rather than reversing and re-deriving identical facts', async () => {
+    const { db, runInTransaction } = await createTestDb()
+    const ctx = { db, runInTransaction }
+    await seedClassifiedTail(db)
+    undoRedoStore.pushRedoGroup([])
+
+    // e2 is the tail, so without the guard this would take the full in-scope path.
+    expect((await updateStoryEntryContent('b1', 'e2', 'old', ctx)).status).toBe('ok')
+
+    const haps = await db.select().from(happenings).where(eq(happenings.branchId, 'b1'))
+    expect(haps.map((h) => h.id).sort()).toEqual(['hap_1', 'hap_2'])
+    const remaining = await db.select().from(deltas).where(eq(deltas.branchId, 'b1'))
+    expect(remaining).toHaveLength(5)
+    const [branch] = await db
+      .select({ status: branches.classifierStatus })
+      .from(branches)
+      .where(eq(branches.id, 'b1'))
+    expect(branch.status?.processedThrough).toBe(2)
+    expect(undoRedoStore.hasRedo()).toBe(true)
+  })
+
   it('covers the tail reply too when the head turn origin is edited', async () => {
     const { db, runInTransaction } = await createTestDb()
     const ctx = { db, runInTransaction }

--- a/lib/actions/story-entries/operational.test.ts
+++ b/lib/actions/story-entries/operational.test.ts
@@ -463,35 +463,67 @@ async function seedClassifiedTail(db: Awaited<ReturnType<typeof createTestDb>>['
   ])
 }
 
+// A head turn proper: an ai_reply tail over its user_action origin, each with one
+// classifier-derived happening, plus an earlier entry whose facts must never move.
+async function seedHeadTurn(db: Awaited<ReturnType<typeof createTestDb>>['db']) {
+  await db.insert(stories).values({ id: 's1', title: 'T', createdAt: 1, updatedAt: 1 })
+  await db.insert(branches).values({
+    id: 'b1',
+    storyId: 's1',
+    name: 'm',
+    createdAt: 1,
+    classifierStatus: classifierStatus(3),
+  })
+  const entries = [
+    { id: 'e1', position: 1, kind: 'ai_reply' as const, content: 'a' },
+    { id: 'e2', position: 2, kind: 'user_action' as const, content: 'act' },
+    { id: 'e3', position: 3, kind: 'ai_reply' as const, content: 'reply' },
+  ].map((e) => ({ ...e, branchId: 'b1', createdAt: e.position }))
+  await db.insert(storyEntries).values(entries)
+  entriesStore.hydrate(
+    'b1',
+    entries.map((e) => ({ ...e, chapterId: null, metadata: null })),
+  )
+  await db.insert(happenings).values(
+    (['e1', 'e2', 'e3'] as const).map((entryId, i) => ({
+      id: `hap_${i + 1}`,
+      branchId: 'b1',
+      title: `derived from ${entryId}`,
+      occurredAtEntryId: entryId,
+      createdAt: i + 1,
+      updatedAt: i + 1,
+    })),
+  )
+  await db
+    .insert(deltas)
+    .values(
+      (['e1', 'e2', 'e3'] as const).map((entryId, i) =>
+        classifierDelta(`d_hap${i + 1}`, i + 1, 'happenings', `hap_${i + 1}`, entryId),
+      ),
+    )
+}
+
 describe('updateStoryEntryContent classifier invalidation', () => {
   it('takes link rows anchored to a different entry down with their happening', async () => {
     const { db, runInTransaction } = await createTestDb()
     const ctx = { db, runInTransaction }
     await seedClassifiedTail(db)
-    // A character learning of hap_2 on a later turn anchors to that turn, not to the
-    // happening's own provenance entry — so anchor-scoped reversal alone would delete
-    // hap_2 and leave this row pointing at nothing.
-    await db.insert(storyEntries).values({
-      id: 'e3',
-      branchId: 'b1',
-      position: 3,
-      kind: 'ai_reply',
-      content: 'c',
-      createdAt: 3,
-    })
+    // Awareness anchors to the turn that narrated the learning, which can sit either
+    // side of the happening's own provenance entry — so anchor-scoped reversal alone
+    // would delete hap_2 and leave this row pointing at nothing.
     await db.insert(happeningAwareness).values({
-      id: 'haw_late',
+      id: 'haw_early',
       branchId: 'b1',
       happeningId: 'hap_2',
       characterId: 'char_m',
-      learnedAtEntryId: 'e3',
+      learnedAtEntryId: 'e1',
       decayResistance: null,
       retrievalCount: 0,
       source: 'told by Jorin',
     })
     await db
       .insert(deltas)
-      .values([classifierDelta('d_haw_late', 6, 'happening_awareness', 'haw_late', 'e3')])
+      .values([classifierDelta('d_haw_early', 6, 'happening_awareness', 'haw_early', 'e1')])
 
     expect((await updateStoryEntryContent('b1', 'e2', 'new', ctx)).status).toBe('ok')
 
@@ -649,5 +681,73 @@ describe('updateStoryEntryContent classifier invalidation', () => {
       .where(and(eq(storyEntries.branchId, 'b1'), eq(storyEntries.id, 'e2')))
     expect(row.content).toBe('new')
     expect(entriesStore.getById('e2')?.content).toBe('new')
+  })
+})
+
+describe('updateStoryEntryContent invalidation scope', () => {
+  it('reverses and clamps nothing below the head turn', async () => {
+    const { db, runInTransaction } = await createTestDb()
+    const ctx = { db, runInTransaction }
+    await seedClassifiedTail(db)
+
+    // e1 sits under the tail, so the clamp would reopen e2 while e2's facts survive.
+    expect((await updateStoryEntryContent('b1', 'e1', 'reworded', ctx)).status).toBe('ok')
+
+    const [row] = await db
+      .select()
+      .from(storyEntries)
+      .where(and(eq(storyEntries.branchId, 'b1'), eq(storyEntries.id, 'e1')))
+    expect(row.content).toBe('reworded')
+    expect(entriesStore.getById('e1')?.content).toBe('reworded')
+    const haps = await db.select().from(happenings).where(eq(happenings.branchId, 'b1'))
+    expect(haps.map((h) => h.id).sort()).toEqual(['hap_1', 'hap_2'])
+    const remaining = await db.select().from(deltas).where(eq(deltas.branchId, 'b1'))
+    expect(remaining.map((d) => d.id).sort()).toEqual([
+      'd_hap1',
+      'd_hap2',
+      'd_haw2',
+      'd_hinv2',
+      'd_meta2',
+    ])
+    const [branch] = await db
+      .select({ status: branches.classifierStatus })
+      .from(branches)
+      .where(eq(branches.id, 'b1'))
+    expect(branch.status?.processedThrough).toBe(2)
+  })
+
+  it('covers the tail reply too when the head turn origin is edited', async () => {
+    const { db, runInTransaction } = await createTestDb()
+    const ctx = { db, runInTransaction }
+    await seedHeadTurn(db)
+
+    // Clamping below e2 reopens e3, so e3's facts have to go with e2's.
+    expect((await updateStoryEntryContent('b1', 'e2', 'rewritten action', ctx)).status).toBe('ok')
+
+    const haps = await db.select().from(happenings).where(eq(happenings.branchId, 'b1'))
+    expect(haps.map((h) => h.id)).toEqual(['hap_1'])
+    const [branch] = await db
+      .select({ status: branches.classifierStatus })
+      .from(branches)
+      .where(eq(branches.id, 'b1'))
+    expect(branch.status?.processedThrough).toBe(1)
+  })
+
+  it('spares the head turn origin when the tail is edited', async () => {
+    const { db, runInTransaction } = await createTestDb()
+    const ctx = { db, runInTransaction }
+    await seedHeadTurn(db)
+
+    // The clamp lands at e3's position - 1, so the window is e3 alone and e2's facts
+    // must survive — reversing them would delete what nothing re-derives.
+    expect((await updateStoryEntryContent('b1', 'e3', 'rewritten reply', ctx)).status).toBe('ok')
+
+    const haps = await db.select().from(happenings).where(eq(happenings.branchId, 'b1'))
+    expect(haps.map((h) => h.id).sort()).toEqual(['hap_1', 'hap_2'])
+    const [branch] = await db
+      .select({ status: branches.classifierStatus })
+      .from(branches)
+      .where(eq(branches.id, 'b1'))
+    expect(branch.status?.processedThrough).toBe(2)
   })
 })

--- a/lib/actions/story-entries/operational.ts
+++ b/lib/actions/story-entries/operational.ts
@@ -75,6 +75,12 @@ async function updateStoryEntryContentBracketed(
       code: STORY_ENTRY_REJECTION.notFound,
     }
 
+  // The editor gates its commit buttons on the same compare, so this is the backstop for
+  // any other caller: on the head turn a no-op write would reverse the entry's facts and
+  // spend a classifier pass rebuilding them identically, and it clears the redo stack for
+  // nothing on every row.
+  if (current.content === content) return { status: 'ok' }
+
   const scope = await resolveInvalidationScope(branchId, id, ctx)
   const derived = scope ? await resolveClassifierFactDeltas(branchId, scope, ctx) : []
 

--- a/lib/actions/story-entries/operational.ts
+++ b/lib/actions/story-entries/operational.ts
@@ -6,7 +6,7 @@ import { entriesStore, generationStore, undoRedoStore } from '@/lib/stores'
 
 import { reverseAndPruneDeltaRows } from '../delta/reverse-replay'
 import type { DbCtx } from '../types'
-import { resolveClassifierFactDeltas } from './classifier-facts'
+import { resolveClassifierFactDeltas, resolveInvalidationScope } from './classifier-facts'
 import { bracketProseReversal, classifierWatermarkClampOps } from './prose-reversal'
 import { STORY_ENTRY_REJECTION, type StoryEntryRejectionCode } from './register'
 
@@ -33,6 +33,9 @@ export async function updateStoryEntryContent(
   // No re-check inside the bracket, matching rollbackToEntry: the gate above and
   // bracketProseReversal's own flag set are one synchronous block, and the flag
   // itself reads as blocked, so a re-check would reject every call.
+  //
+  // Held even for an edit that reverses nothing: resolving the scope needs a read,
+  // and taking it outside the barrier would race the tail it is classifying.
   return bracketProseReversal(branchId, () =>
     updateStoryEntryContentBracketed(branchId, id, content, ctx),
   )
@@ -43,8 +46,12 @@ export async function updateStoryEntryContent(
  * it took from the old text standing on nothing. Clamping the watermark on its own
  * only adds the new reading beside the stale one -- chapter-close dedup merges on
  * cast overlap, which a contradicting fact does not have -- so the two run together:
- * reverse what this entry produced, then let the next pass re-read it
- * (followups.md -> Entry content edits are irreversible).
+ * reverse what the edit invalidated, then let the next pass re-read it
+ * (data-model.md -> Entry mutability & rollback).
+ *
+ * Both halves ride one scope and neither runs without it: the clamp reopens exactly
+ * the window the reversal covers, so a narrower set would re-derive beside surviving
+ * facts. Off the head turn the edit is a bare text write.
  *
  * Scoped by source, not by table: `per_turn_classifier` and `piggyback_tagged_block`
  * write the scene metadata a user may have just corrected by hand, and nothing here
@@ -68,19 +75,21 @@ async function updateStoryEntryContentBracketed(
       code: STORY_ENTRY_REJECTION.notFound,
     }
 
-  const derived = await resolveClassifierFactDeltas(branchId, id, ctx)
+  const scope = await resolveInvalidationScope(branchId, id, ctx)
+  const derived = scope ? await resolveClassifierFactDeltas(branchId, scope, ctx) : []
 
-  // Clamped unconditionally: a pass that read this entry and extracted nothing still
-  // advanced the watermark past it, and the op no-ops when the watermark is behind.
-  // One transaction, because a clamp without the reversal re-derives beside the stale
-  // facts and a reversal without the clamp deletes them with nothing to replace them.
+  // In scope the clamp is unconditional: a pass that read the entry and extracted
+  // nothing still advanced the watermark past it, and the op no-ops when the watermark
+  // is already behind. One transaction, because a clamp without the reversal re-derives
+  // beside the stale facts and a reversal without the clamp deletes them with nothing
+  // to replace them.
   await reverseAndPruneDeltaRows(derived, ctx, [
     ctx.db
       .update(storyEntries)
       .set({ content })
       .where(and(eq(storyEntries.branchId, branchId), eq(storyEntries.id, id)))
       .toSQL(),
-    ...classifierWatermarkClampOps(branchId, current.position),
+    ...(scope ? classifierWatermarkClampOps(branchId, current.position) : []),
   ])
 
   entriesStore.patch(branchId, { op: 'update', id, columns: { content } })

--- a/locales/en/reader.json
+++ b/locales/en/reader.json
@@ -102,7 +102,8 @@
     "deleteEntry": "Delete entry",
     "editNoticeSceneHere": "This doesn't change the scene details recorded for this entry. Update them separately if the rewrite changes who was present.",
     "editNoticeFrozen": "Only the newest entry's scene details can be updated. Rewording is safe — but if this changes who was present or what happened, the recorded world state won't follow. Branch from here, or roll back (which deletes this entry and everything after).",
-    "editNoticeFrozenNoBranch": "Only the newest entry's scene details can be updated. Rewording is safe — but if this changes who was present or what happened, the recorded world state won't follow. Rolling back is the only remedy, and it deletes this entry and everything after."
+    "editNoticeFrozenNoBranch": "Only the newest entry's scene details can be updated. Rewording is safe — but if this changes who was present or what happened, the recorded world state won't follow. Rolling back is the only remedy, and it deletes this entry and everything after.",
+    "editNoticeFrozenNoRollback": "Only the newest entry's scene details can be updated. Rewording is safe — but if this changes who was present or what happened, the recorded world state won't follow. Branching from here is the only remedy — the opening can't be rolled back."
   },
   "worldTimeEdit": {
     "title": "Edit time",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer guidance when story openings can be edited but cannot be rolled back.
  * Editing now respects whether the displayed story has reached its live edge.

* **Bug Fixes**
  * Save actions are disabled when an edited draft has no changes.
  * Unchanged content updates no longer trigger unnecessary processing.
  * Content edits now correctly handle related story facts.
  * Truncated story windows no longer treat the final displayed entry as the editable tail.

* **Tests**
  * Added coverage for pristine drafts, live-edge behavior, and content-edit invalidation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->