### PR TITLE
Report what a turn is doing while it generates

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -137,6 +137,32 @@ which is what keeps them testable.
 Alongside the pipeline, `BackgroundTaskRunner` handles what happens _after_ a turn — the chapter
 threshold check, lore management and the style review — on its own dependency object.
 
+### Activity reporting
+
+A turn records what it is doing as a tree of timed steps, so the wait before the first token is
+readable rather than a three-dot animation. `services/activity/` holds the record and the reading
+views over it — nesting, the deepest running step, durations, retention — all plain TypeScript;
+`stores/activity.svelte.ts` is the reactive shell.
+
+The phases reach it through an `ActivityReporter` on `PipelineDependencies`, bound in
+`buildPipelineDependencies` alongside everything else. They do not import the store: that is the same
+rule that keeps them testable without a provider, and `NO_ACTIVITY` stands in wherever no reporter was
+injected. Services under `services/ai/` write to the store directly instead, following the debug
+store's precedent — their tests mock it the same way.
+
+Nesting is by explicit parent id, threaded through the options objects that already reach those
+services (`activityParentId`). An implicit stack would not survive Stage A's two concurrent branches
+or the parallel post-narrative phases.
+
+Retrieval reports through the record it already keeps: `retrievalSteps.ts` translates `RetrievalEvent`
+into steps as `AgenticRetrievalService` records them, and chapter queries carry the `durationMs` the
+budget already measured. Phases with several completion paths are wrapped by `trackPhase` rather than
+instrumented one exit at a time.
+
+Reporting never alters a turn. Every write is guarded, the display sits inside a boundary, and the
+narrative retry loop is reported but unchanged. Records are session-only, bounded by `RETAINED_TURNS`,
+and never persisted or exported.
+
 ## Images
 
 Nine backends live under `src/lib/services/ai/image/providers/` — NanoGPT, OpenAI, OpenRouter,

--- a/src/lib/components/settings/tabs/interface.svelte
+++ b/src/lib/components/settings/tabs/interface.svelte
@@ -15,6 +15,7 @@
   import { ScrollArea } from '$lib/components/ui/scroll-area'
   import ColorPicker from '$lib/components/shared/ColorPicker.svelte'
   import { Separator } from '$lib/components/ui/separator'
+  import { cn } from '$lib/utils/cn'
   import { getSupportedLanguages } from '$lib/services/ai/utils/TranslationService'
   import { updaterService, UpdateError } from '$lib/services/updater'
   import { updateNotifier } from '$lib/stores/updateNotifier.svelte'
@@ -177,6 +178,18 @@
     { value: 'xlarge', label: 'X-Large' },
     { value: 'xxlarge', label: 'XX-Large' },
   ] as const
+
+  const ACTIVITY_REPORTING_OPTIONS = [
+    { key: 'off', label: 'Off', hint: 'Show the usual waiting animation' },
+    { key: 'line', label: 'Status line', hint: 'Name the step running now, expandable' },
+    { key: 'tree', label: 'Full timeline', hint: 'Open the whole turn timeline by default' },
+  ] as const
+
+  const activitySegment =
+    'flex flex-col items-center justify-center gap-1 rounded-md border px-1.5 py-2 transition-colors'
+  const activitySegmentOn = 'border-primary/60 bg-primary/10 text-foreground font-semibold'
+  const activitySegmentOff =
+    'border-border/40 bg-background/60 text-muted-foreground hover:bg-accent/40'
 </script>
 
 <div class="space-y-4">
@@ -424,6 +437,35 @@
       checked={settings.uiSettings.showReasoning}
       onCheckedChange={(v) => settings.setShowReasoning(v)}
     />
+  </div>
+
+  <!-- Generation Activity -->
+  <div class="space-y-2">
+    <div>
+      <Label>Generation Activity</Label>
+      <p class="text-muted-foreground text-xs">
+        Report what a turn is doing while it generates, and how long each step took. Separate from
+        Debug Mode.
+      </p>
+    </div>
+    <div class="grid grid-cols-3 gap-1.5">
+      {#each ACTIVITY_REPORTING_OPTIONS as option (option.key)}
+        <button
+          type="button"
+          class={cn(
+            activitySegment,
+            settings.uiSettings.activityReporting === option.key
+              ? activitySegmentOn
+              : activitySegmentOff,
+          )}
+          aria-pressed={settings.uiSettings.activityReporting === option.key}
+          title={option.hint}
+          onclick={() => settings.setActivityReporting(option.key)}
+        >
+          <span class="text-xs">{option.label}</span>
+        </button>
+      {/each}
+    </div>
   </div>
 
   <!-- Auto Scroll Toggle -->

--- a/src/lib/components/story/ActionInput.svelte
+++ b/src/lib/components/story/ActionInput.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { tick } from 'svelte'
   import { ui, type RetrievalCacheKey } from '$lib/stores/ui.svelte'
+  import { activity } from '$lib/stores/activity.svelte'
   import { toRetrievalSnapshot } from '$lib/services/ai/retrieval'
   import { buildTimelineFillBlock } from '$lib/services/ai/generation'
   import { joinPromptBlocks } from '$lib/utils/promptBlocks'
@@ -236,6 +237,7 @@
    */
   function buildPipelineDependencies(storyId: string): PipelineDependencies {
     return {
+      activity,
       shouldUseAgenticRetrieval: () =>
         aiService.shouldUseAgenticRetrieval(settings.systemServicesSettings.timelineFill),
       runAgenticRetrieval: (options) =>
@@ -248,7 +250,7 @@
       // The chapter-read budget is derived from this story's own chapterization threshold, so
       // it is bound here with the rest of the store rather than read from settings: a chapter
       // is about `tokenThreshold` tokens by construction. See `story.chapterReadBudget`.
-      runTimelineFill: (visibleEntries, chapters, alreadyInContext) =>
+      runTimelineFill: (visibleEntries, chapters, alreadyInContext, activityParentId) =>
         aiService.runTimelineFill(
           storyId,
           visibleEntries,
@@ -256,6 +258,7 @@
           story.getChapterEntries.bind(story),
           alreadyInContext,
           story.chapterReadBudget,
+          activityParentId,
         ),
       answerChapterQuestion: (chapterNumber, question, chapters) =>
         aiService.answerChapterQuestion(
@@ -480,6 +483,7 @@
     }
 
     ui.setGenerating(true)
+    activity.startTurn(narrationEntryId)
     ui.clearGenerationError()
     ui.clearActionChoices(story.currentStory.id)
     ui.startStreaming(visualProseMode, streamingEntryId)
@@ -826,6 +830,8 @@
       ui.endStreaming()
       ui.setGenerating(false)
       ui.setGenerationStatus('')
+      // Closes the turn even when a step was left running, so the record is bounded.
+      activity.endTurn()
       activeAbortController = null
 
       // Android: always stop the foreground service when generation ends

--- a/src/lib/components/story/ActionInput.svelte
+++ b/src/lib/components/story/ActionInput.svelte
@@ -504,16 +504,6 @@
     }
 
     ui.setGenerating(true)
-    const inputTranslation = options?.inputTranslation
-    activity.startTurn(narrationEntryId, inputTranslation?.startedAt)
-    if (inputTranslation) {
-      activity.recordStep('Translating input', {
-        isLLM: true,
-        startedAt: inputTranslation.startedAt,
-        durationMs: inputTranslation.durationMs,
-        status: inputTranslation.failed ? 'failed' : 'done',
-      })
-    }
     ui.clearGenerationError()
     ui.clearActionChoices(story.currentStory.id)
     ui.startStreaming(visualProseMode, streamingEntryId)
@@ -541,6 +531,19 @@
     ui.resetBackgroundedFlag()
 
     try {
+      // Inside the try: only its `finally` closes the turn, and a throw before that point
+      // would leave a record nothing can close.
+      const inputTranslation = options?.inputTranslation
+      activity.startTurn(narrationEntryId, inputTranslation?.startedAt)
+      if (inputTranslation) {
+        activity.recordStep('Translating input', {
+          isLLM: true,
+          startedAt: inputTranslation.startedAt,
+          durationMs: inputTranslation.durationMs,
+          status: inputTranslation.failed ? 'failed' : 'done',
+        })
+      }
+
       const worldState = story.worldStateSnapshot
 
       const storyPosition = story.entries.length

--- a/src/lib/components/story/ActionInput.svelte
+++ b/src/lib/components/story/ActionInput.svelte
@@ -67,13 +67,29 @@
   // Translation Helper
   // ============================================================================
 
+  /** What the input translation cost, for the turn record. See `InputTranslationTiming`. */
+  type InputTranslationTiming = { startedAt: number; durationMs: number; failed: boolean }
+
   async function translateUserInput(
     content: string,
     translationSettings: typeof settings.translationSettings,
-  ): Promise<{ promptContent: string; originalInput: string | undefined }> {
+  ): Promise<{
+    promptContent: string
+    originalInput: string | undefined
+    timing?: InputTranslationTiming
+  }> {
     if (!TranslationService.shouldTranslateInput(translationSettings)) {
       return { promptContent: content, originalInput: undefined }
     }
+
+    // Measured here because this runs before the generation path opens the turn record, and
+    // it is a model call on the same critical path as everything the record does cover.
+    const startedAt = Date.now()
+    const timing = (failed: boolean): InputTranslationTiming => ({
+      startedAt,
+      durationMs: Date.now() - startedAt,
+      failed,
+    })
 
     try {
       log('Translating user input', {
@@ -88,10 +104,14 @@
         originalLength: content.length,
         translatedLength: result.translatedContent.length,
       })
-      return { promptContent: result.translatedContent, originalInput: content }
+      return {
+        promptContent: result.translatedContent,
+        originalInput: content,
+        timing: timing(false),
+      }
     } catch (error) {
       log('Input translation failed (non-fatal), using original', error)
-      return { promptContent: content, originalInput: undefined }
+      return { promptContent: content, originalInput: undefined, timing: timing(true) }
     }
   }
 
@@ -454,6 +474,7 @@
       countStyleReview?: boolean
       styleReviewSource?: string
       cachedRetrievalResult?: RetrievalResult | null
+      inputTranslation?: InputTranslationTiming
     },
   ) {
     const countStyleReview = options?.countStyleReview ?? true
@@ -483,7 +504,16 @@
     }
 
     ui.setGenerating(true)
-    activity.startTurn(narrationEntryId)
+    const inputTranslation = options?.inputTranslation
+    activity.startTurn(narrationEntryId, inputTranslation?.startedAt)
+    if (inputTranslation) {
+      activity.recordStep('Translating input', {
+        isLLM: true,
+        startedAt: inputTranslation.startedAt,
+        durationMs: inputTranslation.durationMs,
+        status: inputTranslation.failed ? 'failed' : 'done',
+      })
+    }
     ui.clearGenerationError()
     ui.clearActionChoices(story.currentStory.id)
     ui.startStreaming(visualProseMode, streamingEntryId)
@@ -1006,10 +1036,11 @@
       story.currentStory.timeTracker,
     )
 
-    const { promptContent, originalInput } = await translateUserInput(
-      content,
-      settings.translationSettings,
-    )
+    const {
+      promptContent,
+      originalInput,
+      timing: inputTranslation,
+    } = await translateUserInput(content, settings.translationSettings)
 
     const userActionEntry = await story.addEntry('user_action', promptContent)
 
@@ -1025,7 +1056,7 @@
     // entry the narrator reads holds `promptContent`. Passing the raw text here left
     // retrieval and classification working from a different wording than the narration —
     // and the retry path already passes `promptContent`, so the two disagreed.
-    await generateResponse(userActionEntry.id, promptContent)
+    await generateResponse(userActionEntry.id, promptContent, { inputTranslation })
   }
 
   async function handleStopGeneration() {
@@ -1201,10 +1232,11 @@
 
     await tick()
 
-    const { promptContent, originalInput } = await translateUserInput(
-      backup.userActionContent,
-      settings.translationSettings,
-    )
+    const {
+      promptContent,
+      originalInput,
+      timing: inputTranslation,
+    } = await translateUserInput(backup.userActionContent, settings.translationSettings)
     const userActionEntry = await story.addEntry('user_action', promptContent)
 
     if (originalInput) {
@@ -1225,6 +1257,7 @@
         countStyleReview: false,
         styleReviewSource: 'retry-last-message',
         cachedRetrievalResult: cacheKey ? ui.retrievalResultFor(cacheKey) : null,
+        inputTranslation,
       })
     } finally {
       ui.setRetryingLastMessage(false)

--- a/src/lib/components/story/ActivityStatus.svelte
+++ b/src/lib/components/story/ActivityStatus.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+  import { activity } from '$lib/stores/activity.svelte'
+  import { settings } from '$lib/stores/settings.svelte'
+  import {
+    formatDuration,
+    stepDuration,
+    turnDuration,
+    type ActivityTurn,
+  } from '$lib/services/activity'
+  import { ChevronRight, Sparkles } from '@lucide/svelte'
+  import ActivityTimeline from './ActivityTimeline.svelte'
+
+  let { turn }: { turn: ActivityTurn | null } = $props()
+
+  let expanded = $state(settings.uiSettings.activityReporting === 'tree')
+
+  /**
+   * Drives the elapsed times. A step that never ends would otherwise report the duration it
+   * had when the last event landed, which is exactly the case a stalled turn presents.
+   */
+  let now = $state(Date.now())
+  $effect(() => {
+    if (!turn || turn.endedAt) return
+    const handle = setInterval(() => (now = Date.now()), 100)
+    return () => clearInterval(handle)
+  })
+
+  let running = $derived(turn ? activity.deepestRunning(turn) : null)
+</script>
+
+{#if turn}
+  <div class="animate-fade-in">
+    <button
+      type="button"
+      class="text-muted-foreground hover:text-foreground flex w-full items-baseline gap-1.5 text-left text-xs transition-colors"
+      aria-expanded={expanded}
+      onclick={() => (expanded = !expanded)}
+    >
+      <ChevronRight
+        class="h-3 w-3 shrink-0 translate-y-0.5 transition-transform {expanded ? 'rotate-90' : ''}"
+      />
+
+      {#if running}
+        {#if running.isLLM}
+          <Sparkles class="text-primary/70 h-3 w-3 shrink-0 translate-y-0.5" />
+        {/if}
+        <span class="text-foreground min-w-0 truncate">{running.label}</span>
+        {#if running.detail}
+          <span class="text-muted-foreground/60 min-w-0 truncate">· {running.detail}</span>
+        {/if}
+        <span class="text-primary shrink-0 tabular-nums"
+          >{formatDuration(stepDuration(running, now))}</span
+        >
+      {:else}
+        <span class="min-w-0 truncate">{turn.endedAt ? 'Finished' : 'Working'}</span>
+      {/if}
+
+      <span class="flex-1"></span>
+      <span class="shrink-0 tabular-nums">{formatDuration(turnDuration(turn, now))}</span>
+    </button>
+
+    {#if expanded}
+      <ActivityTimeline {turn} {now} />
+    {/if}
+  </div>
+{/if}

--- a/src/lib/components/story/ActivityStatus.svelte
+++ b/src/lib/components/story/ActivityStatus.svelte
@@ -26,7 +26,20 @@
     return () => clearInterval(handle)
   })
 
-  let running = $derived(turn ? activity.deepestRunning(turn) : null)
+  /**
+   * Values, not the step: like the timeline's rows, a live step is mutated in place, so the
+   * label and detail have to be recomputed rather than read off a held reference.
+   */
+  let current = $derived.by(() => {
+    const step = turn ? activity.deepestRunning(turn) : null
+    if (!step) return null
+    return {
+      label: step.label,
+      detail: step.detail ?? '',
+      isLLM: step.isLLM,
+      time: formatDuration(stepDuration(step, now)),
+    }
+  })
 </script>
 
 {#if turn}
@@ -41,17 +54,15 @@
         class="h-3 w-3 shrink-0 translate-y-0.5 transition-transform {expanded ? 'rotate-90' : ''}"
       />
 
-      {#if running}
-        {#if running.isLLM}
+      {#if current}
+        {#if current.isLLM}
           <Sparkles class="text-primary/70 h-3 w-3 shrink-0 translate-y-0.5" />
         {/if}
-        <span class="text-foreground min-w-0 truncate">{running.label}</span>
-        {#if running.detail}
-          <span class="text-muted-foreground/60 min-w-0 truncate">· {running.detail}</span>
+        <span class="text-foreground min-w-0 truncate">{current.label}</span>
+        {#if current.detail}
+          <span class="text-muted-foreground/60 min-w-0 truncate">· {current.detail}</span>
         {/if}
-        <span class="text-primary shrink-0 tabular-nums"
-          >{formatDuration(stepDuration(running, now))}</span
-        >
+        <span class="text-primary shrink-0 tabular-nums">{current.time}</span>
       {:else}
         <span class="min-w-0 truncate">{turn.endedAt ? 'Finished' : 'Working'}</span>
       {/if}

--- a/src/lib/components/story/ActivityStatus.svelte
+++ b/src/lib/components/story/ActivityStatus.svelte
@@ -21,7 +21,8 @@
   let now = $state(Date.now())
   $effect(() => {
     if (!turn || turn.endedAt) return
-    const handle = setInterval(() => (now = Date.now()), 100)
+    // Once a second, matching the resolution `formatDuration` shows.
+    const handle = setInterval(() => (now = Date.now()), 1000)
     return () => clearInterval(handle)
   })
 

--- a/src/lib/components/story/ActivityStatus.svelte
+++ b/src/lib/components/story/ActivityStatus.svelte
@@ -1,78 +1,65 @@
 <script lang="ts">
   import { activity } from '$lib/stores/activity.svelte'
-  import { settings } from '$lib/stores/settings.svelte'
-  import {
-    formatDuration,
-    stepDuration,
-    turnDuration,
-    type ActivityTurn,
-  } from '$lib/services/activity'
+  import { formatDuration, rootStep, stepDuration, type ActivityTurn } from '$lib/services/activity'
   import { ChevronRight, Sparkles } from '@lucide/svelte'
   import ActivityTimeline from './ActivityTimeline.svelte'
 
-  let { turn }: { turn: ActivityTurn | null } = $props()
+  let { turn }: { turn: ActivityTurn } = $props()
 
-  let expanded = $state(settings.uiSettings.activityReporting === 'tree')
-
-  /**
-   * Drives the elapsed times. A step that never ends would otherwise report the duration it
-   * had when the last event landed, which is exactly the case a stalled turn presents.
-   */
-  let now = $state(Date.now())
-  $effect(() => {
-    if (!turn || turn.endedAt) return
-    // Once a second, matching the resolution `formatDuration` shows.
-    const handle = setInterval(() => (now = Date.now()), 1000)
-    return () => clearInterval(handle)
-  })
+  let expanded = $derived(activity.isTreeExpanded(turn.entryId))
 
   /**
    * Values, not the step: like the timeline's rows, a live step is mutated in place, so the
    * label and detail have to be recomputed rather than read off a held reference.
+   *
+   * The root is named beside it because the innermost step is the useful one and the least
+   * self-explanatory: "Model call 1" does not say what the call is for.
    */
   let current = $derived.by(() => {
-    const step = turn ? activity.deepestRunning(turn) : null
+    const step = activity.deepestRunning(turn)
     if (!step) return null
+    const root = rootStep(turn.steps, step)
     return {
       label: step.label,
+      root: root.id === step.id ? '' : root.label,
       detail: step.detail ?? '',
       isLLM: step.isLLM,
-      time: formatDuration(stepDuration(step, now)),
+      time: formatDuration(stepDuration(step, activity.now)),
     }
   })
 </script>
 
-{#if turn}
-  <div class="animate-fade-in">
-    <button
-      type="button"
-      class="text-muted-foreground hover:text-foreground flex w-full items-baseline gap-1.5 text-left text-xs transition-colors"
-      aria-expanded={expanded}
-      onclick={() => (expanded = !expanded)}
-    >
-      <ChevronRight
-        class="h-3 w-3 shrink-0 translate-y-0.5 transition-transform {expanded ? 'rotate-90' : ''}"
-      />
+<div class="animate-fade-in">
+  <button
+    type="button"
+    class="text-muted-foreground hover:text-foreground flex w-full items-baseline gap-1.5 text-left text-xs transition-colors"
+    aria-expanded={expanded}
+    title={expanded ? 'Show only the current step' : 'Show the whole turn'}
+    onclick={() => activity.setTreeExpanded(turn.entryId, !expanded)}
+  >
+    <ChevronRight
+      class="h-3 w-3 shrink-0 translate-y-0.5 transition-transform {expanded ? 'rotate-90' : ''}"
+    />
 
-      {#if current}
-        {#if current.isLLM}
-          <Sparkles class="text-primary/70 h-3 w-3 shrink-0 translate-y-0.5" />
-        {/if}
-        <span class="text-foreground min-w-0 truncate">{current.label}</span>
-        {#if current.detail}
-          <span class="text-muted-foreground/60 min-w-0 truncate">· {current.detail}</span>
-        {/if}
-        <span class="text-primary shrink-0 tabular-nums">{current.time}</span>
-      {:else}
-        <span class="min-w-0 truncate">{turn.endedAt ? 'Finished' : 'Working'}</span>
+    {#if current}
+      {#if current.isLLM}
+        <Sparkles class="text-primary/70 h-3 w-3 shrink-0 translate-y-0.5" />
       {/if}
-
-      <span class="flex-1"></span>
-      <span class="shrink-0 tabular-nums">{formatDuration(turnDuration(turn, now))}</span>
-    </button>
-
-    {#if expanded}
-      <ActivityTimeline {turn} {now} />
+      {#if current.root}
+        <span class="shrink-0">{current.root}</span>
+        <span class="text-muted-foreground/50 shrink-0">·</span>
+      {/if}
+      <span class="text-foreground min-w-0 truncate">{current.label}</span>
+      {#if current.detail}
+        <span class="text-muted-foreground/60 min-w-0 truncate">· {current.detail}</span>
+      {/if}
+      <span class="text-primary shrink-0 tabular-nums">{current.time}</span>
+    {:else}
+      <span class="min-w-0 truncate">{turn.endedAt ? 'Finished' : 'Working'}</span>
     {/if}
-  </div>
-{/if}
+  </button>
+
+  {#if expanded}
+    <ActivityTimeline {turn} now={activity.now} />
+  {/if}
+</div>

--- a/src/lib/components/story/ActivityTimeline.svelte
+++ b/src/lib/components/story/ActivityTimeline.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+  import { activity } from '$lib/stores/activity.svelte'
+  import {
+    formatDuration,
+    stepDuration,
+    type ActivityNode,
+    type ActivityTurn,
+  } from '$lib/services/activity'
+  import { Sparkles } from '@lucide/svelte'
+
+  let { turn, now, depth = 0 }: { turn: ActivityTurn; now: number; depth?: number } = $props()
+
+  let nodes = $derived(activity.tree(turn))
+</script>
+
+{#snippet row(node: ActivityNode, level: number)}
+  {@const step = node.step}
+  <div
+    class="flex items-baseline gap-1.5 py-0.5 text-[11px] leading-tight"
+    style="padding-left: {level * 0.75}rem"
+  >
+    <span
+      class="shrink-0 tabular-nums"
+      class:text-muted-foreground={step.status !== 'running'}
+      class:text-primary={step.status === 'running'}
+    >
+      {formatDuration(stepDuration(step, now))}
+    </span>
+
+    {#if step.isLLM}
+      <Sparkles class="text-primary/70 h-2.5 w-2.5 shrink-0 translate-y-px" />
+    {/if}
+
+    <span
+      class="min-w-0 truncate"
+      class:text-foreground={step.status === 'running'}
+      class:text-muted-foreground={step.status !== 'running'}
+      class:line-through={step.status === 'skipped'}
+      class:text-destructive={step.status === 'failed'}
+    >
+      {step.label}
+    </span>
+
+    {#if step.detail}
+      <span class="text-muted-foreground/60 min-w-0 truncate">· {step.detail}</span>
+    {/if}
+
+    {#if step.status === 'running'}
+      <span class="text-primary/60 shrink-0">…</span>
+    {/if}
+  </div>
+
+  {#each node.children as child (child.step.id)}
+    {@render row(child, level + 1)}
+  {/each}
+{/snippet}
+
+<!-- Capped: a deep retrieval run is tens of rows, and the report must not push the
+     narration off the screen to show them. -->
+<div
+  class="border-border/50 bg-muted/30 mt-1 max-h-64 overflow-y-auto rounded-md border px-2 py-1.5"
+>
+  {#each nodes as node (node.step.id)}
+    {@render row(node, depth)}
+  {:else}
+    <p class="text-muted-foreground py-0.5 text-[11px]">Nothing recorded yet.</p>
+  {/each}
+</div>

--- a/src/lib/components/story/ActivityTimeline.svelte
+++ b/src/lib/components/story/ActivityTimeline.svelte
@@ -1,11 +1,6 @@
 <script lang="ts">
   import { activity } from '$lib/stores/activity.svelte'
-  import {
-    formatDuration,
-    stepDuration,
-    type ActivityNode,
-    type ActivityTurn,
-  } from '$lib/services/activity'
+  import { formatStepDuration, type ActivityNode, type ActivityTurn } from '$lib/services/activity'
   import { Sparkles } from '@lucide/svelte'
 
   let { turn, now, depth = 0 }: { turn: ActivityTurn; now: number; depth?: number } = $props()
@@ -19,12 +14,13 @@
     class="flex items-baseline gap-1.5 py-0.5 text-[11px] leading-tight"
     style="padding-left: {level * 0.75}rem"
   >
+    <!-- Fixed width: the column stays a column when a step has no measured duration. -->
     <span
-      class="shrink-0 tabular-nums"
+      class="w-11 shrink-0 text-right tabular-nums"
       class:text-muted-foreground={step.status !== 'running'}
       class:text-primary={step.status === 'running'}
     >
-      {formatDuration(stepDuration(step, now))}
+      {formatStepDuration(step, now) ?? ''}
     </span>
 
     {#if step.isLLM}

--- a/src/lib/components/story/ActivityTimeline.svelte
+++ b/src/lib/components/story/ActivityTimeline.svelte
@@ -1,63 +1,72 @@
 <script lang="ts">
   import { activity } from '$lib/stores/activity.svelte'
-  import { formatStepDuration, type ActivityNode, type ActivityTurn } from '$lib/services/activity'
+  import { flattenTree, formatStepDuration, type ActivityTurn } from '$lib/services/activity'
   import { Sparkles } from '@lucide/svelte'
 
-  let { turn, now, depth = 0 }: { turn: ActivityTurn; now: number; depth?: number } = $props()
+  let { turn, now }: { turn: ActivityTurn; now: number } = $props()
 
-  let nodes = $derived(activity.tree(turn))
+  /**
+   * Rows carry values, not steps. A step is a plain object mutated in place -- its `detail`
+   * moves while it runs -- so a row holding the reference renders whatever it read first,
+   * however often the tree is rebuilt around it. Recomputing primitives is what puts a
+   * revised detail on screen.
+   */
+  let rows = $derived(
+    flattenTree(activity.tree(turn)).map(({ step, level }) => ({
+      id: step.id,
+      level,
+      label: step.label,
+      detail: step.detail ?? '',
+      isLLM: step.isLLM,
+      running: step.status === 'running',
+      skipped: step.status === 'skipped',
+      failed: step.status === 'failed',
+      time: formatStepDuration(step, now) ?? '',
+    })),
+  )
 </script>
-
-{#snippet row(node: ActivityNode, level: number)}
-  {@const step = node.step}
-  <div
-    class="flex items-baseline gap-1.5 py-0.5 text-[11px] leading-tight"
-    style="padding-left: {level * 0.75}rem"
-  >
-    <!-- Fixed width: the column stays a column when a step has no measured duration. -->
-    <span
-      class="w-11 shrink-0 text-right tabular-nums"
-      class:text-muted-foreground={step.status !== 'running'}
-      class:text-primary={step.status === 'running'}
-    >
-      {formatStepDuration(step, now) ?? ''}
-    </span>
-
-    {#if step.isLLM}
-      <Sparkles class="text-primary/70 h-2.5 w-2.5 shrink-0 translate-y-px" />
-    {/if}
-
-    <span
-      class="min-w-0 truncate"
-      class:text-foreground={step.status === 'running'}
-      class:text-muted-foreground={step.status !== 'running'}
-      class:line-through={step.status === 'skipped'}
-      class:text-destructive={step.status === 'failed'}
-    >
-      {step.label}
-    </span>
-
-    {#if step.detail}
-      <span class="text-muted-foreground/60 min-w-0 truncate">· {step.detail}</span>
-    {/if}
-
-    {#if step.status === 'running'}
-      <span class="text-primary/60 shrink-0">…</span>
-    {/if}
-  </div>
-
-  {#each node.children as child (child.step.id)}
-    {@render row(child, level + 1)}
-  {/each}
-{/snippet}
 
 <!-- Capped: a deep retrieval run is tens of rows, and the report must not push the
      narration off the screen to show them. -->
 <div
   class="border-border/50 bg-muted/30 mt-1 max-h-64 overflow-y-auto rounded-md border px-2 py-1.5"
 >
-  {#each nodes as node (node.step.id)}
-    {@render row(node, depth)}
+  {#each rows as row (row.id)}
+    <div
+      class="flex items-baseline gap-1.5 py-0.5 text-[11px] leading-tight"
+      style="padding-left: {row.level * 0.75}rem"
+    >
+      <!-- Fixed width: the column stays a column when a step has no measured duration. -->
+      <span
+        class="w-11 shrink-0 text-right tabular-nums"
+        class:text-muted-foreground={!row.running}
+        class:text-primary={row.running}
+      >
+        {row.time}
+      </span>
+
+      {#if row.isLLM}
+        <Sparkles class="text-primary/70 h-2.5 w-2.5 shrink-0 translate-y-px" />
+      {/if}
+
+      <span
+        class="min-w-0 truncate"
+        class:text-foreground={row.running}
+        class:text-muted-foreground={!row.running}
+        class:line-through={row.skipped}
+        class:text-destructive={row.failed}
+      >
+        {row.label}
+      </span>
+
+      {#if row.detail}
+        <span class="text-muted-foreground/60 min-w-0 truncate">· {row.detail}</span>
+      {/if}
+
+      {#if row.running}
+        <span class="text-primary/60 shrink-0">…</span>
+      {/if}
+    </div>
   {:else}
     <p class="text-muted-foreground py-0.5 text-[11px]">Nothing recorded yet.</p>
   {/each}

--- a/src/lib/components/story/StoryEntry.svelte
+++ b/src/lib/components/story/StoryEntry.svelte
@@ -19,6 +19,7 @@
     Volume2,
     Image as ImageIcon,
     Copy,
+    Clock,
     MoreVertical,
   } from '@lucide/svelte'
   import { aiService } from '$lib/services/ai'
@@ -52,6 +53,9 @@
   import { database } from '$lib/services/database'
   import { onMount } from 'svelte'
   import ReasoningBlock from './ReasoningBlock.svelte'
+  import ActivityStatus from './ActivityStatus.svelte'
+  import { activity } from '$lib/stores/activity.svelte'
+  import { formatDuration, turnDuration } from '$lib/services/activity'
   import { countTokens } from '$lib/services/tokenizer'
   import { errMessage } from '$lib/utils/error'
   import { Button } from '$lib/components/ui/button'
@@ -115,6 +119,15 @@
 
   // Generation info shown in the "info" popover (model/profile/effort/timestamp)
   const showInfo = $derived(entry.type === 'narration')
+
+  // Only while this turn's record is still retained; an evicted one offers nothing rather
+  // than an empty panel. See RETAINED_TURNS.
+  const activityRecord = $derived(
+    settings.uiSettings.activityReporting !== 'off' && entry.type === 'narration'
+      ? activity.recordFor(entry.id)
+      : null,
+  )
+  let showActivityRecord = $state(false)
 
   function formatStoryTime(time: TimeTracker | null | undefined): string {
     if (!time) return ''
@@ -1356,6 +1369,20 @@
       <span class="text-muted-foreground ml-0.5">tokens</span>
     </span>
 
+    <!-- How long the turn took, opening its timeline. Hidden on narrow screens for the same
+         reason as the token badge above; the overflow menu carries it there instead. -->
+    {#if activityRecord}
+      <button
+        type="button"
+        class="bg-muted text-muted-foreground hover:text-foreground hidden rounded px-1.5 py-0.5 text-[11px] tabular-nums transition-colors sm:inline"
+        aria-expanded={showActivityRecord}
+        title="What this turn spent its time on"
+        onclick={() => (showActivityRecord = !showActivityRecord)}
+      >
+        {formatDuration(turnDuration(activityRecord, activityRecord.endedAt ?? Date.now()))}
+      </button>
+    {/if}
+
     <!-- Spacer to push buttons to the right -->
     <div class="flex-1"></div>
 
@@ -1629,6 +1656,12 @@
                 {storyImagesLabel}
               </DropdownMenu.Item>
             {/if}
+            {#if activityRecord}
+              <DropdownMenu.Item onclick={() => (showActivityRecord = !showActivityRecord)}>
+                <Clock class="h-4 w-4" />
+                {showActivityRecord ? 'Hide' : 'Show'} generation activity
+              </DropdownMenu.Item>
+            {/if}
             <!-- Rendered inline rather than behind an item: selecting an item closes the
                  menu, which would unmount any popover anchored to it. -->
             {#if showInfo}
@@ -1774,6 +1807,16 @@
           showToggleOnly={false}
         />
       {/if}
+
+      <!-- The report is a bystander to the entry: a fault rendering it must not
+         take the narration with it. -->
+      <svelte:boundary>
+        {#if activityRecord && showActivityRecord}
+          <div class="mb-2">
+            <ActivityStatus turn={activityRecord} />
+          </div>
+        {/if}
+      </svelte:boundary>
 
       <div
         bind:this={storyTextContainer}

--- a/src/lib/components/story/StoryEntry.svelte
+++ b/src/lib/components/story/StoryEntry.svelte
@@ -1817,7 +1817,9 @@
 
       <!-- The report is a bystander to the entry: a fault rendering it must not
          take the narration with it. -->
-      <svelte:boundary>
+      <svelte:boundary
+        onerror={(error) => console.warn('[activity] Report failed to render:', error)}
+      >
         {#if activityRecord && showActivityRecord}
           <div class="mb-2">
             <ActivityStatus turn={activityRecord} />

--- a/src/lib/components/story/StoryEntry.svelte
+++ b/src/lib/components/story/StoryEntry.svelte
@@ -127,7 +127,12 @@
       ? activity.recordFor(entry.id)
       : null,
   )
-  let showActivityRecord = $state(false)
+  // Held in the store, keyed by entry: a report opened while the streaming entry was on screen
+  // has to survive this entry replacing it, or it closes mid-turn. Shown by default until the
+  // turn's last task finishes, hidden by default once it has.
+  const showActivityRecord = $derived(
+    !!activityRecord && activity.isReportVisible(entry.id, !activityRecord.endedAt),
+  )
 
   function formatStoryTime(time: TimeTracker | null | undefined): string {
     if (!time) return ''
@@ -1375,11 +1380,11 @@
       <button
         type="button"
         class="bg-muted text-muted-foreground hover:text-foreground hidden rounded px-1.5 py-0.5 text-[11px] tabular-nums transition-colors sm:inline"
-        aria-expanded={showActivityRecord}
-        title="What this turn spent its time on"
-        onclick={() => (showActivityRecord = !showActivityRecord)}
+        aria-pressed={showActivityRecord}
+        title={showActivityRecord ? 'Hide generation activity' : 'Show generation activity'}
+        onclick={() => activity.setReportVisible(entry.id, !showActivityRecord)}
       >
-        {formatDuration(turnDuration(activityRecord, activityRecord.endedAt ?? Date.now()))}
+        {formatDuration(turnDuration(activityRecord, activity.now))}
       </button>
     {/if}
 
@@ -1657,7 +1662,9 @@
               </DropdownMenu.Item>
             {/if}
             {#if activityRecord}
-              <DropdownMenu.Item onclick={() => (showActivityRecord = !showActivityRecord)}>
+              <DropdownMenu.Item
+                onclick={() => activity.setReportVisible(entry.id, !showActivityRecord)}
+              >
                 <Clock class="h-4 w-4" />
                 {showActivityRecord ? 'Hide' : 'Show'} generation activity
               </DropdownMenu.Item>

--- a/src/lib/components/story/StreamingEntry.svelte
+++ b/src/lib/components/story/StreamingEntry.svelte
@@ -6,6 +6,8 @@
   import ReasoningBlock from './ReasoningBlock.svelte'
   import { settings } from '$lib/stores/settings.svelte'
   import { replacePicTagsWithPlaceholders } from '$lib/utils/inlineImageParser'
+  import { activity } from '$lib/stores/activity.svelte'
+  import ActivityStatus from './ActivityStatus.svelte'
 
   // Reactive binding to streaming content
   let content = $derived(ui.streamingContent)
@@ -43,6 +45,12 @@
   // Phase 2: content is actively streaming (has content)
   let isReasoningPhase = $derived(ui.isStreaming && reasoning.length > 0 && content.length === 0)
   let isContentPhase = $derived(ui.isStreaming && content.length > 0)
+
+  // Reported in place of the ellipsis while waiting, and kept reachable once the narration
+  // starts arriving -- below the text, so it never displaces what is being written.
+  let reportingEnabled = $derived(settings.uiSettings.activityReporting !== 'off')
+  let activeTurn = $derived(activity.activeTurn)
+  let showActivity = $derived(reportingEnabled && activeTurn !== null)
 </script>
 
 <!-- Streaming content container -->
@@ -103,6 +111,17 @@
     </div>
   </div>
 
+  <!-- Activity report. Above the content on purpose: it keeps one place on screen while the
+       narration grows underneath it, rather than being pushed off the bottom.
+       A bystander to the entry -- a fault rendering it must not take the narration with it. -->
+  <svelte:boundary>
+    {#if showActivity}
+      <div class="mb-2">
+        <ActivityStatus turn={activeTurn} />
+      </div>
+    {/if}
+  </svelte:boundary>
+
   <!-- Main Content -->
   <div class="min-w-0">
     <!-- Reasoning content panel -->
@@ -125,11 +144,13 @@
       </div>
     {:else if isReasoningPhase || isThinking}
       <!-- Pending Content Indicator (while reasoning or thinking) -->
-      <div class="story-text prose-content animate-fade-in text-muted-foreground mt-1">
-        <span class="typing-indicator">
-          <span>.</span><span>.</span><span>.</span>
-        </span>
-      </div>
+      {#if !showActivity}
+        <div class="story-text prose-content animate-fade-in text-muted-foreground mt-1">
+          <span class="typing-indicator">
+            <span>.</span><span>.</span><span>.</span>
+          </span>
+        </div>
+      {/if}
     {/if}
   </div>
 </div>

--- a/src/lib/components/story/StreamingEntry.svelte
+++ b/src/lib/components/story/StreamingEntry.svelte
@@ -7,6 +7,7 @@
   import { settings } from '$lib/stores/settings.svelte'
   import { replacePicTagsWithPlaceholders } from '$lib/utils/inlineImageParser'
   import { activity } from '$lib/stores/activity.svelte'
+  import { formatDuration, turnDuration } from '$lib/services/activity'
   import ActivityStatus from './ActivityStatus.svelte'
 
   // Reactive binding to streaming content
@@ -50,7 +51,10 @@
   // starts arriving -- below the text, so it never displaces what is being written.
   let reportingEnabled = $derived(settings.uiSettings.activityReporting !== 'off')
   let activeTurn = $derived(activity.activeTurn)
-  let showActivity = $derived(reportingEnabled && activeTurn !== null)
+  // Shown by default while the turn runs; the header badge hides it.
+  let showActivity = $derived(
+    reportingEnabled && activeTurn !== null && activity.isReportVisible(activeTurn.entryId, true),
+  )
 </script>
 
 <!-- Streaming content container -->
@@ -96,6 +100,18 @@
       <span class="text-muted-foreground ml-0.5">tokens</span>
     </span>
 
+    {#if activeTurn}
+      <button
+        type="button"
+        class="bg-muted text-muted-foreground hover:text-foreground rounded px-1.5 py-0.5 text-[11px] tabular-nums transition-colors"
+        aria-pressed={showActivity}
+        title={showActivity ? 'Hide generation activity' : 'Show generation activity'}
+        onclick={() => activity.setReportVisible(activeTurn!.entryId, !showActivity)}
+      >
+        {formatDuration(turnDuration(activeTurn, activity.now))}
+      </button>
+    {/if}
+
     <!-- Spacer to push buttons to the right -->
     <div class="flex-1"></div>
 
@@ -115,7 +131,7 @@
        narration grows underneath it, rather than being pushed off the bottom.
        A bystander to the entry -- a fault rendering it must not take the narration with it. -->
   <svelte:boundary>
-    {#if showActivity}
+    {#if showActivity && activeTurn}
       <div class="mb-2">
         <ActivityStatus turn={activeTurn} />
       </div>

--- a/src/lib/components/story/StreamingEntry.svelte
+++ b/src/lib/components/story/StreamingEntry.svelte
@@ -130,7 +130,9 @@
   <!-- Activity report. Above the content on purpose: it keeps one place on screen while the
        narration grows underneath it, rather than being pushed off the bottom.
        A bystander to the entry -- a fault rendering it must not take the narration with it. -->
-  <svelte:boundary>
+  <!-- `onerror` is what makes this catch: a boundary with neither it nor a `failed`
+       snippet rethrows. No fallback, so a report that cannot render leaves nothing behind. -->
+  <svelte:boundary onerror={(error) => console.warn('[activity] Report failed to render:', error)}>
     {#if showActivity && activeTurn}
       <div class="mb-2">
         <ActivityStatus turn={activeTurn} />

--- a/src/lib/services/activity/duration.test.ts
+++ b/src/lib/services/activity/duration.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { formatDuration, stepDuration, turnDuration } from './duration'
+import type { ActivityStep, ActivityTurn } from './types'
+
+const base: ActivityStep = {
+  id: 's',
+  parentId: null,
+  label: 's',
+  isLLM: false,
+  status: 'done',
+  startedAt: 1_000,
+}
+
+describe('stepDuration', () => {
+  it('measures a finished step between its own times', () => {
+    expect(stepDuration({ ...base, endedAt: 3_500 }, 9_999)).toBe(2_500)
+  })
+
+  it('measures a running step against now', () => {
+    expect(stepDuration({ ...base, status: 'running' }, 4_000)).toBe(3_000)
+  })
+
+  it('never reports a negative duration', () => {
+    expect(stepDuration({ ...base, status: 'running' }, 0)).toBe(0)
+  })
+})
+
+describe('turnDuration', () => {
+  const turn: ActivityTurn = { id: 't', entryId: 'e', startedAt: 500, steps: [] }
+
+  it('measures a running turn against now', () => {
+    expect(turnDuration(turn, 2_500)).toBe(2_000)
+  })
+
+  it('measures a finished turn between its own times', () => {
+    expect(turnDuration({ ...turn, endedAt: 1_500 }, 9_999)).toBe(1_000)
+  })
+})
+
+describe('formatDuration', () => {
+  it('reports sub-second times in milliseconds', () => {
+    expect(formatDuration(0)).toBe('0ms')
+    expect(formatDuration(42)).toBe('42ms')
+    expect(formatDuration(999)).toBe('999ms')
+  })
+
+  it('reports seconds with one decimal', () => {
+    expect(formatDuration(1_000)).toBe('1.0s')
+    expect(formatDuration(6_240)).toBe('6.2s')
+    expect(formatDuration(59_900)).toBe('59.9s')
+  })
+
+  it('reports minutes and seconds beyond a minute', () => {
+    expect(formatDuration(60_000)).toBe('1m 0s')
+    expect(formatDuration(95_000)).toBe('1m 35s')
+    expect(formatDuration(600_000)).toBe('10m 0s')
+  })
+
+  it('carries a rounded 60 seconds into the next minute', () => {
+    expect(formatDuration(119_800)).toBe('2m 0s')
+  })
+})

--- a/src/lib/services/activity/duration.test.ts
+++ b/src/lib/services/activity/duration.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { formatDuration, stepDuration, turnDuration } from './duration'
+import { formatDuration, formatStepDuration, stepDuration, turnDuration } from './duration'
 import type { ActivityStep, ActivityTurn } from './types'
 
 const base: ActivityStep = {
@@ -44,10 +44,15 @@ describe('formatDuration', () => {
     expect(formatDuration(999)).toBe('999ms')
   })
 
-  it('reports seconds with one decimal', () => {
-    expect(formatDuration(1_000)).toBe('1.0s')
-    expect(formatDuration(6_240)).toBe('6.2s')
-    expect(formatDuration(59_900)).toBe('59.9s')
+  it('reports whole seconds, so a dozen rows do not tick a decimal each', () => {
+    expect(formatDuration(1_000)).toBe('1s')
+    expect(formatDuration(6_240)).toBe('6s')
+    expect(formatDuration(59_900)).toBe('59s')
+  })
+
+  it('truncates rather than rounding, so it never reports time that has not passed', () => {
+    expect(formatDuration(1_999)).toBe('1s')
+    expect(formatDuration(119_800)).toBe('1m 59s')
   })
 
   it('reports minutes and seconds beyond a minute', () => {
@@ -55,8 +60,19 @@ describe('formatDuration', () => {
     expect(formatDuration(95_000)).toBe('1m 35s')
     expect(formatDuration(600_000)).toBe('10m 0s')
   })
+})
 
-  it('carries a rounded 60 seconds into the next minute', () => {
-    expect(formatDuration(119_800)).toBe('2m 0s')
+describe('formatStepDuration', () => {
+  it('shows nothing for a finished step that was never timed', () => {
+    // Most retrieval tool calls carry no duration; a column of "0ms" is all this avoids.
+    expect(formatStepDuration({ ...base, endedAt: base.startedAt }, 9_999)).toBeNull()
+  })
+
+  it('shows a finished step that took measurable time', () => {
+    expect(formatStepDuration({ ...base, endedAt: base.startedAt + 6_240 }, 9_999)).toBe('6s')
+  })
+
+  it('shows a running step from its first tick, including at zero', () => {
+    expect(formatStepDuration({ ...base, status: 'running' }, base.startedAt)).toBe('0ms')
   })
 })

--- a/src/lib/services/activity/duration.ts
+++ b/src/lib/services/activity/duration.ts
@@ -1,0 +1,30 @@
+/**
+ * Activity Durations
+ *
+ * Durations are derived rather than stored, so a step that is still running reports a
+ * growing time and a stalled turn is distinguishable from a progressing one.
+ */
+
+import type { ActivityStep, ActivityTurn } from './types'
+
+/** Elapsed milliseconds, measured against `now` while the step is still running. */
+export function stepDuration(step: ActivityStep, now: number): number {
+  return Math.max(0, (step.endedAt ?? now) - step.startedAt)
+}
+
+/** Elapsed milliseconds for the whole turn, measured against `now` while it runs. */
+export function turnDuration(turn: ActivityTurn, now: number): number {
+  return Math.max(0, (turn.endedAt ?? now) - turn.startedAt)
+}
+
+/**
+ * Compact elapsed time. Milliseconds below a second so a free tool call does not read as
+ * "0.0s"; one decimal up to a minute, which is the resolution the live line changes at.
+ */
+export function formatDuration(ms: number): string {
+  if (ms < 1000) return `${Math.round(ms)}ms`
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`
+  const minutes = Math.floor(ms / 60_000)
+  const seconds = Math.round((ms % 60_000) / 1000)
+  return seconds === 60 ? `${minutes + 1}m 0s` : `${minutes}m ${seconds}s`
+}

--- a/src/lib/services/activity/duration.ts
+++ b/src/lib/services/activity/duration.ts
@@ -18,13 +18,28 @@ export function turnDuration(turn: ActivityTurn, now: number): number {
 }
 
 /**
- * Compact elapsed time. Milliseconds below a second so a free tool call does not read as
- * "0.0s"; one decimal up to a minute, which is the resolution the live line changes at.
+ * Compact elapsed time.
+ *
+ * Whole seconds, not tenths: several of these tick at once while a turn runs, and a digit
+ * changing ten times a second across a dozen rows is what makes the panel hard to read.
+ * Truncated rather than rounded, so the number never reports time that has not passed.
+ * Milliseconds below a second, where the value is a finished tool call rather than a
+ * counter, and "0s" would throw away the difference between 5ms and 900ms.
  */
 export function formatDuration(ms: number): string {
   if (ms < 1000) return `${Math.round(ms)}ms`
-  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`
-  const minutes = Math.floor(ms / 60_000)
-  const seconds = Math.round((ms % 60_000) / 1000)
-  return seconds === 60 ? `${minutes + 1}m 0s` : `${minutes}m ${seconds}s`
+  if (ms < 60_000) return `${Math.floor(ms / 1000)}s`
+  return `${Math.floor(ms / 60_000)}m ${Math.floor((ms % 60_000) / 1000)}s`
+}
+
+/**
+ * What to show in a step's time column, or null when there is nothing worth showing.
+ *
+ * A finished step measuring zero was never timed -- most retrieval tool calls carry no
+ * duration of their own -- and a column of "0ms" says only that, loudly, once per row.
+ */
+export function formatStepDuration(step: ActivityStep, now: number): string | null {
+  const ms = stepDuration(step, now)
+  if (step.status !== 'running' && ms === 0) return null
+  return formatDuration(ms)
 }

--- a/src/lib/services/activity/index.ts
+++ b/src/lib/services/activity/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Activity Module
+ *
+ * The record a generation turn keeps of its own progress, and the reading views over it.
+ * Pure and dependency-free: the reactive shell lives in `stores/activity.svelte.ts`.
+ */
+
+export type { ActivityStep, ActivityTurn, ActivityNode, ActivityStatus } from './types'
+
+export { buildTree, deepestRunningStep } from './tree'
+
+export { stepDuration, turnDuration, formatDuration } from './duration'
+
+export { retainTurns, findTurnByEntryId, RETAINED_TURNS } from './retention'
+
+export { ActivityRecorder, type ActivityReporting, type StartStepOptions } from './recorder'
+
+export { NO_ACTIVITY, type ActivityReporter } from './reporter'
+
+export { trackPhase } from './trackPhase'

--- a/src/lib/services/activity/index.ts
+++ b/src/lib/services/activity/index.ts
@@ -9,12 +9,12 @@ export type { ActivityStep, ActivityTurn, ActivityNode, ActivityStatus } from '.
 
 export { buildTree, deepestRunningStep } from './tree'
 
-export { stepDuration, turnDuration, formatDuration } from './duration'
+export { stepDuration, turnDuration, formatDuration, formatStepDuration } from './duration'
 
 export { retainTurns, findTurnByEntryId, RETAINED_TURNS } from './retention'
 
 export { ActivityRecorder, type ActivityReporting, type StartStepOptions } from './recorder'
 
-export { NO_ACTIVITY, type ActivityReporter } from './reporter'
+export { NO_ACTIVITY, trackStep, type ActivityReporter } from './reporter'
 
 export { trackPhase } from './trackPhase'

--- a/src/lib/services/activity/index.ts
+++ b/src/lib/services/activity/index.ts
@@ -5,9 +5,9 @@
  * Pure and dependency-free: the reactive shell lives in `stores/activity.svelte.ts`.
  */
 
-export type { ActivityStep, ActivityTurn, ActivityNode, ActivityStatus } from './types'
+export type { ActivityStep, ActivityTurn, ActivityNode, ActivityRow, ActivityStatus } from './types'
 
-export { buildTree, deepestRunningStep } from './tree'
+export { buildTree, flattenTree, deepestRunningStep } from './tree'
 
 export { stepDuration, turnDuration, formatDuration, formatStepDuration } from './duration'
 

--- a/src/lib/services/activity/index.ts
+++ b/src/lib/services/activity/index.ts
@@ -7,7 +7,7 @@
 
 export type { ActivityStep, ActivityTurn, ActivityNode, ActivityRow, ActivityStatus } from './types'
 
-export { buildTree, flattenTree, deepestRunningStep } from './tree'
+export { buildTree, flattenTree, deepestRunningStep, rootStep } from './tree'
 
 export { stepDuration, turnDuration, formatDuration, formatStepDuration } from './duration'
 

--- a/src/lib/services/activity/recorder.test.ts
+++ b/src/lib/services/activity/recorder.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ActivityRecorder } from './recorder'
+
+function recorderAt(times: number[] = []) {
+  let i = 0
+  const clock = () => times[Math.min(i++, times.length - 1)] ?? 0
+  const onChange = vi.fn()
+  const recorder = new ActivityRecorder(onChange, times.length ? clock : () => 0)
+  return { recorder, onChange }
+}
+
+describe('reporting off', () => {
+  it('appends nothing', () => {
+    const { recorder, onChange } = recorderAt()
+
+    recorder.startTurn('entry-1')
+    const id = recorder.startStep('retrieval')
+    recorder.endStep(id)
+    recorder.recordStep('grep')
+    recorder.endTurn()
+
+    expect(recorder.snapshot()).toEqual([])
+    expect(recorder.activeTurn).toBeNull()
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('returns an empty step id that closing tolerates', () => {
+    const { recorder } = recorderAt()
+
+    expect(recorder.startStep('retrieval')).toBe('')
+    expect(() => recorder.endStep('')).not.toThrow()
+  })
+
+  it('drops the turn in flight when reporting is turned off mid-turn', () => {
+    const { recorder } = recorderAt()
+    recorder.setReporting('line')
+    recorder.startTurn('entry-1')
+
+    recorder.setReporting('off')
+
+    expect(recorder.activeTurn).toBeNull()
+    expect(recorder.startStep('retrieval')).toBe('')
+  })
+
+  it('does not retain the abandoned turn, which nothing can close', () => {
+    const { recorder } = recorderAt()
+    recorder.setReporting('line')
+    recorder.startTurn('entry-1')
+    recorder.startStep('retrieval')
+
+    recorder.setReporting('off')
+    recorder.setReporting('line')
+
+    expect(recorder.snapshot()).toEqual([])
+  })
+
+  it('keeps turns that had already finished when reporting is turned off', () => {
+    const { recorder } = recorderAt()
+    recorder.setReporting('line')
+    recorder.startTurn('entry-1')
+    recorder.endTurn()
+    recorder.startTurn('entry-2')
+
+    recorder.setReporting('off')
+
+    expect(recorder.snapshot().map((t) => t.entryId)).toEqual(['entry-1'])
+  })
+})
+
+describe('recording', () => {
+  it('records steps under the turn in flight', () => {
+    const { recorder } = recorderAt()
+    recorder.setReporting('line')
+    recorder.startTurn('entry-1')
+
+    const retrieval = recorder.startStep('retrieval')
+    recorder.startStep('query ch.12', { parentId: retrieval, isLLM: true })
+
+    const [turn] = recorder.snapshot()
+    expect(turn.entryId).toBe('entry-1')
+    expect(turn.steps).toHaveLength(2)
+    expect(turn.steps[1].parentId).toBe(retrieval)
+    expect(turn.steps[1].isLLM).toBe(true)
+  })
+
+  it('records `line` and `tree` identically', () => {
+    const shape = (reporting: 'line' | 'tree') => {
+      const { recorder } = recorderAt()
+      recorder.setReporting(reporting)
+      recorder.startTurn('entry-1')
+      recorder.startStep('retrieval')
+      recorder.endTurn()
+      return recorder.snapshot()[0].steps.map((s) => s.label)
+    }
+
+    expect(shape('line')).toEqual(shape('tree'))
+  })
+
+  it('closes a step with a status and an optional detail', () => {
+    const { recorder } = recorderAt([0, 0, 250])
+    recorder.setReporting('line')
+    recorder.startTurn('entry-1')
+    const id = recorder.startStep('classification')
+
+    recorder.endStep(id, 'failed', 'timed out')
+
+    const step = recorder.snapshot()[0].steps[0]
+    expect(step.status).toBe('failed')
+    expect(step.detail).toBe('timed out')
+    expect(step.endedAt).toBe(250)
+  })
+
+  it('ignores a second close of the same step', () => {
+    const { recorder } = recorderAt()
+    recorder.setReporting('line')
+    recorder.startTurn('entry-1')
+    const id = recorder.startStep('retrieval')
+    recorder.endStep(id, 'done')
+
+    recorder.endStep(id, 'failed')
+
+    expect(recorder.snapshot()[0].steps[0].status).toBe('done')
+  })
+
+  it('places a pre-measured step by its duration rather than the clock', () => {
+    const { recorder } = recorderAt([0, 0, 5_000])
+    recorder.setReporting('line')
+    recorder.startTurn('entry-1')
+
+    recorder.recordStep('query ch.4', { isLLM: true, durationMs: 6_200 })
+
+    const step = recorder.snapshot()[0].steps[0]
+    expect(step.endedAt! - step.startedAt).toBe(6_200)
+    expect(step.status).toBe('done')
+  })
+
+  it('closes a step still open when the turn ends, at the end time of that turn', () => {
+    // startTurn, startStep, endTurn -- one clock read each.
+    const { recorder } = recorderAt([0, 0, 900])
+    recorder.setReporting('line')
+    recorder.startTurn('entry-1')
+    recorder.startStep('retrieval')
+
+    recorder.endTurn()
+
+    const turn = recorder.snapshot()[0]
+    expect(turn.endedAt).toBe(900)
+    // Not left running: its duration would otherwise be measured against viewing time.
+    expect(turn.steps[0]).toMatchObject({
+      status: 'skipped',
+      endedAt: 900,
+      detail: 'interrupted',
+    })
+  })
+
+  it('keeps the detail a step already carried when the turn ends around it', () => {
+    const { recorder } = recorderAt()
+    recorder.setReporting('line')
+    recorder.startTurn('entry-1')
+    recorder.startStep('Agent', { detail: '3/8 steps' })
+
+    recorder.endTurn()
+
+    expect(recorder.snapshot()[0].steps[0].detail).toBe('3/8 steps')
+  })
+
+  it('leaves already-closed steps alone when the turn ends', () => {
+    const { recorder } = recorderAt()
+    recorder.setReporting('line')
+    recorder.startTurn('entry-1')
+    const done = recorder.startStep('retrieval')
+    recorder.endStep(done, 'failed', 'boom')
+
+    recorder.endTurn()
+
+    expect(recorder.snapshot()[0].steps[0]).toMatchObject({ status: 'failed', detail: 'boom' })
+  })
+
+  it('discards the oldest turns beyond the retention bound', () => {
+    const recorder = new ActivityRecorder(
+      () => {},
+      () => 0,
+      2,
+    )
+    recorder.setReporting('line')
+
+    for (const entryId of ['a', 'b', 'c']) {
+      recorder.startTurn(entryId)
+      recorder.endTurn()
+    }
+
+    expect(recorder.snapshot().map((t) => t.entryId)).toEqual(['b', 'c'])
+  })
+
+  it('notifies on every change', () => {
+    const { recorder, onChange } = recorderAt()
+    recorder.setReporting('line')
+
+    recorder.startTurn('entry-1')
+    const id = recorder.startStep('retrieval')
+    recorder.endStep(id)
+    recorder.endTurn()
+
+    expect(onChange).toHaveBeenCalledTimes(4)
+  })
+})

--- a/src/lib/services/activity/recorder.test.ts
+++ b/src/lib/services/activity/recorder.test.ts
@@ -176,6 +176,61 @@ describe('recording', () => {
     expect(recorder.snapshot()[0].steps[0]).toMatchObject({ status: 'failed', detail: 'boom' })
   })
 
+  it('revises a running step detail, for a counter that moves while it is open', () => {
+    const { recorder } = recorderAt()
+    recorder.setReporting('line')
+    recorder.startTurn('entry-1')
+    const id = recorder.startStep('Agent', { detail: '0/10 steps' })
+
+    recorder.updateStep(id, '3/10 steps')
+
+    expect(recorder.snapshot()[0].steps[0].detail).toBe('3/10 steps')
+  })
+
+  it('does not revise a step that has already closed', () => {
+    const { recorder } = recorderAt()
+    recorder.setReporting('line')
+    recorder.startTurn('entry-1')
+    const id = recorder.startStep('Agent', { detail: '0/10 steps' })
+    recorder.endStep(id, 'done', '8/10 steps')
+
+    recorder.updateStep(id, '9/10 steps')
+
+    expect(recorder.snapshot()[0].steps[0].detail).toBe('8/10 steps')
+  })
+
+  it('does not notify when the detail is unchanged', () => {
+    const { recorder, onChange } = recorderAt()
+    recorder.setReporting('line')
+    recorder.startTurn('entry-1')
+    const id = recorder.startStep('Agent', { detail: '3/10 steps' })
+    onChange.mockClear()
+
+    recorder.updateStep(id, '3/10 steps')
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('backdates the turn to work that ran before it opened', () => {
+    // Input translation is a model call on the same critical path, but it runs before the
+    // generation path is entered.
+    const { recorder } = recorderAt([5_000])
+    recorder.setReporting('line')
+
+    recorder.startTurn('entry-1', 1_000)
+
+    expect(recorder.snapshot()[0].startedAt).toBe(1_000)
+  })
+
+  it('uses the clock when nothing preceded the turn', () => {
+    const { recorder } = recorderAt([5_000])
+    recorder.setReporting('line')
+
+    recorder.startTurn('entry-1')
+
+    expect(recorder.snapshot()[0].startedAt).toBe(5_000)
+  })
+
   it('discards the oldest turns beyond the retention bound', () => {
     const recorder = new ActivityRecorder(
       () => {},

--- a/src/lib/services/activity/recorder.ts
+++ b/src/lib/services/activity/recorder.ts
@@ -1,0 +1,148 @@
+/**
+ * Activity Recorder
+ *
+ * Holds the turns a session has recorded and the one in flight. Plain TypeScript so the
+ * gating and the append behaviour are testable; `stores/activity.svelte.ts` adds reactivity.
+ *
+ * Nesting is by explicit parent id rather than an implicit stack: Stage A's two branches and
+ * the post-narrative phases run concurrently, so there is no single "current" step to push
+ * onto.
+ */
+
+import { retainTurns, RETAINED_TURNS } from './retention'
+import type { ActivityStatus, ActivityStep, ActivityTurn } from './types'
+
+/** How much of a turn's activity the story view reports. See design.md. */
+export type ActivityReporting = 'off' | 'line' | 'tree'
+
+export interface StartStepOptions {
+  /** Step this one runs inside. Omitted for a step directly under the turn. */
+  parentId?: string | null
+  detail?: string
+  isLLM?: boolean
+  /** Overrides the clock, for a step whose duration was measured elsewhere. */
+  startedAt?: number
+}
+
+export class ActivityRecorder {
+  private turns: ActivityTurn[] = []
+  private current: ActivityTurn | null = null
+  private reporting: ActivityReporting = 'off'
+  private counter = 0
+
+  constructor(
+    private onChange: () => void = () => {},
+    private now: () => number = Date.now,
+    private bound: number = RETAINED_TURNS,
+  ) {}
+
+  /** Recording happens for any state but `off`; `line` and `tree` differ only in display. */
+  get enabled(): boolean {
+    return this.reporting !== 'off'
+  }
+
+  setReporting(reporting: ActivityReporting) {
+    this.reporting = reporting
+    if (!this.enabled && this.current) {
+      // Discarded, not kept: with reporting off nothing further can close this turn, and a
+      // record frozen mid-turn would come back on re-enabling with its steps still running
+      // and their durations still climbing.
+      this.turns = this.turns.filter((turn) => turn !== this.current)
+      this.current = null
+      this.onChange()
+    }
+  }
+
+  startTurn(entryId: string): void {
+    if (!this.enabled) return
+    this.current = {
+      id: `turn-${++this.counter}`,
+      entryId,
+      startedAt: this.now(),
+      steps: [],
+    }
+    this.turns = retainTurns([...this.turns, this.current], this.bound)
+    this.onChange()
+  }
+
+  endTurn(): void {
+    if (!this.current) return
+    const endedAt = this.now()
+    // A turn can end with steps still open -- an abort unwinds past the `endStep` that would
+    // have closed them. Left running, their durations would be measured against the time the
+    // record is *viewed*, so a finished turn would report a duration that keeps growing.
+    for (const step of this.current.steps) {
+      if (step.status !== 'running') continue
+      step.status = 'skipped'
+      step.endedAt = endedAt
+      step.detail ??= 'interrupted'
+    }
+    this.current.endedAt = endedAt
+    this.current = null
+    this.onChange()
+  }
+
+  /** Returns the step id to close later, or `''` when nothing was recorded. */
+  startStep(label: string, options: StartStepOptions = {}): string {
+    if (!this.enabled || !this.current) return ''
+    const step: ActivityStep = {
+      id: `step-${++this.counter}`,
+      parentId: options.parentId ?? null,
+      label,
+      detail: options.detail,
+      isLLM: options.isLLM ?? false,
+      status: 'running',
+      startedAt: options.startedAt ?? this.now(),
+    }
+    this.current.steps.push(step)
+    this.onChange()
+    return step.id
+  }
+
+  endStep(id: string, status: Exclude<ActivityStatus, 'running'> = 'done', detail?: string): void {
+    if (!id || !this.current) return
+    const step = this.current.steps.find((s) => s.id === id)
+    if (!step || step.status !== 'running') return
+    step.status = status
+    step.endedAt = this.now()
+    if (detail !== undefined) step.detail = detail
+    this.onChange()
+  }
+
+  /**
+   * A step that is already over — a tool call, or work timed by whoever performed it.
+   * `durationMs` places the end relative to the start rather than to now.
+   */
+  recordStep(
+    label: string,
+    options: StartStepOptions & {
+      status?: Exclude<ActivityStatus, 'running'>
+      durationMs?: number
+    } = {},
+  ): string {
+    const id = this.startStep(label, options)
+    if (!id || !this.current) return ''
+    const step = this.current.steps.find((s) => s.id === id)!
+    step.status = options.status ?? 'done'
+    step.endedAt = step.startedAt + (options.durationMs ?? 0)
+    this.onChange()
+    return id
+  }
+
+  /** The turn in flight, or null between turns. */
+  get activeTurn(): ActivityTurn | null {
+    return this.current
+  }
+
+  /** Retained turns, oldest first. */
+  snapshot(): ActivityTurn[] {
+    return this.turns.map((turn) => ({ ...turn, steps: [...turn.steps] }))
+  }
+
+  /** Discards every retained record. */
+  clear(): void {
+    this.turns = []
+    this.current = null
+    this.onChange()
+  }
+}

--- a/src/lib/services/activity/recorder.ts
+++ b/src/lib/services/activity/recorder.ts
@@ -148,12 +148,8 @@ export class ActivityRecorder {
   }
 
   /**
-   * The retained record for an entry, or null once evicted.
-   *
-   * Reads the live turn rather than a copy out of `snapshot()`: this is called from a
-   * `$derived` in every mounted narration entry and re-runs on every step appended, so a
-   * fresh copy per call would churn allocations through a whole turn -- and change identity
-   * each time, restarting the timers and tree rebuilds downstream of it.
+   * The retained record for an entry, or null once evicted. The live turn, not a copy out of
+   * `snapshot()`: callers key their reactivity off its identity.
    */
   find(entryId: string): ActivityTurn | null {
     return findTurnByEntryId(this.turns, entryId)

--- a/src/lib/services/activity/recorder.ts
+++ b/src/lib/services/activity/recorder.ts
@@ -9,7 +9,7 @@
  * onto.
  */
 
-import { retainTurns, RETAINED_TURNS } from './retention'
+import { findTurnByEntryId, retainTurns, RETAINED_TURNS } from './retention'
 import type { ActivityStatus, ActivityStep, ActivityTurn } from './types'
 
 /** How much of a turn's activity the story view reports. See design.md. */
@@ -145,6 +145,18 @@ export class ActivityRecorder {
   /** The turn in flight, or null between turns. */
   get activeTurn(): ActivityTurn | null {
     return this.current
+  }
+
+  /**
+   * The retained record for an entry, or null once evicted.
+   *
+   * Reads the live turn rather than a copy out of `snapshot()`: this is called from a
+   * `$derived` in every mounted narration entry and re-runs on every step appended, so a
+   * fresh copy per call would churn allocations through a whole turn -- and change identity
+   * each time, restarting the timers and tree rebuilds downstream of it.
+   */
+  find(entryId: string): ActivityTurn | null {
+    return findTurnByEntryId(this.turns, entryId)
   }
 
   /** Retained turns, oldest first. */

--- a/src/lib/services/activity/recorder.ts
+++ b/src/lib/services/activity/recorder.ts
@@ -12,7 +12,7 @@
 import { findTurnByEntryId, retainTurns, RETAINED_TURNS } from './retention'
 import type { ActivityStatus, ActivityStep, ActivityTurn } from './types'
 
-/** How much of a turn's activity the story view reports. See design.md. */
+/** How much of a turn's activity the story view reports. See docs/architecture/overview.md. */
 export type ActivityReporting = 'off' | 'line' | 'tree'
 
 export interface StartStepOptions {

--- a/src/lib/services/activity/recorder.ts
+++ b/src/lib/services/activity/recorder.ts
@@ -53,12 +53,16 @@ export class ActivityRecorder {
     }
   }
 
-  startTurn(entryId: string): void {
+  /**
+   * `startedAt` backdates the turn to work that ran before this call -- input translation
+   * happens before the generation path is entered, and is on the same critical path.
+   */
+  startTurn(entryId: string, startedAt?: number): void {
     if (!this.enabled) return
     this.current = {
       id: `turn-${++this.counter}`,
       entryId,
-      startedAt: this.now(),
+      startedAt: startedAt ?? this.now(),
       steps: [],
     }
     this.turns = retainTurns([...this.turns, this.current], this.bound)
@@ -97,6 +101,15 @@ export class ActivityRecorder {
     this.current.steps.push(step)
     this.onChange()
     return step.id
+  }
+
+  /** Revise a running step's detail, for a counter that moves while the step is open. */
+  updateStep(id: string, detail: string): void {
+    if (!id || !this.current) return
+    const step = this.current.steps.find((s) => s.id === id)
+    if (!step || step.status !== 'running' || step.detail === detail) return
+    step.detail = detail
+    this.onChange()
   }
 
   endStep(id: string, status: Exclude<ActivityStatus, 'running'> = 'done', detail?: string): void {

--- a/src/lib/services/activity/reporter.ts
+++ b/src/lib/services/activity/reporter.ts
@@ -1,0 +1,30 @@
+/**
+ * Activity Reporter
+ *
+ * The write side of the activity record, as the generation phases see it. Phases are handed
+ * one of these rather than importing the store, which is what keeps them testable without a
+ * provider -- see docs/architecture/overview.md.
+ */
+
+import type { ActivityStatus } from './types'
+import type { StartStepOptions } from './recorder'
+
+export interface ActivityReporter {
+  /** Returns the id to close later, or `''` when nothing was recorded. */
+  startStep(label: string, options?: StartStepOptions): string
+  endStep(id: string, status?: Exclude<ActivityStatus, 'running'>, detail?: string): void
+  recordStep(
+    label: string,
+    options?: StartStepOptions & {
+      status?: Exclude<ActivityStatus, 'running'>
+      durationMs?: number
+    },
+  ): string
+}
+
+/** Stands in wherever no reporter was injected, so reporting is never a required dependency. */
+export const NO_ACTIVITY: ActivityReporter = {
+  startStep: () => '',
+  endStep: () => {},
+  recordStep: () => '',
+}

--- a/src/lib/services/activity/reporter.ts
+++ b/src/lib/services/activity/reporter.ts
@@ -28,3 +28,29 @@ export const NO_ACTIVITY: ActivityReporter = {
   endStep: () => {},
   recordStep: () => '',
 }
+
+/**
+ * Run `work` as one step, closing it as failed if it throws.
+ *
+ * The throw is re-raised: whether a failure is fatal is the caller's decision, and reporting
+ * must not change it.
+ */
+export async function trackStep<T>(
+  activity: ActivityReporter,
+  label: string,
+  options: StartStepOptions,
+  work: () => Promise<T>,
+): Promise<T> {
+  const id = activity.startStep(label, options)
+  try {
+    const result = await work()
+    activity.endStep(id)
+    return result
+  } catch (error) {
+    activity.endStep(
+      id,
+      error instanceof Error && error.name === 'AbortError' ? 'skipped' : 'failed',
+    )
+    throw error
+  }
+}

--- a/src/lib/services/activity/retention.test.ts
+++ b/src/lib/services/activity/retention.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { findTurnByEntryId, retainTurns, RETAINED_TURNS } from './retention'
+import type { ActivityTurn } from './types'
+
+const turn = (id: string): ActivityTurn => ({
+  id,
+  entryId: `entry-${id}`,
+  startedAt: 0,
+  steps: [],
+})
+
+describe('retainTurns', () => {
+  it('keeps everything below the bound', () => {
+    const turns = [turn('1'), turn('2')]
+    expect(retainTurns(turns, 5)).toEqual(turns)
+  })
+
+  it('discards oldest first once the bound is exceeded', () => {
+    const turns = ['1', '2', '3', '4', '5', '6', '7'].map(turn)
+
+    expect(retainTurns(turns, 5).map((t) => t.id)).toEqual(['3', '4', '5', '6', '7'])
+  })
+
+  it('defaults to the retention bound', () => {
+    const turns = Array.from({ length: RETAINED_TURNS + 3 }, (_, i) => turn(String(i)))
+
+    expect(retainTurns(turns)).toHaveLength(RETAINED_TURNS)
+  })
+
+  it('keeps nothing for a bound of zero', () => {
+    expect(retainTurns([turn('1')], 0)).toEqual([])
+  })
+})
+
+describe('findTurnByEntryId', () => {
+  it('finds a retained turn', () => {
+    const turns = [turn('1'), turn('2')]
+
+    expect(findTurnByEntryId(turns, 'entry-2')?.id).toBe('2')
+  })
+
+  it('misses an evicted entry', () => {
+    const turns = retainTurns(['1', '2', '3', '4', '5', '6'].map(turn), 5)
+
+    expect(findTurnByEntryId(turns, 'entry-1')).toBeNull()
+  })
+})

--- a/src/lib/services/activity/retention.ts
+++ b/src/lib/services/activity/retention.ts
@@ -1,0 +1,25 @@
+/**
+ * Activity Retention
+ *
+ * Records are kept for the current session only, bounded by a count of turns. See
+ * design.md — Retention is five turns.
+ */
+
+import type { ActivityTurn } from './types'
+
+/** Turns whose records are kept. Beyond this the oldest are discarded. */
+export const RETAINED_TURNS = 5
+
+/** Drop the oldest turns until at most `bound` remain. Input order is oldest-first. */
+export function retainTurns(turns: ActivityTurn[], bound: number = RETAINED_TURNS): ActivityTurn[] {
+  if (bound <= 0) return []
+  return turns.length <= bound ? turns : turns.slice(turns.length - bound)
+}
+
+/** The retained record for an entry, or null once it has been evicted. */
+export function findTurnByEntryId(turns: ActivityTurn[], entryId: string): ActivityTurn | null {
+  for (let i = turns.length - 1; i >= 0; i--) {
+    if (turns[i].entryId === entryId) return turns[i]
+  }
+  return null
+}

--- a/src/lib/services/activity/retention.ts
+++ b/src/lib/services/activity/retention.ts
@@ -2,7 +2,7 @@
  * Activity Retention
  *
  * Records are kept for the current session only, bounded by a count of turns. See
- * design.md — Retention is five turns.
+ * docs/architecture/overview.md — Activity reporting.
  */
 
 import type { ActivityTurn } from './types'

--- a/src/lib/services/activity/trackPhase.test.ts
+++ b/src/lib/services/activity/trackPhase.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi } from 'vitest'
+import { trackPhase } from './trackPhase'
+import type { ActivityReporter } from './reporter'
+
+function reporter() {
+  const closed: { id: string; status: string }[] = []
+  const started: string[] = []
+  const activity: ActivityReporter = {
+    startStep: (label) => {
+      started.push(label)
+      return `s${started.length}`
+    },
+    endStep: (id, status = 'done') => {
+      if (closed.some((c) => c.id === id)) return
+      closed.push({ id, status })
+    },
+    recordStep: () => '',
+  }
+  return { activity, started, closed }
+}
+
+async function drain<E, R>(gen: AsyncGenerator<E, R>) {
+  const events: E[] = []
+  for (;;) {
+    const next = await gen.next()
+    if (next.done) return { events, result: next.value }
+    events.push(next.value)
+  }
+}
+
+const phaseOf = (events: { type: string }[], result: unknown = 'ok') =>
+  (async function* () {
+    for (const e of events) yield e
+    return result
+  })()
+
+describe('trackPhase', () => {
+  it('opens a step and closes it as done, passing events and result through', async () => {
+    const { activity, started, closed } = reporter()
+
+    const { events, result } = await drain(
+      trackPhase(activity, 'Classification', phaseOf([{ type: 'phase_start' }])),
+    )
+
+    expect(started).toEqual(['Classification'])
+    expect(closed).toEqual([{ id: 's1', status: 'done' }])
+    expect(events).toEqual([{ type: 'phase_start' }])
+    expect(result).toBe('ok')
+  })
+
+  it('records a tolerated failure as failed rather than dropping it', async () => {
+    const { activity, closed } = reporter()
+
+    // A phase that degrades yields an error event and still returns; the turn continues.
+    const { result } = await drain(
+      trackPhase(
+        activity,
+        'Classification',
+        phaseOf([{ type: 'phase_start' }, { type: 'error' }], null),
+      ),
+    )
+
+    expect(closed).toEqual([{ id: 's1', status: 'failed' }])
+    expect(result).toBeNull()
+  })
+
+  it('records an aborted phase as skipped', async () => {
+    const { activity, closed } = reporter()
+
+    await drain(trackPhase(activity, 'Images', phaseOf([{ type: 'aborted' }], null)))
+
+    expect(closed).toEqual([{ id: 's1', status: 'skipped' }])
+  })
+
+  it('closes the step as failed and re-raises when the phase throws', async () => {
+    const { activity, closed } = reporter()
+    const phase = (async function* () {
+      yield { type: 'phase_start' }
+      throw new Error('boom')
+    })()
+
+    await expect(drain(trackPhase(activity, 'Narrative', phase))).rejects.toThrow('boom')
+    expect(closed).toEqual([{ id: 's1', status: 'failed' }])
+  })
+
+  it('closes the inner phase when the wrapper is abandoned', async () => {
+    const { activity, closed } = reporter()
+    const cleanup = vi.fn()
+    const phase = (async function* () {
+      try {
+        yield { type: 'phase_start' }
+        yield { type: 'phase_complete' }
+      } finally {
+        cleanup()
+      }
+    })()
+
+    const wrapped = trackPhase(activity, 'Translation', phase)
+    await wrapped.next()
+    await wrapped.return(undefined as never)
+
+    expect(cleanup).toHaveBeenCalled()
+    expect(closed).toHaveLength(1)
+  })
+
+  it('reports an error even when a later event is ordinary', async () => {
+    const { activity, closed } = reporter()
+
+    await drain(
+      trackPhase(
+        activity,
+        'Images',
+        phaseOf([{ type: 'error' }, { type: 'phase_complete' }], null),
+      ),
+    )
+
+    expect(closed).toEqual([{ id: 's1', status: 'failed' }])
+  })
+})

--- a/src/lib/services/activity/trackPhase.test.ts
+++ b/src/lib/services/activity/trackPhase.test.ts
@@ -39,7 +39,11 @@ describe('trackPhase', () => {
     const { activity, started, closed } = reporter()
 
     const { events, result } = await drain(
-      trackPhase(activity, 'Classification', phaseOf([{ type: 'phase_start' }])),
+      trackPhase(
+        activity,
+        activity.startStep('Classification'),
+        phaseOf([{ type: 'phase_start' }]),
+      ),
     )
 
     expect(started).toEqual(['Classification'])
@@ -55,7 +59,7 @@ describe('trackPhase', () => {
     const { result } = await drain(
       trackPhase(
         activity,
-        'Classification',
+        activity.startStep('Classification'),
         phaseOf([{ type: 'phase_start' }, { type: 'error' }], null),
       ),
     )
@@ -67,7 +71,9 @@ describe('trackPhase', () => {
   it('records an aborted phase as skipped', async () => {
     const { activity, closed } = reporter()
 
-    await drain(trackPhase(activity, 'Images', phaseOf([{ type: 'aborted' }], null)))
+    await drain(
+      trackPhase(activity, activity.startStep('Images'), phaseOf([{ type: 'aborted' }], null)),
+    )
 
     expect(closed).toEqual([{ id: 's1', status: 'skipped' }])
   })
@@ -79,7 +85,9 @@ describe('trackPhase', () => {
       throw new Error('boom')
     })()
 
-    await expect(drain(trackPhase(activity, 'Narrative', phase))).rejects.toThrow('boom')
+    await expect(
+      drain(trackPhase(activity, activity.startStep('Narrative'), phase)),
+    ).rejects.toThrow('boom')
     expect(closed).toEqual([{ id: 's1', status: 'failed' }])
   })
 
@@ -95,7 +103,7 @@ describe('trackPhase', () => {
       }
     })()
 
-    const wrapped = trackPhase(activity, 'Translation', phase)
+    const wrapped = trackPhase(activity, activity.startStep('Translation'), phase)
     await wrapped.next()
     await wrapped.return(undefined as never)
 
@@ -109,7 +117,7 @@ describe('trackPhase', () => {
     await drain(
       trackPhase(
         activity,
-        'Images',
+        activity.startStep('Images'),
         phaseOf([{ type: 'error' }, { type: 'phase_complete' }], null),
       ),
     )

--- a/src/lib/services/activity/trackPhase.ts
+++ b/src/lib/services/activity/trackPhase.ts
@@ -1,0 +1,45 @@
+/**
+ * Track Phase
+ *
+ * Records a phase as one step, reading the outcome off the events it already yields.
+ *
+ * Wrapping rather than instrumenting each phase: `ImagePhase` alone has five completion
+ * paths, and a step closed at only four of them is worse than none.
+ */
+
+import type { ActivityReporter } from './reporter'
+import type { StartStepOptions } from './recorder'
+
+/** The only thing this needs of a phase event. */
+interface PhaseEvent {
+  type: string
+}
+
+export async function* trackPhase<E extends PhaseEvent, R>(
+  activity: ActivityReporter,
+  label: string,
+  phase: AsyncGenerator<E, R>,
+  options: StartStepOptions = {},
+): AsyncGenerator<E, R> {
+  const id = activity.startStep(label, options)
+  let status: 'done' | 'failed' | 'skipped' = 'done'
+  try {
+    let next = await phase.next()
+    while (!next.done) {
+      const event = next.value
+      if (event.type === 'error') status = 'failed'
+      else if (event.type === 'aborted') status = 'skipped'
+      yield event
+      next = await phase.next()
+    }
+    return next.value
+  } catch (error) {
+    status = 'failed'
+    throw error
+  } finally {
+    // The loop steps the phase by hand rather than delegating, so abandoning this generator
+    // would otherwise leave the phase's own cleanup unrun.
+    await phase.return(undefined as R)
+    activity.endStep(id, status)
+  }
+}

--- a/src/lib/services/activity/trackPhase.ts
+++ b/src/lib/services/activity/trackPhase.ts
@@ -8,20 +8,22 @@
  */
 
 import type { ActivityReporter } from './reporter'
-import type { StartStepOptions } from './recorder'
 
 /** The only thing this needs of a phase event. */
 interface PhaseEvent {
   type: string
 }
 
+/**
+ * `stepId` is opened by the caller rather than here, so the same id can be handed to the
+ * phase as the parent for whatever it reports itself.
+ */
 export async function* trackPhase<E extends PhaseEvent, R>(
   activity: ActivityReporter,
-  label: string,
+  stepId: string,
   phase: AsyncGenerator<E, R>,
-  options: StartStepOptions = {},
 ): AsyncGenerator<E, R> {
-  const id = activity.startStep(label, options)
+  const id = stepId
   let status: 'done' | 'failed' | 'skipped' = 'done'
   try {
     let next = await phase.next()

--- a/src/lib/services/activity/tree.test.ts
+++ b/src/lib/services/activity/tree.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest'
+import { buildTree, deepestRunningStep } from './tree'
+import type { ActivityStep } from './types'
+
+function step(partial: Partial<ActivityStep> & { id: string }): ActivityStep {
+  return {
+    parentId: null,
+    label: partial.id,
+    isLLM: false,
+    status: 'done',
+    startedAt: 0,
+    ...partial,
+  }
+}
+
+describe('buildTree', () => {
+  it('nests a child under its parent', () => {
+    const tree = buildTree([
+      step({ id: 'retrieval' }),
+      step({ id: 'query', parentId: 'retrieval' }),
+    ])
+
+    expect(tree).toHaveLength(1)
+    expect(tree[0].step.id).toBe('retrieval')
+    expect(tree[0].children.map((c) => c.step.id)).toEqual(['query'])
+  })
+
+  it('keeps concurrent siblings in append order with their own times', () => {
+    const tree = buildTree([
+      step({ id: 'retrieval' }),
+      step({ id: 'worldstate', parentId: 'retrieval', startedAt: 10, endedAt: 40 }),
+      step({ id: 'lorebook', parentId: 'retrieval', startedAt: 12, endedAt: 38 }),
+    ])
+
+    const children = tree[0].children
+    expect(children.map((c) => c.step.id)).toEqual(['worldstate', 'lorebook'])
+    // Overlapping, not serialised.
+    expect(children[1].step.startedAt).toBeLessThan(children[0].step.endedAt!)
+  })
+
+  it('treats a step whose parent is absent as a root rather than dropping it', () => {
+    const tree = buildTree([step({ id: 'orphan', parentId: 'never-appended' })])
+
+    expect(tree.map((n) => n.step.id)).toEqual(['orphan'])
+  })
+
+  it('nests a child appended before its parent', () => {
+    const tree = buildTree([
+      step({ id: 'query', parentId: 'retrieval' }),
+      step({ id: 'retrieval' }),
+    ])
+
+    expect(tree.map((n) => n.step.id)).toEqual(['retrieval'])
+    expect(tree[0].children.map((c) => c.step.id)).toEqual(['query'])
+  })
+
+  it('keeps an unclosed step in the tree', () => {
+    const tree = buildTree([step({ id: 'retrieval', status: 'running' })])
+
+    expect(tree[0].step.status).toBe('running')
+    expect(tree[0].step.endedAt).toBeUndefined()
+  })
+})
+
+describe('deepestRunningStep', () => {
+  it('returns null when nothing is running', () => {
+    expect(deepestRunningStep([step({ id: 'a' }), step({ id: 'b' })])).toBeNull()
+  })
+
+  it('returns the only running step', () => {
+    const found = deepestRunningStep([step({ id: 'a' }), step({ id: 'b', status: 'running' })])
+
+    expect(found?.id).toBe('b')
+  })
+
+  it('prefers the deepest step over its running ancestor', () => {
+    const found = deepestRunningStep([
+      step({ id: 'retrieval', status: 'running' }),
+      step({ id: 'agentic', parentId: 'retrieval', status: 'running' }),
+      step({ id: 'query', parentId: 'agentic', status: 'running' }),
+    ])
+
+    expect(found?.id).toBe('query')
+  })
+
+  it('picks the most recently started among concurrent steps at the same depth', () => {
+    const found = deepestRunningStep([
+      step({ id: 'retrieval', status: 'running' }),
+      step({ id: 'worldstate', parentId: 'retrieval', status: 'running', startedAt: 10 }),
+      step({ id: 'lorebook', parentId: 'retrieval', status: 'running', startedAt: 20 }),
+    ])
+
+    expect(found?.id).toBe('lorebook')
+  })
+
+  it('ignores finished steps deeper than the running one', () => {
+    const found = deepestRunningStep([
+      step({ id: 'retrieval', status: 'running' }),
+      step({ id: 'query', parentId: 'retrieval', status: 'done' }),
+    ])
+
+    expect(found?.id).toBe('retrieval')
+  })
+
+  it('terminates on a parent cycle', () => {
+    const found = deepestRunningStep([
+      step({ id: 'a', parentId: 'b', status: 'running' }),
+      step({ id: 'b', parentId: 'a', status: 'running' }),
+    ])
+
+    expect(found).not.toBeNull()
+  })
+})

--- a/src/lib/services/activity/tree.test.ts
+++ b/src/lib/services/activity/tree.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { buildTree, deepestRunningStep, flattenTree } from './tree'
+import { buildTree, deepestRunningStep, flattenTree, rootStep } from './tree'
 import type { ActivityStep } from './types'
 
 function step(partial: Partial<ActivityStep> & { id: string }): ActivityStep {
@@ -148,5 +148,35 @@ describe('flattenTree', () => {
 
   it('is empty for an empty forest', () => {
     expect(flattenTree([])).toEqual([])
+  })
+})
+
+describe('rootStep', () => {
+  const steps = [
+    step({ id: 'retrieval' }),
+    step({ id: 'memory', parentId: 'retrieval' }),
+    step({ id: 'agent', parentId: 'memory' }),
+    step({ id: 'call-1', parentId: 'agent' }),
+    step({ id: 'narrative' }),
+  ]
+
+  it('walks a nested step up to the phase it belongs to', () => {
+    expect(rootStep(steps, steps[3]).id).toBe('retrieval')
+  })
+
+  it('returns a root step unchanged', () => {
+    expect(rootStep(steps, steps[4]).id).toBe('narrative')
+  })
+
+  it('stops at the outermost step it can reach when a parent is missing', () => {
+    const orphaned = [step({ id: 'child', parentId: 'never-appended' })]
+
+    expect(rootStep(orphaned, orphaned[0]).id).toBe('child')
+  })
+
+  it('terminates on a parent cycle', () => {
+    const cyclic = [step({ id: 'a', parentId: 'b' }), step({ id: 'b', parentId: 'a' })]
+
+    expect(rootStep(cyclic, cyclic[0])).toBeDefined()
   })
 })

--- a/src/lib/services/activity/tree.test.ts
+++ b/src/lib/services/activity/tree.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { buildTree, deepestRunningStep } from './tree'
+import { buildTree, deepestRunningStep, flattenTree } from './tree'
 import type { ActivityStep } from './types'
 
 function step(partial: Partial<ActivityStep> & { id: string }): ActivityStep {
@@ -109,5 +109,44 @@ describe('deepestRunningStep', () => {
     ])
 
     expect(found).not.toBeNull()
+  })
+})
+
+describe('flattenTree', () => {
+  it('returns the forest in reading order with each step at its depth', () => {
+    const rows = flattenTree(
+      buildTree([
+        step({ id: 'retrieval' }),
+        step({ id: 'agent', parentId: 'retrieval' }),
+        step({ id: 'call-1', parentId: 'agent' }),
+        step({ id: 'grep', parentId: 'call-1' }),
+        step({ id: 'narrative' }),
+      ]),
+    )
+
+    expect(rows.map((r) => [r.step.id, r.level])).toEqual([
+      ['retrieval', 0],
+      ['agent', 1],
+      ['call-1', 2],
+      ['grep', 3],
+      ['narrative', 0],
+    ])
+  })
+
+  it('keeps concurrent siblings adjacent at the same depth', () => {
+    const rows = flattenTree(
+      buildTree([
+        step({ id: 'retrieval' }),
+        step({ id: 'worldstate', parentId: 'retrieval' }),
+        step({ id: 'lorebook', parentId: 'retrieval' }),
+      ]),
+    )
+
+    expect(rows.map((r) => r.step.id)).toEqual(['retrieval', 'worldstate', 'lorebook'])
+    expect(rows.slice(1).every((r) => r.level === 1)).toBe(true)
+  })
+
+  it('is empty for an empty forest', () => {
+    expect(flattenTree([])).toEqual([])
   })
 })

--- a/src/lib/services/activity/tree.ts
+++ b/src/lib/services/activity/tree.ts
@@ -1,0 +1,75 @@
+/**
+ * Activity Tree
+ *
+ * Reading views over a turn's flat step list: the nesting, and which step is currently the
+ * innermost one running.
+ */
+
+import type { ActivityNode, ActivityStep } from './types'
+
+/**
+ * Assemble the flat list into a forest, preserving append order among siblings.
+ *
+ * A step naming a parent that is not in the list is treated as a root rather than dropped:
+ * the list is read while it is still being written, and a record missing a step is worse
+ * than one whose nesting is shallower than it will be.
+ */
+export function buildTree(steps: ActivityStep[]): ActivityNode[] {
+  const nodes = new Map<string, ActivityNode>()
+  for (const step of steps) {
+    nodes.set(step.id, { step, children: [] })
+  }
+
+  const roots: ActivityNode[] = []
+  for (const step of steps) {
+    const node = nodes.get(step.id)!
+    const parent = step.parentId === null ? undefined : nodes.get(step.parentId)
+    if (parent) parent.children.push(node)
+    else roots.push(node)
+  }
+  return roots
+}
+
+/**
+ * The innermost step still running, or null when nothing is.
+ *
+ * Depth beats recency: while a chapter query runs, its retrieval ancestor is running too,
+ * and naming the ancestor is what makes a forty-second wait unreadable. Among steps at the
+ * same depth the latest to start wins, so concurrent branches report the freshest work.
+ *
+ * A step whose parent is missing counts as a root, matching `buildTree`.
+ */
+export function deepestRunningStep(steps: ActivityStep[]): ActivityStep | null {
+  const byId = new Map(steps.map((s) => [s.id, s]))
+
+  const depthOf = (step: ActivityStep): number => {
+    let depth = 0
+    let current = step
+    const seen = new Set<string>([step.id])
+    while (current.parentId !== null) {
+      const parent = byId.get(current.parentId)
+      // A cycle cannot arise from correct recording, but the list is appended to from
+      // several places and an unbounded walk here would hang the render loop.
+      if (!parent || seen.has(parent.id)) break
+      seen.add(parent.id)
+      current = parent
+      depth++
+    }
+    return depth
+  }
+
+  let best: ActivityStep | null = null
+  let bestDepth = -1
+  for (const step of steps) {
+    if (step.status !== 'running') continue
+    const depth = depthOf(step)
+    if (
+      depth > bestDepth ||
+      (depth === bestDepth && best !== null && step.startedAt >= best.startedAt)
+    ) {
+      best = step
+      bestDepth = depth
+    }
+  }
+  return best
+}

--- a/src/lib/services/activity/tree.ts
+++ b/src/lib/services/activity/tree.ts
@@ -5,7 +5,7 @@
  * innermost one running.
  */
 
-import type { ActivityNode, ActivityStep } from './types'
+import type { ActivityNode, ActivityRow, ActivityStep } from './types'
 
 /**
  * Assemble the flat list into a forest, preserving append order among siblings.
@@ -72,4 +72,14 @@ export function deepestRunningStep(steps: ActivityStep[]): ActivityStep | null {
     }
   }
   return best
+}
+
+/** The forest in reading order, each step carrying its depth. */
+export function flattenTree(nodes: ActivityNode[], level = 0): ActivityRow[] {
+  const rows: ActivityRow[] = []
+  for (const node of nodes) {
+    rows.push({ step: node.step, level })
+    rows.push(...flattenTree(node.children, level + 1))
+  }
+  return rows
 }

--- a/src/lib/services/activity/tree.ts
+++ b/src/lib/services/activity/tree.ts
@@ -74,6 +74,26 @@ export function deepestRunningStep(steps: ActivityStep[]): ActivityStep | null {
   return best
 }
 
+/**
+ * The outermost step this one sits under, or the step itself when it is already a root.
+ *
+ * The short form names the innermost step running, which on its own says "Model call 1"
+ * without saying what that call is for. The root is the phase it belongs to.
+ */
+export function rootStep(steps: ActivityStep[], step: ActivityStep): ActivityStep {
+  const byId = new Map(steps.map((s) => [s.id, s]))
+  let current = step
+  const seen = new Set<string>([step.id])
+  while (current.parentId !== null) {
+    const parent = byId.get(current.parentId)
+    // A cycle cannot arise from correct recording, but the walk must still terminate.
+    if (!parent || seen.has(parent.id)) break
+    seen.add(parent.id)
+    current = parent
+  }
+  return current
+}
+
 /** The forest in reading order, each step carrying its depth. */
 export function flattenTree(nodes: ActivityNode[], level = 0): ActivityRow[] {
   const rows: ActivityRow[] = []

--- a/src/lib/services/activity/types.ts
+++ b/src/lib/services/activity/types.ts
@@ -1,0 +1,39 @@
+/**
+ * Activity Types
+ *
+ * What a generation turn records about its own progress. A turn holds a flat, append-only
+ * list of steps; nesting is carried by `parentId` and derived on read, so concurrent
+ * producers can append without agreeing on an insertion point.
+ */
+
+export type ActivityStatus = 'running' | 'done' | 'failed' | 'skipped'
+
+export interface ActivityStep {
+  id: string
+  /** null for a step directly under the turn. */
+  parentId: string | null
+  label: string
+  /** Qualifier shown beside the label: "6/8 steps", "4 excerpts", "empty response". */
+  detail?: string
+  /** True when the step's work is an LLM request. */
+  isLLM: boolean
+  status: ActivityStatus
+  startedAt: number
+  /** Absent while the step is running. */
+  endedAt?: number
+}
+
+export interface ActivityTurn {
+  id: string
+  /** The narration entry this turn produced. Set when the turn starts. */
+  entryId: string
+  startedAt: number
+  endedAt?: number
+  steps: ActivityStep[]
+}
+
+/** A step with its children attached. See `buildTree`. */
+export interface ActivityNode {
+  step: ActivityStep
+  children: ActivityNode[]
+}

--- a/src/lib/services/activity/types.ts
+++ b/src/lib/services/activity/types.ts
@@ -37,3 +37,9 @@ export interface ActivityNode {
   step: ActivityStep
   children: ActivityNode[]
 }
+
+/** A step positioned for display: see `flattenTree`. */
+export interface ActivityRow {
+  step: ActivityStep
+  level: number
+}

--- a/src/lib/services/ai/generation/WorldStateInjector.test.ts
+++ b/src/lib/services/ai/generation/WorldStateInjector.test.ts
@@ -2,6 +2,14 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { WorldStateInjector } from './WorldStateInjector'
 import type { Character, Location, Item, StoryBeat, StoryEntry } from '$lib/types'
 
+vi.mock('$lib/stores/activity.svelte', () => ({
+  activity: {
+    startStep: vi.fn(() => ''),
+    endStep: vi.fn(),
+    recordStep: vi.fn(() => ''),
+  },
+}))
+
 vi.mock('$lib/stores/debug.svelte', () => ({
   debug: {
     addDebugRequest: vi.fn(),

--- a/src/lib/services/ai/generation/WorldStateInjector.test.ts
+++ b/src/lib/services/ai/generation/WorldStateInjector.test.ts
@@ -5,6 +5,7 @@ import type { Character, Location, Item, StoryBeat, StoryEntry } from '$lib/type
 vi.mock('$lib/stores/activity.svelte', () => ({
   activity: {
     startStep: vi.fn(() => ''),
+    updateStep: vi.fn(),
     endStep: vi.fn(),
     recordStep: vi.fn(() => ''),
   },

--- a/src/lib/services/ai/generation/WorldStateInjector.ts
+++ b/src/lib/services/ai/generation/WorldStateInjector.ts
@@ -113,6 +113,8 @@ export interface WorldStateInjectorOptions {
    * lorebook pass start from what is in the scene without waiting on an LLM call.
    */
   onSceneEntities?: (entities: SceneEntity[]) => void
+  /** Step the Tier 3 selection nests under in the activity record, when reporting is on. */
+  activityParentId?: string
 }
 
 export const DEFAULT_WORLD_STATE_INJECTOR_CONFIG: WorldStateInjectorConfig = {
@@ -272,6 +274,7 @@ export class WorldStateInjector extends BaseAIService {
         currentPosition,
         signal,
         userActionEntryId,
+        options.activityParentId,
       )
       log('Tier 3 entries:', tier3.length)
     } else {
@@ -719,6 +722,7 @@ export class WorldStateInjector extends BaseAIService {
     currentPosition: number,
     signal?: AbortSignal,
     userActionEntryId?: string,
+    activityParentId?: string,
   ): Promise<WorldStateContextEntry[]> {
     const result = await runTier3Selection({
       storyId,
@@ -729,6 +733,7 @@ export class WorldStateInjector extends BaseAIService {
       presetId: this.presetId,
       serviceLabel: 'tier3-world-state-selection',
       userActionEntryId,
+      activityParentId,
       currentPosition,
       signal,
     })

--- a/src/lib/services/ai/index.ts
+++ b/src/lib/services/ai/index.ts
@@ -203,6 +203,8 @@ export interface AgenticRetrievalOptions {
   getChapterEntries?: (chapter: Chapter) => StoryEntry[]
   getUnchapterizedEntries?: () => StoryEntry[]
   signal?: AbortSignal
+  /** Step the agent's own steps nest under in the activity record. */
+  activityParentId?: string
 }
 
 class AIService {
@@ -762,6 +764,7 @@ class AIService {
       queryChapter: options.onQueryChapter,
       getChapterEntries: options.getChapterEntries,
       getUnchapterizedEntries: options.getUnchapterizedEntries,
+      activityParentId: options.activityParentId,
     }
 
     const result = await service.runRetrieval(context, signal)
@@ -795,6 +798,8 @@ class AIService {
     alreadyInContext?: string,
     /** Budget for each answer prompt's chapter text; see `chapterReadBudget`. */
     maxChapterTokens?: number,
+    /** Step the fill's own work nests under in the activity record. */
+    activityParentId?: string,
   ): Promise<TimelineFillResult> {
     log('runTimelineFill called', {
       visibleEntriesCount: visibleEntries.length,
@@ -811,6 +816,7 @@ class AIService {
       getChapterEntries,
       alreadyInContext,
       maxChapterTokens,
+      activityParentId,
     )
   }
 

--- a/src/lib/services/ai/retrieval/AgenticRetrievalService.test.ts
+++ b/src/lib/services/ai/retrieval/AgenticRetrievalService.test.ts
@@ -2,6 +2,14 @@ import { finishOnlyOnLastStep } from '$lib/services/ai/sdk/agents'
 import { describe, it, expect, vi } from 'vitest'
 import type { Entry, Chapter } from '$lib/types'
 
+vi.mock('$lib/stores/activity.svelte', () => ({
+  activity: {
+    startStep: vi.fn(() => ''),
+    endStep: vi.fn(),
+    recordStep: vi.fn(() => ''),
+  },
+}))
+
 vi.mock('$lib/stores/debug.svelte', () => ({
   debug: {
     addDebugRequest: vi.fn(),

--- a/src/lib/services/ai/retrieval/AgenticRetrievalService.test.ts
+++ b/src/lib/services/ai/retrieval/AgenticRetrievalService.test.ts
@@ -5,6 +5,7 @@ import type { Entry, Chapter } from '$lib/types'
 vi.mock('$lib/stores/activity.svelte', () => ({
   activity: {
     startStep: vi.fn(() => ''),
+    updateStep: vi.fn(),
     endStep: vi.fn(),
     recordStep: vi.fn(() => ''),
   },

--- a/src/lib/services/ai/retrieval/AgenticRetrievalService.ts
+++ b/src/lib/services/ai/retrieval/AgenticRetrievalService.ts
@@ -28,6 +28,8 @@ import {
 } from '../sdk/tools'
 import { ContextBuilder } from '$lib/services/context'
 import { debug } from '$lib/stores/debug.svelte'
+import { activity } from '$lib/stores/activity.svelte'
+import { retrievalStep, retrievalStepStatus } from './retrievalSteps'
 import { recentContent, AS_PROSE } from '$lib/utils/recentContent'
 import {
   formatRetrievalHistory,
@@ -109,6 +111,8 @@ export interface RetrievalContext {
   getChapterEntries?: (chapter: Chapter) => StoryEntry[]
   /** Optional callback for the entries after the last chapter, also searched by grep_chapters */
   getUnchapterizedEntries?: () => StoryEntry[]
+  /** Step this run's own steps nest under in the activity record. */
+  activityParentId?: string
 }
 
 /**
@@ -162,9 +166,26 @@ export class AgenticRetrievalService extends BaseAIService {
 
     // Single append-only record of the run. Selections, queried chapters and the query
     // history are all derived from it rather than tracked separately.
+    // Set once the agent step is open; tool calls before then nest under the phase's step.
+    let agentStepId = ''
+
     const events: RetrievalEvent[] = []
     const record = (event: RetrievalEventInput) => {
-      events.push({ ...event, at: events.length } as RetrievalEvent)
+      const stamped = { ...event, at: events.length } as RetrievalEvent
+      events.push(stamped)
+      reportStep(stamped)
+    }
+
+    // The agent's steps are reported as they happen, under the step the phase opened. Each
+    // tool call is already over by the time it is recorded, so it is a closed step rather
+    // than one opened and closed around the work.
+    const reportStep = (event: RetrievalEvent) => {
+      const { label, options } = retrievalStep(event)
+      activity.recordStep(label, {
+        ...options,
+        parentId: agentStepId || context.activityParentId,
+        status: retrievalStepStatus(event),
+      })
     }
     /**
      * Chapter answers this run paid for, salvaged if the agent never reaches its summary.
@@ -301,6 +322,11 @@ export class AgenticRetrievalService extends BaseAIService {
       this.maxIterations,
     ) as PrepareStepFunction<typeof tools>
 
+    agentStepId = activity.startStep('Agent', {
+      parentId: context.activityParentId,
+      detail: `0/${this.maxIterations} steps`,
+    })
+
     // Create the agent
     const agent = createAgentFromPreset(
       {
@@ -332,6 +358,12 @@ export class AgenticRetrievalService extends BaseAIService {
       failure = error instanceof Error ? error.message : String(error)
       log('Agent run failed -- salvaging what it gathered', { failure, steps: stepsTaken })
     }
+
+    activity.endStep(
+      agentStepId,
+      failure ? 'failed' : 'done',
+      `${stepsTaken}/${this.maxIterations} steps`,
+    )
 
     const metrics = retrievalMetrics(events)
     const transcript = formatRetrievalHistory(events)

--- a/src/lib/services/ai/retrieval/AgenticRetrievalService.ts
+++ b/src/lib/services/ai/retrieval/AgenticRetrievalService.ts
@@ -267,15 +267,22 @@ export class AgenticRetrievalService extends BaseAIService {
     // Wrapped so the real step count reaches describeProgress. Runs after each step, so
     // inside a tool call it reports steps finished, not the one in flight.
     //
-    // Writing from inside a stop predicate is only safe because the SDK evaluates the
-    // conditions exactly once per loop iteration (`isStopConditionMet`, called at the foot
-    // of the generate loop). It is not contractual, so the count is kept monotonic: were a
-    // future version to re-evaluate with a stale array, progress could read as going
-    // backwards, which is worse than being one step behind.
+    // `N steps (limit M)`, not `N/M`: the budget is a ceiling the run may never approach, and
+    // a fraction reads as progress towards planned work.
+    const stepBudget = (count: number) =>
+      `${count} step${count === 1 ? '' : 's'} (limit ${this.maxIterations})`
+
+    // Monotonic, and fed from both hooks: `stopWhen` is documented as the condition
+    // "for stopping the generation when there are tool results in the last step", so it does
+    // not see an iteration that called no tool. `prepareStep` opens every one.
+    const noteSteps = (count: number) => {
+      stepsTaken = Math.max(stepsTaken, count)
+      activity.updateStep(agentStepId, stepBudget(stepsTaken))
+    }
+
     const terminalStop = stopOnTerminalTool<typeof tools>('finish_retrieval', this.maxIterations)
     const stopWhen: typeof terminalStop = (input) => {
-      stepsTaken = Math.max(stepsTaken, input.steps.length)
-      activity.updateStep(agentStepId, `${stepsTaken}/${this.maxIterations} steps`)
+      noteSteps(input.steps.length)
       return terminalStop(input)
     }
 
@@ -323,10 +330,16 @@ export class AgenticRetrievalService extends BaseAIService {
 
     const lastStepOnly = finishOnlyOnLastStep('finish_retrieval', this.maxIterations)
 
-    // Wrapped to open an activity step per iteration. The run's time is in these model
-    // calls; its tool calls are in-memory and effectively instant, so reporting only those
-    // leaves the time unattributed.
+    agentStepId = activity.startStep('Agent', {
+      parentId: context.activityParentId,
+      detail: stepBudget(0),
+    })
+
+    // Wrapped to open an activity step per iteration, and to count them. The run's time is in
+    // these model calls; its tool calls are in-memory and effectively instant, so reporting
+    // only those leaves the time unattributed.
     const prepareStep = ((input: { stepNumber: number }) => {
+      noteSteps(input.stepNumber + 1)
       activity.endStep(iterationStepId)
       iterationStepId = activity.startStep(`Model call ${input.stepNumber + 1}`, {
         parentId: agentStepId,
@@ -334,11 +347,6 @@ export class AgenticRetrievalService extends BaseAIService {
       })
       return lastStepOnly(input)
     }) as PrepareStepFunction<typeof tools>
-
-    agentStepId = activity.startStep('Agent', {
-      parentId: context.activityParentId,
-      detail: `0/${this.maxIterations} steps`,
-    })
 
     // Create the agent
     const agent = createAgentFromPreset(
@@ -361,7 +369,7 @@ export class AgenticRetrievalService extends BaseAIService {
     let failure: string | null = null
     try {
       const result = await agent.generate({ prompt: userPrompt })
-      stepsTaken = result.steps.length
+      stepsTaken = Math.max(stepsTaken, result.steps.length)
       terminalResult = extractTerminalToolResult<FinishRetrievalResult>(
         result.steps as any,
         'finish_retrieval',
@@ -370,7 +378,7 @@ export class AgenticRetrievalService extends BaseAIService {
       if (signal?.aborted) {
         // Rethrown past the closes below, so they happen here instead.
         activity.endStep(iterationStepId, 'skipped')
-        activity.endStep(agentStepId, 'skipped', `${stepsTaken}/${this.maxIterations} steps`)
+        activity.endStep(agentStepId, 'skipped', stepBudget(stepsTaken))
         throw error
       }
       failure = error instanceof Error ? error.message : String(error)
@@ -378,11 +386,7 @@ export class AgenticRetrievalService extends BaseAIService {
     }
 
     activity.endStep(iterationStepId, failure ? 'failed' : 'done')
-    activity.endStep(
-      agentStepId,
-      failure ? 'failed' : 'done',
-      `${stepsTaken}/${this.maxIterations} steps`,
-    )
+    activity.endStep(agentStepId, failure ? 'failed' : 'done', stepBudget(stepsTaken))
 
     const metrics = retrievalMetrics(events)
     const transcript = formatRetrievalHistory(events)

--- a/src/lib/services/ai/retrieval/AgenticRetrievalService.ts
+++ b/src/lib/services/ai/retrieval/AgenticRetrievalService.ts
@@ -323,9 +323,9 @@ export class AgenticRetrievalService extends BaseAIService {
 
     const lastStepOnly = finishOnlyOnLastStep('finish_retrieval', this.maxIterations)
 
-    // Wrapped to open an activity step per iteration. Without it the run reports only its
-    // tool calls, which are in-memory and effectively instant -- so a two-minute retrieval
-    // showed two minutes of nothing, when nearly all of it is these model calls.
+    // Wrapped to open an activity step per iteration. The run's time is in these model
+    // calls; its tool calls are in-memory and effectively instant, so reporting only those
+    // leaves the time unattributed.
     const prepareStep = ((input: { stepNumber: number }) => {
       activity.endStep(iterationStepId)
       iterationStepId = activity.startStep(`Model call ${input.stepNumber + 1}`, {
@@ -367,7 +367,12 @@ export class AgenticRetrievalService extends BaseAIService {
         'finish_retrieval',
       )
     } catch (error) {
-      if (signal?.aborted) throw error
+      if (signal?.aborted) {
+        // Rethrown past the closes below, so they happen here instead.
+        activity.endStep(iterationStepId, 'skipped')
+        activity.endStep(agentStepId, 'skipped', `${stepsTaken}/${this.maxIterations} steps`)
+        throw error
+      }
       failure = error instanceof Error ? error.message : String(error)
       log('Agent run failed -- salvaging what it gathered', { failure, steps: stepsTaken })
     }

--- a/src/lib/services/ai/retrieval/AgenticRetrievalService.ts
+++ b/src/lib/services/ai/retrieval/AgenticRetrievalService.ts
@@ -168,6 +168,9 @@ export class AgenticRetrievalService extends BaseAIService {
     // history are all derived from it rather than tracked separately.
     // Set once the agent step is open; tool calls before then nest under the phase's step.
     let agentStepId = ''
+    // The iteration in flight. Tool calls nest under it, so the model call that chose them
+    // and the calls themselves read as one step of the run.
+    let iterationStepId = ''
 
     const events: RetrievalEvent[] = []
     const record = (event: RetrievalEventInput) => {
@@ -183,7 +186,7 @@ export class AgenticRetrievalService extends BaseAIService {
       const { label, options } = retrievalStep(event)
       activity.recordStep(label, {
         ...options,
-        parentId: agentStepId || context.activityParentId,
+        parentId: iterationStepId || agentStepId || context.activityParentId,
         status: retrievalStepStatus(event),
       })
     }
@@ -272,6 +275,7 @@ export class AgenticRetrievalService extends BaseAIService {
     const terminalStop = stopOnTerminalTool<typeof tools>('finish_retrieval', this.maxIterations)
     const stopWhen: typeof terminalStop = (input) => {
       stepsTaken = Math.max(stepsTaken, input.steps.length)
+      activity.updateStep(agentStepId, `${stepsTaken}/${this.maxIterations} steps`)
       return terminalStop(input)
     }
 
@@ -317,10 +321,19 @@ export class AgenticRetrievalService extends BaseAIService {
     })
     const { system: systemPrompt, user: userPrompt } = await ctx.render('agentic-retrieval')
 
-    const prepareStep = finishOnlyOnLastStep(
-      'finish_retrieval',
-      this.maxIterations,
-    ) as PrepareStepFunction<typeof tools>
+    const lastStepOnly = finishOnlyOnLastStep('finish_retrieval', this.maxIterations)
+
+    // Wrapped to open an activity step per iteration. Without it the run reports only its
+    // tool calls, which are in-memory and effectively instant -- so a two-minute retrieval
+    // showed two minutes of nothing, when nearly all of it is these model calls.
+    const prepareStep = ((input: { stepNumber: number }) => {
+      activity.endStep(iterationStepId)
+      iterationStepId = activity.startStep(`Model call ${input.stepNumber + 1}`, {
+        parentId: agentStepId,
+        isLLM: true,
+      })
+      return lastStepOnly(input)
+    }) as PrepareStepFunction<typeof tools>
 
     agentStepId = activity.startStep('Agent', {
       parentId: context.activityParentId,
@@ -359,6 +372,7 @@ export class AgenticRetrievalService extends BaseAIService {
       log('Agent run failed -- salvaging what it gathered', { failure, steps: stepsTaken })
     }
 
+    activity.endStep(iterationStepId, failure ? 'failed' : 'done')
     activity.endStep(
       agentStepId,
       failure ? 'failed' : 'done',

--- a/src/lib/services/ai/retrieval/EntryRetrievalService.test.ts
+++ b/src/lib/services/ai/retrieval/EntryRetrievalService.test.ts
@@ -2,6 +2,14 @@ import { describe, it, expect, vi } from 'vitest'
 import { EntryRetrievalService, SimpleActivationTracker } from './EntryRetrievalService'
 import type { Entry, StoryEntry } from '$lib/types'
 
+vi.mock('$lib/stores/activity.svelte', () => ({
+  activity: {
+    startStep: vi.fn(() => ''),
+    endStep: vi.fn(),
+    recordStep: vi.fn(() => ''),
+  },
+}))
+
 vi.mock('$lib/stores/debug.svelte', () => ({
   debug: {
     addDebugRequest: vi.fn(),

--- a/src/lib/services/ai/retrieval/EntryRetrievalService.test.ts
+++ b/src/lib/services/ai/retrieval/EntryRetrievalService.test.ts
@@ -5,6 +5,7 @@ import type { Entry, StoryEntry } from '$lib/types'
 vi.mock('$lib/stores/activity.svelte', () => ({
   activity: {
     startStep: vi.fn(() => ''),
+    updateStep: vi.fn(),
     endStep: vi.fn(),
     recordStep: vi.fn(() => ''),
   },

--- a/src/lib/services/ai/retrieval/EntryRetrievalService.ts
+++ b/src/lib/services/ai/retrieval/EntryRetrievalService.ts
@@ -137,6 +137,8 @@ export interface EntryRetrievalOptions {
    * name it. Never travels the other way: see the haystack comment in `getRelevantEntries`.
    */
   sceneEntities?: SceneEntity[]
+  /** Step the Tier 3 selection nests under in the activity record, when reporting is on. */
+  activityParentId?: string
 }
 
 export const DEFAULT_ENTRY_RETRIEVAL_CONFIG: EntryRetrievalConfig = {
@@ -335,6 +337,7 @@ export class EntryRetrievalService extends BaseAIService {
         currentPosition,
         signal,
         userActionEntryId,
+        options.activityParentId,
       )
       log(
         'Tier 3 entries:',
@@ -562,6 +565,7 @@ export class EntryRetrievalService extends BaseAIService {
     currentPosition: number,
     signal?: AbortSignal,
     userActionEntryId?: string,
+    activityParentId?: string,
   ): Promise<RetrievedEntry[]> {
     if (availableEntries.length === 0) {
       return []
@@ -583,6 +587,7 @@ export class EntryRetrievalService extends BaseAIService {
       presetId: this.presetId,
       serviceLabel: 'tier3-lorebook-selection',
       userActionEntryId,
+      activityParentId,
       currentPosition,
       signal,
     })

--- a/src/lib/services/ai/retrieval/TimelineFillService.test.ts
+++ b/src/lib/services/ai/retrieval/TimelineFillService.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { Chapter, StoryEntry } from '$lib/types'
 
+vi.mock('$lib/stores/activity.svelte', () => ({
+  activity: {
+    startStep: vi.fn(() => ''),
+    endStep: vi.fn(),
+    recordStep: vi.fn(() => ''),
+  },
+}))
+
 vi.mock('$lib/stores/debug.svelte', () => ({
   debug: {
     addDebugRequest: vi.fn(),

--- a/src/lib/services/ai/retrieval/TimelineFillService.test.ts
+++ b/src/lib/services/ai/retrieval/TimelineFillService.test.ts
@@ -39,6 +39,8 @@ vi.mock('../sdk/generate', () => ({
 // ContextBuilder reaches the pack store and the database; the prompt text is not what these
 // tests are about, but `chapterContent` is — so it is captured on the way through.
 const rendered: Record<string, string>[] = []
+/** Set by the test covering a prompt that cannot be rendered. */
+let renderError: Error | null = null
 vi.mock('$lib/services/context', () => ({
   ContextBuilder: class ContextBuilderMock {
     static async forPack() {
@@ -50,12 +52,14 @@ vi.mock('$lib/services/context', () => ({
       rendered.push(vars)
     }
     async render() {
+      if (renderError) throw renderError
       return { system: 'system', user: 'user' }
     }
   },
 }))
 
 import { TimelineFillService } from './TimelineFillService'
+import { activity } from '$lib/stores/activity.svelte'
 
 const mockEntries: StoryEntry[] = [
   { id: 'se-1', content: 'She looked up at the fortress.', type: 'narration' } as StoryEntry,
@@ -80,6 +84,9 @@ beforeEach(() => {
   generateStructured.mockReset()
   generatePlainText.mockReset()
   rendered.length = 0
+  renderError = null
+  vi.mocked(activity.startStep).mockClear().mockReturnValue('step-1')
+  vi.mocked(activity.endStep).mockClear()
 })
 
 describe('TimelineFillService', () => {
@@ -296,5 +303,54 @@ describe('runTimelineFill - subset grouping', () => {
     // Neither is a subset of the other, so they stay separate rather than both paying for
     // a widened three-chapter render.
     expect(rendered.filter((v) => 'chapterContent' in v)).toHaveLength(2)
+  })
+})
+
+describe('runTimelineFill activity reporting', () => {
+  const chapters = [chapter(1)]
+
+  it('closes the planning step as failed when the prompt cannot be rendered', async () => {
+    // `generateQueries` guards the model call but not the render before it, so this rejects
+    // straight past the success-only close.
+    renderError = new Error('no such template')
+
+    await expect(
+      new TimelineFillService('timelineFill', 3).runTimelineFill(
+        's1',
+        mockEntries,
+        chapters,
+        () => [],
+        '',
+        10_000,
+        'parent-step',
+      ),
+    ).rejects.toThrow('no such template')
+
+    expect(activity.startStep).toHaveBeenCalledWith('Planning questions', {
+      parentId: 'parent-step',
+      isLLM: true,
+    })
+    // Not left running for the turn to sweep up as 'interrupted': it failed.
+    expect(activity.endStep).toHaveBeenCalledWith('step-1', 'failed')
+  })
+
+  it('closes the planning step as skipped when the turn was aborted', async () => {
+    const aborted = new Error('aborted')
+    aborted.name = 'AbortError'
+    renderError = aborted
+
+    await expect(
+      new TimelineFillService('timelineFill', 3).runTimelineFill(
+        's1',
+        mockEntries,
+        chapters,
+        () => [],
+        '',
+        10_000,
+        'parent-step',
+      ),
+    ).rejects.toThrow('aborted')
+
+    expect(activity.endStep).toHaveBeenCalledWith('step-1', 'skipped')
   })
 })

--- a/src/lib/services/ai/retrieval/TimelineFillService.test.ts
+++ b/src/lib/services/ai/retrieval/TimelineFillService.test.ts
@@ -4,6 +4,7 @@ import type { Chapter, StoryEntry } from '$lib/types'
 vi.mock('$lib/stores/activity.svelte', () => ({
   activity: {
     startStep: vi.fn(() => ''),
+    updateStep: vi.fn(),
     endStep: vi.fn(),
     recordStep: vi.fn(() => ''),
   },

--- a/src/lib/services/ai/retrieval/TimelineFillService.ts
+++ b/src/lib/services/ai/retrieval/TimelineFillService.ts
@@ -27,6 +27,11 @@ import { activity } from '$lib/stores/activity.svelte'
 
 const log = createLogger('TimelineFill')
 
+/** How a step that threw is closed: an abort was not a failure of the work itself. */
+function abortedStatus(error: unknown): 'skipped' | 'failed' {
+  return error instanceof Error && error.name === 'AbortError' ? 'skipped' : 'failed'
+}
+
 /**
  * Text `answerQuestion` returns when the call failed, so `runTimelineFill` can drop it.
  *
@@ -378,7 +383,15 @@ export class TimelineFillService extends BaseAIService {
       parentId: activityParentId,
       isLLM: true,
     })
-    const queries = await this.generateQueries(storyId, visibleEntries, chapters, alreadyInContext)
+    let queries: TimelineQuery[]
+    try {
+      queries = await this.generateQueries(storyId, visibleEntries, chapters, alreadyInContext)
+    } catch (error) {
+      // `generateQueries` swallows a failed model call, but renders its prompt outside that
+      // guard -- a template lookup rejects straight past the close below.
+      activity.endStep(planStepId, abortedStatus(error))
+      throw error
+    }
     activity.endStep(planStepId, 'done', `${queries.length} questions`)
     if (queries.length === 0) {
       return { queries: [], responses: [] }
@@ -432,19 +445,26 @@ export class TimelineFillService extends BaseAIService {
           parentId: activityParentId,
           isLLM: true,
         })
-        const { answers, llmCalls } =
-          group.items.length === 1
-            ? {
-                answers: [
-                  await this.answerQuestionWithContent(storyId, group.items[0].query, content),
-                ],
-                llmCalls: 1,
-              }
-            : await this.answerQuestionsWithContent(
-                storyId,
-                group.items.map((i) => i.query),
-                content,
-              )
+        let answers: Awaited<ReturnType<typeof this.answerQuestionWithContent>>[]
+        let llmCalls: number
+        try {
+          ;({ answers, llmCalls } =
+            group.items.length === 1
+              ? {
+                  answers: [
+                    await this.answerQuestionWithContent(storyId, group.items[0].query, content),
+                  ],
+                  llmCalls: 1,
+                }
+              : await this.answerQuestionsWithContent(
+                  storyId,
+                  group.items.map((i) => i.query),
+                  content,
+                ))
+        } catch (error) {
+          activity.endStep(readStepId, abortedStatus(error))
+          throw error
+        }
 
         activity.endStep(readStepId, 'done', `${group.items.length} answered`)
 

--- a/src/lib/services/ai/retrieval/TimelineFillService.ts
+++ b/src/lib/services/ai/retrieval/TimelineFillService.ts
@@ -23,6 +23,8 @@ import { buildChapterRead, type ChapterForRead } from './chapterContentBudget'
 import { countTokens } from '$lib/services/tokenizer'
 import { chapterReadBudget } from '../core/defaults'
 
+import { activity } from '$lib/stores/activity.svelte'
+
 const log = createLogger('TimelineFill')
 
 /**
@@ -358,6 +360,8 @@ export class TimelineFillService extends BaseAIService {
     getChapterEntries?: (chapter: Chapter) => StoryEntry[],
     alreadyInContext?: string,
     maxChapterTokens: number = chapterReadBudget(undefined),
+    /** Step this fill's own work nests under in the activity record. */
+    activityParentId?: string,
   ): Promise<TimelineFillResult> {
     log('runTimelineFill called', {
       visibleEntriesCount: visibleEntries.length,
@@ -370,7 +374,12 @@ export class TimelineFillService extends BaseAIService {
       return { queries: [], responses: [] }
     }
 
+    const planStepId = activity.startStep('Planning questions', {
+      parentId: activityParentId,
+      isLLM: true,
+    })
     const queries = await this.generateQueries(storyId, visibleEntries, chapters, alreadyInContext)
+    activity.endStep(planStepId, 'done', `${queries.length} questions`)
     if (queries.length === 0) {
       return { queries: [], responses: [] }
     }
@@ -419,6 +428,10 @@ export class TimelineFillService extends BaseAIService {
 
         const content = this.buildContentFrom(targetChapters, maxChapterTokens)
 
+        const readStepId = activity.startStep(`Reading ch.${group.chapterNumbers.join(',')}`, {
+          parentId: activityParentId,
+          isLLM: true,
+        })
         const { answers, llmCalls } =
           group.items.length === 1
             ? {
@@ -432,6 +445,8 @@ export class TimelineFillService extends BaseAIService {
                 group.items.map((i) => i.query),
                 content,
               )
+
+        activity.endStep(readStepId, 'done', `${group.items.length} answered`)
 
         group.items.forEach((item, i) => {
           // `confidence: 0` is what every give-up path sets. None of it is retrieved

--- a/src/lib/services/ai/retrieval/index.ts
+++ b/src/lib/services/ai/retrieval/index.ts
@@ -55,3 +55,6 @@ export {
   type TimelineFillResult,
   type TimelineQueryResult,
 } from './TimelineFillService'
+
+// How the agent's own event record reads in the activity timeline.
+export { retrievalStep, retrievalStepStatus, type RetrievalStep } from './retrievalSteps'

--- a/src/lib/services/ai/retrieval/retrievalHistory.ts
+++ b/src/lib/services/ai/retrieval/retrievalHistory.ts
@@ -111,7 +111,7 @@ function grepLabel(event: Extract<RetrievalEvent, { kind: 'grep' }>): string {
 }
 
 /**
- * Step budget. `steps` must come from the loop's stop condition, not `events.length`:
+ * Step budget. `steps` must come from the agent loop's own hooks, not `events.length`:
  * one step can call several tools, or none, so an event count misstates the budget.
  */
 export interface ProgressBudget {
@@ -255,7 +255,7 @@ export function formatRetrievalHistory(events: RetrievalEvent[]): string {
 export interface RetrievalMetrics {
   /**
    * Recorded tool calls, not agent steps -- one step can call several tools, or none.
-   * The step budget is `ProgressBudget.steps`, which only the loop's stop condition knows.
+   * The step budget is `ProgressBudget.steps`, which only the agent loop's hooks know.
    */
   toolCalls: number
   greps: number

--- a/src/lib/services/ai/retrieval/retrievalSteps.test.ts
+++ b/src/lib/services/ai/retrieval/retrievalSteps.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest'
+import { retrievalStep, retrievalStepStatus } from './retrievalSteps'
+import type { RetrievalEvent } from './retrievalHistory'
+
+describe('retrievalStep', () => {
+  it('labels a grep by its term and reports its scope and yield', () => {
+    const step = retrievalStep({
+      at: 0,
+      kind: 'grep',
+      query: 'Kaelen',
+      chapters: [12],
+      wholeWord: false,
+      caseSensitive: false,
+      totalMatches: 9,
+      excerptsShown: 4,
+      sampled: true,
+      repeated: false,
+    })
+
+    expect(step.label).toBe('grep "Kaelen"')
+    expect(step.options.detail).toBe('ch.12 · 4 of 9 matches')
+    expect(step.options.isLLM).toBeFalsy()
+  })
+
+  it('says when a grep covered every chapter and was repeated', () => {
+    const step = retrievalStep({
+      at: 0,
+      kind: 'grep',
+      query: 'temple',
+      chapters: null,
+      wholeWord: false,
+      caseSensitive: false,
+      totalMatches: 2,
+      excerptsShown: 2,
+      sampled: false,
+      repeated: true,
+    })
+
+    expect(step.options.detail).toBe('all chapters · 2 matches · repeated')
+  })
+
+  it('marks a chapter query as an LLM step and carries its measured duration', () => {
+    const step = retrievalStep({
+      at: 1,
+      kind: 'query',
+      chapterNumber: 12,
+      question: 'What happened to the seal?',
+      answer: '...',
+      cached: false,
+      durationMs: 6_200,
+    })
+
+    expect(step.label).toBe('query ch.12')
+    expect(step.options.isLLM).toBe(true)
+    expect(step.options.durationMs).toBe(6_200)
+    expect(step.options.detail).toBe('What happened to the seal?')
+  })
+
+  it('does not count a cached chapter answer as a model call', () => {
+    const step = retrievalStep({
+      at: 1,
+      kind: 'query',
+      chapterNumber: 4,
+      question: 'q',
+      answer: 'a',
+      cached: true,
+      durationMs: 0,
+    })
+
+    expect(step.options.isLLM).toBe(false)
+    expect(step.options.detail).toBe('cached')
+  })
+
+  it('reports a failed chapter query as failed and not as a model call', () => {
+    const event: RetrievalEvent = {
+      at: 1,
+      kind: 'query',
+      chapterNumber: 4,
+      question: 'q',
+      answer: 'boom',
+      cached: false,
+      failed: true,
+    }
+
+    expect(retrievalStep(event).options.isLLM).toBe(false)
+    expect(retrievalStepStatus(event)).toBe('failed')
+  })
+
+  it('labels an entry search by its query and result count', () => {
+    const step = retrievalStep({ at: 2, kind: 'search', query: 'temple', resultCount: 3 })
+
+    expect(step.label).toBe('search "temple"')
+    expect(step.options.detail).toBe('3 found')
+  })
+
+  it('labels a world state inspection', () => {
+    const step = retrievalStep({
+      at: 3,
+      kind: 'world_state',
+      query: 'Kaelen',
+      category: 'characters',
+      resultCount: 1,
+    })
+
+    expect(step.label).toBe('world state "Kaelen"')
+    expect(step.options.detail).toBe('1 found · characters')
+  })
+
+  it('labels an entry read and says when it was not found', () => {
+    expect(retrievalStep({ at: 4, kind: 'entry', name: 'Seal', found: true }).label).toBe(
+      'read Seal',
+    )
+    expect(
+      retrievalStep({ at: 4, kind: 'entry', entryId: 'e1', found: false }).options.detail,
+    ).toBe('not found')
+  })
+
+  it('labels the terminal step with its confidence', () => {
+    const step = retrievalStep({ at: 5, kind: 'finish', confidence: 'medium', hasSummary: true })
+
+    expect(step.label).toBe('finish')
+    expect(step.options.detail).toBe('confidence: medium')
+  })
+
+  it('notes a terminal step that produced no summary', () => {
+    const step = retrievalStep({ at: 5, kind: 'finish', confidence: 'low', hasSummary: false })
+
+    expect(step.options.detail).toBe('confidence: low · no summary')
+  })
+})

--- a/src/lib/services/ai/retrieval/retrievalSteps.ts
+++ b/src/lib/services/ai/retrieval/retrievalSteps.ts
@@ -1,0 +1,77 @@
+/**
+ * Retrieval Steps
+ *
+ * Translates the retrieval agent's own event record into activity steps.
+ *
+ * A translation rather than a direct reuse of `RetrievalEvent`: that type is shaped for the
+ * agent's progress line and the debug transcript, and binding the activity record to it
+ * would make either hard to change.
+ */
+
+import type { RetrievalEvent } from './retrievalHistory'
+import type { StartStepOptions } from '$lib/services/activity'
+
+export interface RetrievalStep {
+  label: string
+  options: StartStepOptions & { durationMs?: number }
+}
+
+/**
+ * How a tool call reads in the timeline: what it looked for, and what came back.
+ *
+ * Only `query` is marked as an LLM step -- it is the one that costs a model call, and the
+ * point of the marker is to tell the expensive work from the free work at a glance.
+ */
+export function retrievalStep(event: RetrievalEvent): RetrievalStep {
+  switch (event.kind) {
+    case 'grep': {
+      const scope = event.chapters?.length ? `ch.${event.chapters.join(',')}` : 'all chapters'
+      const shown = event.sampled
+        ? `${event.excerptsShown} of ${event.totalMatches} matches`
+        : `${event.totalMatches} matches`
+      return {
+        label: `grep "${event.query}"`,
+        options: { detail: `${scope} · ${shown}${event.repeated ? ' · repeated' : ''}` },
+      }
+    }
+    case 'query':
+      return {
+        label: `query ch.${event.chapterNumber}`,
+        options: {
+          detail: event.failed ? 'failed' : event.cached ? 'cached' : event.question,
+          // A cached replay is the same answer handed back, not a second model call.
+          isLLM: !event.cached && !event.failed,
+          durationMs: event.durationMs ?? 0,
+        },
+      }
+    case 'search':
+      return {
+        label: event.query ? `search "${event.query}"` : 'search entries',
+        options: { detail: `${event.resultCount} found${event.type ? ` · ${event.type}` : ''}` },
+      }
+    case 'world_state':
+      return {
+        label: event.query ? `world state "${event.query}"` : 'world state',
+        options: {
+          detail: `${event.resultCount} found${event.category ? ` · ${event.category}` : ''}`,
+        },
+      }
+    case 'entry':
+      return {
+        label: `read ${event.name ?? event.entryId ?? 'entry'}`,
+        options: { detail: event.found ? undefined : 'not found' },
+      }
+    case 'finish':
+      return {
+        label: 'finish',
+        options: {
+          detail: `confidence: ${event.confidence}${event.hasSummary ? '' : ' · no summary'}`,
+        },
+      }
+  }
+}
+
+/** The status a translated step is recorded with. */
+export function retrievalStepStatus(event: RetrievalEvent): 'done' | 'failed' {
+  return event.kind === 'query' && event.failed ? 'failed' : 'done'
+}

--- a/src/lib/services/ai/retrieval/tier3Selection.test.ts
+++ b/src/lib/services/ai/retrieval/tier3Selection.test.ts
@@ -5,6 +5,14 @@ import type { StoryEntry } from '$lib/types'
 // and fails to import under `environment: 'node'`. Mocked rather than worked around: the LLM
 // call is not what these tests are about, and stubbing it is what makes the failure path
 // reachable at all.
+vi.mock('$lib/stores/activity.svelte', () => ({
+  activity: {
+    startStep: vi.fn(() => ''),
+    endStep: vi.fn(),
+    recordStep: vi.fn(() => ''),
+  },
+}))
+
 vi.mock('$lib/stores/debug.svelte', () => ({
   debug: { addDebugRequest: vi.fn(), addDebugResponse: vi.fn() },
 }))
@@ -39,6 +47,7 @@ import {
   type Tier3SelectionResult,
 } from './tier3Selection'
 import { TIER3_SELECTION_CACHE_POSITIONS } from '../core/defaults'
+import { activity } from '$lib/stores/activity.svelte'
 
 /** A candidate list in the order the prompt was built from. */
 const candidates = [
@@ -437,5 +446,69 @@ describe('runTier3Selection caching', () => {
     await runTier3Selection({ ...cachedRequest, currentPosition: 100 })
 
     expect(generateStructured).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('runTier3Selection activity reporting', () => {
+  const request = {
+    storyId: 'story-1',
+    candidates: [
+      { id: 'a-uuid', type: 'character', name: 'Aria', description: 'A swordswoman.' },
+      { id: 'b-uuid', type: 'location', name: 'The Tower', description: null },
+    ],
+    userInput: 'She climbs the tower.',
+    recentEntries: [{ type: 'narration', content: 'The tower loomed.' } as StoryEntry],
+    recentEntriesCount: 5,
+    presetId: 'entryRetrieval',
+    serviceLabel: 'tier3-activity-selection',
+    activityParentId: 'parent-step',
+  }
+
+  beforeEach(() => {
+    vi.mocked(activity.startStep).mockClear()
+    vi.mocked(activity.endStep).mockClear()
+    vi.mocked(activity.recordStep).mockClear()
+  })
+
+  it('records nothing when there are no candidates to select from', async () => {
+    await runTier3Selection({ ...request, candidates: [] })
+
+    expect(activity.startStep).not.toHaveBeenCalled()
+    expect(activity.recordStep).not.toHaveBeenCalled()
+  })
+
+  it('records the selection as an LLM step nested under its caller', async () => {
+    generateStructured.mockResolvedValue({ selectedIndices: ['1'] })
+
+    await runTier3Selection(request)
+
+    expect(activity.startStep).toHaveBeenCalledWith('Tier 3 selection', {
+      parentId: 'parent-step',
+      isLLM: true,
+      detail: '2 candidates',
+    })
+    expect(activity.endStep).toHaveBeenCalledWith('', 'done', '1 of 2')
+  })
+
+  it('records a failed selection as failed', async () => {
+    generateStructured.mockRejectedValue(new Error('boom'))
+
+    await runTier3Selection(request)
+
+    expect(activity.endStep).toHaveBeenCalledWith('', 'failed')
+  })
+
+  it('records a cache hit as a finished step that cost no model call', async () => {
+    generateStructured.mockResolvedValue({ selectedIndices: ['0'] })
+    await runTier3Selection({ ...request, currentPosition: 100 })
+    vi.mocked(activity.recordStep).mockClear()
+
+    await runTier3Selection({ ...request, currentPosition: 100 })
+
+    expect(generateStructured).toHaveBeenCalledTimes(1)
+    expect(activity.recordStep).toHaveBeenCalledWith('Tier 3 selection', {
+      parentId: 'parent-step',
+      detail: 'cached · 1 of 2',
+    })
   })
 })

--- a/src/lib/services/ai/retrieval/tier3Selection.test.ts
+++ b/src/lib/services/ai/retrieval/tier3Selection.test.ts
@@ -8,6 +8,7 @@ import type { StoryEntry } from '$lib/types'
 vi.mock('$lib/stores/activity.svelte', () => ({
   activity: {
     startStep: vi.fn(() => ''),
+    updateStep: vi.fn(),
     endStep: vi.fn(),
     recordStep: vi.fn(() => ''),
   },

--- a/src/lib/services/ai/retrieval/tier3Selection.ts
+++ b/src/lib/services/ai/retrieval/tier3Selection.ts
@@ -19,6 +19,8 @@ import { generateStructured } from '../sdk/generate'
 import { recentContent, AS_PROSE } from '$lib/utils/recentContent'
 import { TIER3_SELECTION_CACHE_POSITIONS } from '../core/defaults'
 
+import { activity } from '$lib/stores/activity.svelte'
+
 const log = createLogger('Tier3Selection')
 
 /**
@@ -61,6 +63,8 @@ export interface Tier3SelectionRequest {
    * a text comparison stops recognising it exactly when the two diverge.
    */
   userActionEntryId?: string
+  /** Step this selection nests under in the activity record. */
+  activityParentId?: string
   /**
    * Current story position, used to age the selection cache. Omit to bypass the cache — a
    * caller that cannot say "when" cannot say whether a hit is still fresh.
@@ -159,6 +163,7 @@ export async function runTier3Selection({
   presetId,
   serviceLabel,
   userActionEntryId,
+  activityParentId,
   currentPosition,
   signal,
 }: Tier3SelectionRequest): Promise<Tier3SelectionResult | null> {
@@ -190,6 +195,10 @@ export async function runTier3Selection({
       candidates: candidates.length,
       selected: cached.result.selectedIndices.size,
     })
+    activity.recordStep('Tier 3 selection', {
+      parentId: activityParentId,
+      detail: `cached · ${cached.result.selectedIndices.size} of ${candidates.length}`,
+    })
     return cached.result
   }
 
@@ -214,6 +223,12 @@ export async function runTier3Selection({
   })
   const { system, user: prompt } = await ctx.render('tier3-entry-selection')
 
+  const stepId = activity.startStep('Tier 3 selection', {
+    parentId: activityParentId,
+    isLLM: true,
+    detail: `${candidates.length} candidates`,
+  })
+
   try {
     const result = await generateStructured(
       { presetId, schema: entitySelectionSchema, system, prompt, signal },
@@ -230,10 +245,15 @@ export async function runTier3Selection({
         result: selection,
       })
     }
+    activity.endStep(stepId, 'done', `${selection.selectedIndices.size} of ${candidates.length}`)
     return selection
   } catch (error) {
     // Not cached: a failure says nothing about which candidates matter, and storing it
     // would suppress the retry that might succeed.
+    activity.endStep(
+      stepId,
+      error instanceof Error && error.name === 'AbortError' ? 'skipped' : 'failed',
+    )
     log('Tier 3 LLM selection failed', error)
     return null
   }

--- a/src/lib/services/generation/GenerationPipeline.ts
+++ b/src/lib/services/generation/GenerationPipeline.ts
@@ -42,6 +42,7 @@ import {
   type BackgroundImageSettings,
 } from './phases/BackgroundImagePhase'
 import { mergeGenerators } from '$lib/utils/async'
+import { NO_ACTIVITY, trackPhase, type ActivityReporter } from '$lib/services/activity'
 import { sameEntityName } from '$lib/utils/text'
 
 export interface PipelineDependencies
@@ -94,6 +95,18 @@ export class GenerationPipeline {
   private imagePhase: ImagePhase
   private postPhase: PostGenerationPhase
 
+  /** Absent wherever reporting is not wired; see NO_ACTIVITY. */
+  private get activity(): ActivityReporter {
+    return this.deps.activity ?? NO_ACTIVITY
+  }
+
+  private tracked<R>(
+    label: string,
+    phase: AsyncGenerator<GenerationEvent, R>,
+  ): AsyncGenerator<GenerationEvent, R> {
+    return trackPhase(this.activity, label, phase)
+  }
+
   constructor(private deps: PipelineDependencies) {
     this.narrativePhase = new NarrativePhase(deps)
     this.backgroundPhase = new BackgroundImagePhase(deps)
@@ -125,12 +138,17 @@ export class GenerationPipeline {
         rawInput: cfg.rawInput,
         actionType: cfg.actionType,
         wasRawActionChoice: cfg.wasRawActionChoice,
+        activity: this.activity,
       })
       if (ctx.abortSignal?.aborted) return { ...r, aborted: true }
 
       let retrieval: RetrievalResult
       if (cfg.cachedRetrievalResult) {
         log('Using cached retrieval result (regenerate)')
+        this.activity.recordStep('Retrieval', {
+          status: 'skipped',
+          detail: 'reused from last turn',
+        })
         yield { type: 'phase_start', phase: 'retrieval' } as GenerationEvent
         retrieval = cfg.cachedRetrievalResult
         yield { type: 'phase_complete', phase: 'retrieval', result: retrieval } as GenerationEvent
@@ -166,26 +184,32 @@ export class GenerationPipeline {
           r.preGeneration?.visualProseMode ?? false,
         ),
         // Independent phases
-        background: this.backgroundPhase.execute({
-          storyId: ctx.story.id,
-          storyEntries: ctx.visibleEntries,
-          imageSettings: cfg.imageSettings,
-          abortSignal: ctx.abortSignal,
-        }),
-        postGeneration: this.postPhase.execute({
-          isCreativeMode: cfg.storyMode === 'creative-writing',
-          disableSuggestions: cfg.disableSuggestions,
-          storyId: ctx.story.id,
-          entries: ctx.visibleEntries,
-          activeThreads: cfg.activeThreads,
-          lorebookEntries: ctx.worldState.lorebookEntries,
-          promptContext: cfg.promptContext,
-          worldState: ctx.worldState,
-          narrativeResponse: r.narrative.content,
-          pov: cfg.pov,
-          translationSettings: cfg.translationSettings,
-          abortSignal: ctx.abortSignal,
-        }),
+        background: this.tracked(
+          'Background image',
+          this.backgroundPhase.execute({
+            storyId: ctx.story.id,
+            storyEntries: ctx.visibleEntries,
+            imageSettings: cfg.imageSettings,
+            abortSignal: ctx.abortSignal,
+          }),
+        ),
+        postGeneration: this.tracked(
+          cfg.storyMode === 'creative-writing' ? 'Suggestions' : 'Action choices',
+          this.postPhase.execute({
+            isCreativeMode: cfg.storyMode === 'creative-writing',
+            disableSuggestions: cfg.disableSuggestions,
+            storyId: ctx.story.id,
+            entries: ctx.visibleEntries,
+            activeThreads: cfg.activeThreads,
+            lorebookEntries: ctx.worldState.lorebookEntries,
+            promptContext: cfg.promptContext,
+            worldState: ctx.worldState,
+            narrativeResponse: r.narrative.content,
+            pov: cfg.pov,
+            translationSettings: cfg.translationSettings,
+            abortSignal: ctx.abortSignal,
+          }),
+        ),
       })
 
       r.classification = allPhases.imagePipeline.classification
@@ -222,23 +246,29 @@ export class GenerationPipeline {
     }
   > {
     const imageDeps = yield* mergeGenerators({
-      classification: this.classificationPhase.execute({
-        narrativeContent,
-        narrativeEntryId: ctx.userAction.entryId,
-        userActionContent: ctx.userAction.content,
-        worldState: ctx.worldState,
-        story: ctx.story,
-        visibleEntries: ctx.visibleEntries,
-        abortSignal: ctx.abortSignal,
-      }),
-      translation: this.translationPhase.execute({
-        storyId: ctx.story.id,
-        narrativeContent,
-        narrativeEntryId: ctx.userAction.entryId,
-        isVisualProse,
-        translationSettings: cfg.translationSettings,
-        abortSignal: ctx.abortSignal,
-      }),
+      classification: this.tracked(
+        'Classification',
+        this.classificationPhase.execute({
+          narrativeContent,
+          narrativeEntryId: ctx.userAction.entryId,
+          userActionContent: ctx.userAction.content,
+          worldState: ctx.worldState,
+          story: ctx.story,
+          visibleEntries: ctx.visibleEntries,
+          abortSignal: ctx.abortSignal,
+        }),
+      ),
+      translation: this.tracked(
+        'Translation',
+        this.translationPhase.execute({
+          storyId: ctx.story.id,
+          narrativeContent,
+          narrativeEntryId: ctx.userAction.entryId,
+          isVisualProse,
+          translationSettings: cfg.translationSettings,
+          abortSignal: ctx.abortSignal,
+        }),
+      ),
     })
 
     if (ctx.abortSignal?.aborted) {
@@ -256,7 +286,7 @@ export class GenerationPipeline {
       imageDeps.classification,
       imageDeps.translation,
     )
-    const image = yield* this.imagePhase.execute(imageInput)
+    const image = yield* this.tracked('Images', this.imagePhase.execute(imageInput))
 
     return {
       classification: imageDeps.classification,

--- a/src/lib/services/generation/GenerationPipeline.ts
+++ b/src/lib/services/generation/GenerationPipeline.ts
@@ -100,11 +100,17 @@ export class GenerationPipeline {
     return this.deps.activity ?? NO_ACTIVITY
   }
 
+  /**
+   * Open the phase's step, then let the phase report inside it. The container is never marked
+   * as an LLM step: most of these can skip without calling a model at all, so the marker
+   * belongs on what the phase actually did.
+   */
   private tracked<R>(
     label: string,
-    phase: AsyncGenerator<GenerationEvent, R>,
+    build: (parentId: string) => AsyncGenerator<GenerationEvent, R>,
   ): AsyncGenerator<GenerationEvent, R> {
-    return trackPhase(this.activity, label, phase)
+    const id = this.activity.startStep(label)
+    return trackPhase(this.activity, id, build(id))
   }
 
   constructor(private deps: PipelineDependencies) {
@@ -172,6 +178,10 @@ export class GenerationPipeline {
       })
       if (!r.narrative || ctx.abortSignal?.aborted) return { ...r, aborted: true }
 
+      // Read once: the phases below take it inside closures, where the narrowing above
+      // no longer reaches.
+      const narrativeContent = r.narrative.content
+
       // All post-narrative phases run in parallel. Image needs classification
       // + translation results, so it chains after them via imagePipeline.
       // Background and postGeneration are fully independent.
@@ -180,12 +190,11 @@ export class GenerationPipeline {
         imagePipeline: this.runImagePipeline(
           ctx,
           cfg,
-          r.narrative!.content,
+          narrativeContent,
           r.preGeneration?.visualProseMode ?? false,
         ),
         // Independent phases
-        background: this.tracked(
-          'Background image',
+        background: this.tracked('Background image', () =>
           this.backgroundPhase.execute({
             storyId: ctx.story.id,
             storyEntries: ctx.visibleEntries,
@@ -195,20 +204,23 @@ export class GenerationPipeline {
         ),
         postGeneration: this.tracked(
           cfg.storyMode === 'creative-writing' ? 'Suggestions' : 'Action choices',
-          this.postPhase.execute({
-            isCreativeMode: cfg.storyMode === 'creative-writing',
-            disableSuggestions: cfg.disableSuggestions,
-            storyId: ctx.story.id,
-            entries: ctx.visibleEntries,
-            activeThreads: cfg.activeThreads,
-            lorebookEntries: ctx.worldState.lorebookEntries,
-            promptContext: cfg.promptContext,
-            worldState: ctx.worldState,
-            narrativeResponse: r.narrative.content,
-            pov: cfg.pov,
-            translationSettings: cfg.translationSettings,
-            abortSignal: ctx.abortSignal,
-          }),
+          (parentId) =>
+            this.postPhase.execute({
+              activity: this.activity,
+              activityParentId: parentId,
+              isCreativeMode: cfg.storyMode === 'creative-writing',
+              disableSuggestions: cfg.disableSuggestions,
+              storyId: ctx.story.id,
+              entries: ctx.visibleEntries,
+              activeThreads: cfg.activeThreads,
+              lorebookEntries: ctx.worldState.lorebookEntries,
+              promptContext: cfg.promptContext,
+              worldState: ctx.worldState,
+              narrativeResponse: narrativeContent,
+              pov: cfg.pov,
+              translationSettings: cfg.translationSettings,
+              abortSignal: ctx.abortSignal,
+            }),
         ),
       })
 
@@ -246,9 +258,10 @@ export class GenerationPipeline {
     }
   > {
     const imageDeps = yield* mergeGenerators({
-      classification: this.tracked(
-        'Classification',
+      classification: this.tracked('Classification', (parentId) =>
         this.classificationPhase.execute({
+          activity: this.activity,
+          activityParentId: parentId,
           narrativeContent,
           narrativeEntryId: ctx.userAction.entryId,
           userActionContent: ctx.userAction.content,
@@ -258,9 +271,10 @@ export class GenerationPipeline {
           abortSignal: ctx.abortSignal,
         }),
       ),
-      translation: this.tracked(
-        'Translation',
+      translation: this.tracked('Translation', (parentId) =>
         this.translationPhase.execute({
+          activity: this.activity,
+          activityParentId: parentId,
           storyId: ctx.story.id,
           narrativeContent,
           narrativeEntryId: ctx.userAction.entryId,
@@ -286,7 +300,7 @@ export class GenerationPipeline {
       imageDeps.classification,
       imageDeps.translation,
     )
-    const image = yield* this.tracked('Images', this.imagePhase.execute(imageInput))
+    const image = yield* this.tracked('Images', () => this.imagePhase.execute(imageInput))
 
     return {
       classification: imageDeps.classification,

--- a/src/lib/services/generation/phases/ClassificationPhase.ts
+++ b/src/lib/services/generation/phases/ClassificationPhase.ts
@@ -20,6 +20,8 @@ import type { Story, StoryEntry, TimeTracker } from '$lib/types'
 import type { ClassificationResult } from '$lib/services/ai/sdk/schemas/classifier'
 
 /** Dependencies for classification phase - injected to avoid tight coupling */
+import { NO_ACTIVITY, type ActivityReporter } from '$lib/services/activity'
+
 export interface ClassificationDependencies {
   classifyResponse: (
     narrativeResponse: string,
@@ -40,6 +42,9 @@ export interface ClassificationInput {
   story: Story | null | undefined
   visibleEntries: StoryEntry[]
   abortSignal?: AbortSignal
+  activity?: ActivityReporter
+  /** Step this phase's own reporting nests under. */
+  activityParentId?: string | null
 }
 
 /** Result from classification phase */
@@ -81,14 +86,29 @@ export class ClassificationPhase {
       // (once in chatHistory, once as narrativeResponse)
       const chatHistoryEntries = visibleEntries.filter((e) => e.id !== narrativeEntryId)
 
-      const classificationResult = await this.deps.classifyResponse(
-        narrativeContent,
-        userActionContent,
-        worldState,
-        story,
-        chatHistoryEntries,
-        story?.timeTracker,
-      )
+      const activity = input.activity ?? NO_ACTIVITY
+      const callId = activity.startStep('Classifying', {
+        parentId: input.activityParentId,
+        isLLM: true,
+      })
+      let classificationResult
+      try {
+        classificationResult = await this.deps.classifyResponse(
+          narrativeContent,
+          userActionContent,
+          worldState,
+          story,
+          chatHistoryEntries,
+          story?.timeTracker,
+        )
+        activity.endStep(callId)
+      } catch (error) {
+        activity.endStep(
+          callId,
+          error instanceof Error && error.name === 'AbortError' ? 'skipped' : 'failed',
+        )
+        throw error
+      }
 
       if (abortSignal?.aborted) {
         yield { type: 'aborted', phase: 'classification' } satisfies AbortedEvent

--- a/src/lib/services/generation/phases/NarrativePhase.test.ts
+++ b/src/lib/services/generation/phases/NarrativePhase.test.ts
@@ -187,3 +187,111 @@ describe('NarrativePhase', () => {
     })
   })
 })
+
+describe('NarrativePhase activity reporting', () => {
+  /** Records what the phase reported, in order, as `label` + final status. */
+  function recordingReporter() {
+    const steps: { id: string; label: string; status?: string; detail?: string }[] = []
+    let n = 0
+    return {
+      steps,
+      reporter: {
+        startStep: (label: string, options: any = {}) => {
+          const id = `s${++n}`
+          steps.push({ id, label, detail: options.detail })
+          return id
+        },
+        endStep: (id: string, status = 'done', detail?: string) => {
+          const step = steps.find((s) => s.id === id)
+          if (!step || step.status) return
+          step.status = status
+          if (detail !== undefined) step.detail = detail
+        },
+        recordStep: () => '',
+      },
+    }
+  }
+
+  const phaseReporting = (streamNarrative: any, activity: any) =>
+    new NarrativePhase({ streamNarrative, activity })
+
+  it('reports the wait for the model, ending it at the first chunk that carries anything', async () => {
+    const { steps, reporter } = recordingReporter()
+    const stream = streamOf(
+      chunk({ reasoning: 'thinking' }),
+      chunk({ content: 'The dragon fell.' }),
+      chunk({ done: true }),
+    )
+
+    await drain(phaseReporting(stream, reporter).execute(makeInput()))
+
+    expect(steps.map((s) => s.label)).toEqual(['Narrative', 'Generating', 'Waiting for model'])
+    const wait = steps.find((s) => s.label === 'Waiting for model')!
+    expect(wait.status).toBe('done')
+    // Ended by the reasoning chunk, so it is not still open when content arrives.
+    expect(wait.detail).toBeUndefined()
+  })
+
+  it('marks the wait as having produced no tokens when the stream is empty', async () => {
+    const { steps, reporter } = recordingReporter()
+
+    await drain(phaseReporting(streamOf(chunk({ done: true })), reporter).execute(makeInput()))
+
+    expect(steps.find((s) => s.label === 'Waiting for model')?.detail).toBe('no tokens')
+  })
+
+  it('reports the generating attempt as an LLM step with its chunk count', async () => {
+    const { steps, reporter } = recordingReporter()
+    const stream = streamOf(chunk({ content: 'Hi.' }), chunk({ done: true }))
+
+    await drain(phaseReporting(stream, reporter).execute(makeInput()))
+
+    const attempt = steps.find((s) => s.label === 'Generating')!
+    expect(attempt.status).toBe('done')
+    expect(attempt.detail).toBe('2 chunks')
+  })
+
+  it('reports each empty attempt separately without changing the retry loop', async () => {
+    const { steps, reporter } = recordingReporter()
+    const streamNarrative = vi.fn(streamOf(chunk({ content: '' }), chunk({ done: true })))
+
+    const { events, result } = await drain(
+      phaseReporting(streamNarrative, reporter).execute(makeInput()),
+    )
+
+    // Unchanged behaviour: still three attempts, still a fatal error, still no result.
+    expect(streamNarrative).toHaveBeenCalledTimes(3)
+    expect(result).toBeNull()
+    expect(events.at(-1)).toMatchObject({ type: 'error', phase: 'narrative', fatal: true })
+
+    const attempts = steps.filter(
+      (s) => s.label.startsWith('Generating') || s.label.startsWith('Attempt'),
+    )
+    expect(attempts.map((s) => s.label)).toEqual(['Generating', 'Attempt 2', 'Attempt 3'])
+    expect(attempts.every((s) => s.detail === 'empty response')).toBe(true)
+    expect(steps.find((s) => s.label === 'Narrative')).toMatchObject({
+      status: 'failed',
+      detail: 'empty after 3 attempts',
+    })
+  })
+
+  it('leaves no step running when the stream throws', async () => {
+    const { steps, reporter } = recordingReporter()
+    const streamNarrative = async function* (): AsyncGenerator<StreamChunk> {
+      throw new Error('provider exploded')
+    }
+
+    await drain(phaseReporting(streamNarrative, reporter).execute(makeInput()))
+
+    expect(steps.every((s) => s.status !== undefined)).toBe(true)
+    expect(steps.find((s) => s.label === 'Narrative')?.status).toBe('failed')
+  })
+
+  it('records nothing when no reporter is injected', async () => {
+    const stream = streamOf(chunk({ content: 'Hi.' }), chunk({ done: true }))
+
+    const { result } = await drain(phaseWith(stream).execute(makeInput()))
+
+    expect(result?.content).toBe('Hi.')
+  })
+})

--- a/src/lib/services/generation/phases/NarrativePhase.ts
+++ b/src/lib/services/generation/phases/NarrativePhase.ts
@@ -21,11 +21,14 @@ import type {
 import type { Story, StoryEntry } from '$lib/types'
 import type { StyleReviewResult } from '$lib/services/ai/generation/StyleReviewerService'
 import type { StreamChunk } from '$lib/services/ai/core/types'
+import { NO_ACTIVITY, type ActivityReporter } from '$lib/services/activity'
 
 const MAX_EMPTY_RESPONSE_RETRIES = 3
 
 /** Dependencies for narrative phase - injected to avoid tight coupling */
 export interface NarrativeDependencies {
+  /** Absent in tests and anywhere reporting is not wired; see NO_ACTIVITY. */
+  activity?: ActivityReporter
   streamNarrative: (
     entries: StoryEntry[],
     worldState: WorldState,
@@ -46,6 +49,8 @@ export interface NarrativeInput {
   retrievalResult: RetrievalResult
   styleReview: StyleReviewResult | null | undefined
   abortSignal?: AbortSignal
+  /** Step this phase nests under. */
+  activityParentId?: string | null
 }
 
 /** Result from narrative phase */
@@ -68,6 +73,8 @@ export class NarrativePhase {
     yield { type: 'phase_start', phase: 'narrative' } satisfies PhaseStartEvent
 
     const { visibleEntries, worldState, story, retrievalResult, styleReview, abortSignal } = input
+    const activity = this.deps.activity ?? NO_ACTIVITY
+    const narrativeStepId = activity.startStep('Narrative', { parentId: input.activityParentId })
 
     let fullResponse = ''
     let fullReasoning = ''
@@ -76,6 +83,7 @@ export class NarrativePhase {
 
     while (retryCount < MAX_EMPTY_RESPONSE_RETRIES) {
       if (abortSignal?.aborted) {
+        activity.endStep(narrativeStepId, 'skipped')
         yield { type: 'aborted', phase: 'narrative' } satisfies AbortedEvent
         return null
       }
@@ -83,6 +91,16 @@ export class NarrativePhase {
       fullResponse = ''
       fullReasoning = ''
       chunkCount = 0
+
+      // An attempt is its own step: the loop is otherwise silent, so three empty responses
+      // read as one long wait with nothing to show for it.
+      const attemptId = activity.startStep(
+        retryCount > 0 ? `Attempt ${retryCount + 1}` : 'Generating',
+        { parentId: narrativeStepId, isLLM: true },
+      )
+      // Closed at the first chunk carrying anything, so the wait for the model is separable
+      // from the time spent streaming.
+      let waitId = activity.startStep('Waiting for model', { parentId: attemptId })
 
       try {
         for await (const chunk of this.deps.streamNarrative(
@@ -96,8 +114,16 @@ export class NarrativePhase {
           retrievalResult.worldStateBlock,
         )) {
           if (abortSignal?.aborted) {
+            activity.endStep(waitId, 'skipped')
+            activity.endStep(attemptId, 'skipped')
+            activity.endStep(narrativeStepId, 'skipped')
             yield { type: 'aborted', phase: 'narrative' } satisfies AbortedEvent
             return null
+          }
+
+          if (waitId && (chunk.content || chunk.reasoning)) {
+            activity.endStep(waitId)
+            waitId = ''
           }
 
           chunkCount++
@@ -124,12 +150,19 @@ export class NarrativePhase {
           }
         }
 
+        activity.endStep(waitId, 'done', 'no tokens')
         if (fullResponse.trim()) {
+          activity.endStep(attemptId, 'done', `${chunkCount} chunks`)
           break // Success
         }
+        activity.endStep(attemptId, 'done', 'empty response')
         retryCount++
       } catch (error) {
-        if (error instanceof Error && error.name === 'AbortError') {
+        const aborted = error instanceof Error && error.name === 'AbortError'
+        activity.endStep(waitId, aborted ? 'skipped' : 'failed')
+        activity.endStep(attemptId, aborted ? 'skipped' : 'failed')
+        activity.endStep(narrativeStepId, aborted ? 'skipped' : 'failed')
+        if (aborted) {
           yield { type: 'aborted', phase: 'narrative' } satisfies AbortedEvent
           return null
         }
@@ -144,11 +177,17 @@ export class NarrativePhase {
     }
 
     if (abortSignal?.aborted) {
+      activity.endStep(narrativeStepId, 'skipped')
       yield { type: 'aborted', phase: 'narrative' } satisfies AbortedEvent
       return null
     }
 
     if (!fullResponse.trim()) {
+      activity.endStep(
+        narrativeStepId,
+        'failed',
+        `empty after ${MAX_EMPTY_RESPONSE_RETRIES} attempts`,
+      )
       yield {
         type: 'error',
         phase: 'narrative',
@@ -163,6 +202,8 @@ export class NarrativePhase {
       reasoning: fullReasoning,
       chunkCount,
     }
+
+    activity.endStep(narrativeStepId)
 
     yield {
       type: 'phase_complete',

--- a/src/lib/services/generation/phases/PostGenerationPhase.test.ts
+++ b/src/lib/services/generation/phases/PostGenerationPhase.test.ts
@@ -239,3 +239,93 @@ describe('PostGenerationPhase', () => {
     expect(events.map((e) => e.type)).toEqual(['phase_start', 'aborted'])
   })
 })
+
+describe('PostGenerationPhase activity reporting', () => {
+  /** Records the label and LLM marker of every step opened. */
+  function recordingReporter() {
+    const steps: { label: string; isLLM: boolean; parentId?: string | null; status?: string }[] = []
+    return {
+      steps,
+      reporter: {
+        startStep: (label: string, options: any = {}) => {
+          steps.push({ label, isLLM: !!options.isLLM, parentId: options.parentId })
+          return `s${steps.length}`
+        },
+        endStep: (id: string, status = 'done') => {
+          const step = steps[Number(id.slice(1)) - 1]
+          if (step && !step.status) step.status = status
+        },
+        recordStep: () => '',
+        updateStep: () => {},
+      },
+    }
+  }
+
+  it('marks the action-choice call as an LLM step under the phase', async () => {
+    const { steps, reporter } = recordingReporter()
+    const generateActionChoices = vi.fn().mockResolvedValue({ choices })
+
+    await drain(
+      new PostGenerationPhase(makeDeps({ generateActionChoices })).execute(
+        makeInput({ activity: reporter, activityParentId: 'phase-step' }),
+      ),
+    )
+
+    expect(steps).toEqual([
+      { label: 'Generating action choices', isLLM: true, parentId: 'phase-step', status: 'done' },
+    ])
+  })
+
+  it('marks the follow-up translation as its own LLM step', async () => {
+    const { steps, reporter } = recordingReporter()
+    const generateActionChoices = vi.fn().mockResolvedValue({ choices })
+    const translateActionChoices = vi.fn().mockResolvedValue(choices)
+
+    await drain(
+      new PostGenerationPhase(makeDeps({ generateActionChoices, translateActionChoices })).execute(
+        makeInput({
+          activity: reporter,
+          activityParentId: 'phase-step',
+          translationSettings: italian,
+        }),
+      ),
+    )
+
+    expect(steps.map((s) => s.label)).toEqual([
+      'Generating action choices',
+      'Translating action choices',
+    ])
+    expect(steps.every((s) => s.isLLM)).toBe(true)
+  })
+
+  it('records a failed translation as failed, and still returns the untranslated choices', async () => {
+    const { steps, reporter } = recordingReporter()
+    const generateActionChoices = vi.fn().mockResolvedValue({ choices })
+    const translateActionChoices = vi.fn().mockRejectedValue(new Error('boom'))
+
+    const { result } = await drain(
+      new PostGenerationPhase(makeDeps({ generateActionChoices, translateActionChoices })).execute(
+        makeInput({
+          activity: reporter,
+          activityParentId: 'phase-step',
+          translationSettings: italian,
+        }),
+      ),
+    )
+
+    expect(steps.find((s) => s.label === 'Translating action choices')?.status).toBe('failed')
+    expect(result.actionChoices).toEqual(choices)
+  })
+
+  it('reports nothing when suggestions are disabled, so no model call is implied', async () => {
+    const { steps, reporter } = recordingReporter()
+
+    await drain(
+      new PostGenerationPhase(makeDeps({})).execute(
+        makeInput({ activity: reporter, activityParentId: 'phase-step', disableSuggestions: true }),
+      ),
+    )
+
+    expect(steps).toEqual([])
+  })
+})

--- a/src/lib/services/generation/phases/PostGenerationPhase.ts
+++ b/src/lib/services/generation/phases/PostGenerationPhase.ts
@@ -50,6 +50,8 @@ export interface PostWorldState {
 }
 
 /** Dependencies for post-generation phase */
+import { NO_ACTIVITY, trackStep, type ActivityReporter } from '$lib/services/activity'
+
 export interface PostGenerationDependencies {
   generateSuggestions: (
     entries: StoryEntry[],
@@ -94,6 +96,9 @@ export interface PostGenerationInput {
   pov: 'first' | 'second' | 'third'
   translationSettings: TranslationSettings
   abortSignal?: AbortSignal
+  activity?: ActivityReporter
+  /** Step this phase's own reporting nests under. */
+  activityParentId?: string | null
 }
 
 /** Result from post-generation phase */
@@ -153,20 +158,23 @@ export class PostGenerationPhase {
       narrativeResponse,
       translationSettings,
     } = input
-    const { suggestions } = await this.deps.generateSuggestions(
-      entries,
-      activeThreads,
-      lorebookEntries,
-      narrativeResponse,
-      storyId,
+    const llm = { parentId: input.activityParentId, isLLM: true }
+    const activity = input.activity ?? NO_ACTIVITY
+
+    const { suggestions } = await trackStep(activity, 'Generating suggestions', llm, () =>
+      this.deps.generateSuggestions(
+        entries,
+        activeThreads,
+        lorebookEntries,
+        narrativeResponse,
+        storyId,
+      ),
     )
 
     if (TranslationService.shouldTranslate(translationSettings)) {
       try {
-        return await this.deps.translateSuggestions(
-          suggestions,
-          translationSettings.targetLanguage,
-          storyId,
+        return await trackStep(activity, 'Translating suggestions', llm, () =>
+          this.deps.translateSuggestions(suggestions, translationSettings.targetLanguage, storyId),
         )
       } catch {
         return suggestions
@@ -186,22 +194,25 @@ export class PostGenerationPhase {
       pov,
       translationSettings,
     } = input
-    const { choices } = await this.deps.generateActionChoices(
-      entries,
-      worldState,
-      narrativeResponse,
-      lorebookEntries,
-      promptContext,
-      pov,
-      storyId,
+    const llm = { parentId: input.activityParentId, isLLM: true }
+    const activity = input.activity ?? NO_ACTIVITY
+
+    const { choices } = await trackStep(activity, 'Generating action choices', llm, () =>
+      this.deps.generateActionChoices(
+        entries,
+        worldState,
+        narrativeResponse,
+        lorebookEntries,
+        promptContext,
+        pov,
+        storyId,
+      ),
     )
 
     if (TranslationService.shouldTranslate(translationSettings)) {
       try {
-        return await this.deps.translateActionChoices(
-          choices,
-          translationSettings.targetLanguage,
-          storyId,
+        return await trackStep(activity, 'Translating action choices', llm, () =>
+          this.deps.translateActionChoices(choices, translationSettings.targetLanguage, storyId),
         )
       } catch {
         return choices

--- a/src/lib/services/generation/phases/PreGenerationPhase.ts
+++ b/src/lib/services/generation/phases/PreGenerationPhase.ts
@@ -22,6 +22,7 @@ import type {
   TimeTracker,
   ActionInputType,
 } from '$lib/types'
+import { NO_ACTIVITY, type ActivityReporter } from '$lib/services/activity'
 
 /**
  * Data needed for retry backup - prepared by this phase, applied by caller
@@ -58,6 +59,9 @@ export interface PreGenerationInput {
   rawInput: string
   actionType: ActionInputType
   wasRawActionChoice: boolean
+  activity?: ActivityReporter
+  /** Step this phase nests under. */
+  activityParentId?: string | null
 }
 
 /**
@@ -81,6 +85,8 @@ export class PreGenerationPhase {
 
     const { context, rawInput, actionType, wasRawActionChoice } = input
     const { story, worldState } = context
+    const activity = input.activity ?? NO_ACTIVITY
+    const stepId = activity.startStep('Preparing', { parentId: input.activityParentId })
 
     // Prepare retry backup data
     // The actual backup is created by the caller using ui.createRetryBackup()
@@ -110,6 +116,8 @@ export class PreGenerationPhase {
       visualProseMode,
       streamingEntryId,
     }
+
+    activity.endStep(stepId)
 
     // Emit phase complete
     yield {

--- a/src/lib/services/generation/phases/RetrievalPhase.ts
+++ b/src/lib/services/generation/phases/RetrievalPhase.ts
@@ -28,9 +28,12 @@ import {
   type ContextEntity,
 } from '$lib/services/ai/retrieval/alreadyInContext'
 import { joinPromptBlocks } from '$lib/utils/promptBlocks'
+import { NO_ACTIVITY, type ActivityReporter } from '$lib/services/activity'
 
 /** Dependencies injected from AIService - phase calls these methods rather than duplicating logic */
 export interface RetrievalDependencies {
+  /** Absent in tests and anywhere reporting is not wired; see NO_ACTIVITY. */
+  activity?: ActivityReporter
   shouldUseAgenticRetrieval: () => boolean
   runAgenticRetrieval: (options: {
     userInput: string
@@ -42,11 +45,13 @@ export interface RetrievalDependencies {
     currentStoryTime?: GenerationContext['story']['timeTracker']
     alreadyInContext?: string
     signal?: AbortSignal
+    activityParentId?: string
   }) => Promise<AgenticRetrievalResult>
   runTimelineFill: (
     visibleEntries: GenerationContext['visibleEntries'],
     chapters: GenerationContext['worldState']['chapters'],
     alreadyInContext?: string,
+    activityParentId?: string,
   ) => Promise<TimelineFillResult>
   answerChapterQuestion: (
     chapterNumber: number,
@@ -72,6 +77,8 @@ export interface RetrievalInput {
   dependencies: RetrievalDependencies
   memoryRetrievalEnabled: boolean
   activationTracker?: ActivationTracker
+  /** Step this phase nests under. */
+  activityParentId?: string | null
 }
 
 export class RetrievalPhase {
@@ -81,6 +88,8 @@ export class RetrievalPhase {
     const { context, dependencies, memoryRetrievalEnabled, activationTracker } = input
     const { worldState, visibleEntries, userAction, abortSignal, story } = context
     const { chapters, lorebookEntries, memoryConfig } = worldState
+    const activity = dependencies.activity ?? NO_ACTIVITY
+    const retrievalStepId = activity.startStep('Retrieval', { parentId: input.activityParentId })
 
     let chapterContext: string | null = null
     let lorebookContext: string | null = null
@@ -118,6 +127,8 @@ export class RetrievalPhase {
 
     const stageA: Promise<void>[] = []
 
+    const worldStateStepId = activity.startStep('World state', { parentId: retrievalStepId })
+
     stageA.push(
       dependencies
         .buildWorldStateContext(worldState, userAction.content, visibleEntries, {
@@ -126,17 +137,25 @@ export class RetrievalPhase {
           activationTracker,
           userActionEntryId: userAction.entryId,
           onSceneEntities: releaseSceneEntities,
+          activityParentId: worldStateStepId,
         })
         .then((result) => {
           worldStateResult = result
           worldStateBlock = result.contextBlock
           worldStateEntities = result.all.map((e) => ({ type: e.type, name: e.name }))
         })
-        .catch((err) => {
-          contextInventoryComplete = false
-          if (err instanceof Error && err.name === 'AbortError') return
-          console.warn('[RetrievalPhase] World state injection failed (non-fatal):', err)
-        })
+        .then(
+          () => activity.endStep(worldStateStepId),
+          (err) => {
+            contextInventoryComplete = false
+            activity.endStep(
+              worldStateStepId,
+              err instanceof Error && err.name === 'AbortError' ? 'skipped' : 'failed',
+            )
+            if (err instanceof Error && err.name === 'AbortError') return
+            console.warn('[RetrievalPhase] World state injection failed (non-fatal):', err)
+          },
+        )
         // Unblocks the lorebook pass when the world state never got as far as handing over.
         .finally(() => releaseSceneEntities([])),
     )
@@ -147,6 +166,9 @@ export class RetrievalPhase {
     // selects (`select_entry` is gone); it only reads lore while reasoning about chapters.
     // Entry selection has one owner again, so there is no skip and nothing to fall back to.
     const hasLoreContent = lorebookEntries.length > 0
+    const lorebookStepId = hasLoreContent
+      ? activity.startStep('Lorebook', { parentId: retrievalStepId })
+      : ''
     if (hasLoreContent) {
       stageA.push(
         sceneEntities
@@ -164,6 +186,7 @@ export class RetrievalPhase {
                 signal: abortSignal,
                 userActionEntryId: userAction.entryId,
                 sceneEntities: scene,
+                activityParentId: lorebookStepId,
               },
             ),
           )
@@ -175,17 +198,25 @@ export class RetrievalPhase {
               name: r.entry.name,
             }))
           })
-          .catch((err) => {
-            contextInventoryComplete = false
-            if (err instanceof Error && err.name === 'AbortError') return
-            console.warn('[RetrievalPhase] Lorebook retrieval failed (non-fatal):', err)
-          }),
+          .then(
+            () => activity.endStep(lorebookStepId),
+            (err) => {
+              contextInventoryComplete = false
+              activity.endStep(
+                lorebookStepId,
+                err instanceof Error && err.name === 'AbortError' ? 'skipped' : 'failed',
+              )
+              if (err instanceof Error && err.name === 'AbortError') return
+              console.warn('[RetrievalPhase] Lorebook retrieval failed (non-fatal):', err)
+            },
+          ),
       )
     }
 
     await Promise.all(stageA)
 
     if (abortSignal?.aborted) {
+      activity.endStep(retrievalStepId, 'skipped')
       yield { type: 'aborted', phase: 'retrieval' } satisfies AbortedEvent
       return {
         worldStateBlock: null,
@@ -220,18 +251,39 @@ export class RetrievalPhase {
         )
       }
 
+      const memoryStepId = activity.startStep(
+        useAgenticRetrieval ? 'Memory retrieval' : 'Timeline fill',
+        { parentId: retrievalStepId },
+      )
       try {
-        const result = await this.runMemoryRetrieval(input, useAgenticRetrieval, alreadyInContext)
+        const result = await this.runMemoryRetrieval(
+          input,
+          useAgenticRetrieval,
+          alreadyInContext,
+          memoryStepId,
+        )
         chapterContext = result.chapterContext
         timelineFillResult = result.timelineFillResult
+        activity.endStep(memoryStepId)
       } catch (err) {
-        if (!(err instanceof Error && err.name === 'AbortError')) {
+        const aborted = err instanceof Error && err.name === 'AbortError'
+        activity.endStep(memoryStepId, aborted ? 'skipped' : 'failed')
+        if (!aborted) {
           console.warn('[RetrievalPhase] Memory retrieval failed (non-fatal):', err)
         }
       }
+    } else {
+      // Reported rather than omitted, so a turn that did less is distinguishable from one
+      // whose reporting is incomplete.
+      activity.recordStep('Memory retrieval', {
+        parentId: retrievalStepId,
+        status: 'skipped',
+        detail: chapters.length === 0 ? 'no chapters' : 'disabled',
+      })
     }
 
     if (abortSignal?.aborted) {
+      activity.endStep(retrievalStepId, 'skipped')
       yield { type: 'aborted', phase: 'retrieval' } satisfies AbortedEvent
       return {
         worldStateBlock: null,
@@ -257,6 +309,8 @@ export class RetrievalPhase {
       combinedContext,
     }
 
+    activity.endStep(retrievalStepId)
+
     yield { type: 'phase_complete', phase: 'retrieval', result } satisfies PhaseCompleteEvent
     return result
   }
@@ -265,6 +319,7 @@ export class RetrievalPhase {
     input: RetrievalInput,
     useAgenticRetrieval: boolean,
     alreadyInContext: string,
+    activityParentId: string,
   ): Promise<{
     chapterContext: string | null
     timelineFillResult: TimelineFillResult | null
@@ -284,6 +339,7 @@ export class RetrievalPhase {
         currentStoryTime: story.timeTracker,
         alreadyInContext,
         signal: abortSignal,
+        activityParentId,
       })
       return { chapterContext: result.context || null, timelineFillResult: null }
     }
@@ -294,6 +350,7 @@ export class RetrievalPhase {
         visibleEntries,
         chapters,
         alreadyInContext,
+        activityParentId,
       ),
     }
   }

--- a/src/lib/services/generation/phases/TranslationPhase.ts
+++ b/src/lib/services/generation/phases/TranslationPhase.ts
@@ -22,6 +22,8 @@ import type { TranslationResult } from '$lib/services/ai/utils/TranslationServic
 import { TranslationService } from '$lib/services/ai/utils/TranslationService'
 
 /** Dependencies for translation phase - injected to avoid tight coupling */
+import { NO_ACTIVITY, type ActivityReporter } from '$lib/services/activity'
+
 export interface TranslationDependencies {
   translateNarration: (
     content: string,
@@ -40,6 +42,9 @@ export interface TranslationInput {
   isVisualProse: boolean
   translationSettings: TranslationSettings
   abortSignal?: AbortSignal
+  activity?: ActivityReporter
+  /** Step this phase's own reporting nests under. */
+  activityParentId?: string | null
 }
 
 /** Result from translation phase */
@@ -91,6 +96,12 @@ export class TranslationPhase {
 
     const targetLanguage = translationSettings.targetLanguage
 
+    const activity = input.activity ?? NO_ACTIVITY
+    const callId = activity.startStep(`Translating to ${targetLanguage}`, {
+      parentId: input.activityParentId,
+      isLLM: true,
+    })
+
     try {
       const translationResult = await this.deps.translateNarration(
         narrativeContent,
@@ -98,6 +109,7 @@ export class TranslationPhase {
         isVisualProse,
         storyId,
       )
+      activity.endStep(callId)
 
       if (abortSignal?.aborted) {
         yield { type: 'aborted', phase: 'translation' } satisfies AbortedEvent
@@ -122,6 +134,10 @@ export class TranslationPhase {
 
       return result
     } catch (error) {
+      activity.endStep(
+        callId,
+        error instanceof Error && error.name === 'AbortError' ? 'skipped' : 'failed',
+      )
       if (error instanceof Error && error.name === 'AbortError') {
         yield { type: 'aborted', phase: 'translation' } satisfies AbortedEvent
         return {

--- a/src/lib/stores/activity.svelte.ts
+++ b/src/lib/stores/activity.svelte.ts
@@ -1,0 +1,118 @@
+/**
+ * Activity Store
+ *
+ * Reactive shell over `ActivityRecorder`. The turn records are held non-reactively and the
+ * UI pulls them via `snapshot()` when `version` changes -- per-step reactivity on a path
+ * that appends several times a second is waste, and the same reasoning shapes `debug`.
+ *
+ * All logic lives in `$lib/services/activity`; this file only wires it to a rune.
+ */
+
+import {
+  ActivityRecorder,
+  buildTree,
+  deepestRunningStep,
+  findTurnByEntryId,
+  type ActivityNode,
+  type ActivityReporting,
+  type ActivityStatus,
+  type ActivityStep,
+  type ActivityTurn,
+  type StartStepOptions,
+} from '$lib/services/activity'
+
+class ActivityStore {
+  /** Increments on every recorded change. Read it to make a derivation reactive. */
+  version = $state(0)
+  /** Entry whose finished record the reader has opened, if any. */
+  openRecordEntryId = $state<string | null>(null)
+
+  private recorder = new ActivityRecorder(() => this.version++)
+
+  get enabled(): boolean {
+    return this.recorder.enabled
+  }
+
+  setReporting(reporting: ActivityReporting) {
+    this.recorder.setReporting(reporting)
+    this.version++
+  }
+
+  /**
+   * Recording is a bystander to the turn. Every write is guarded so a fault in the record
+   * cannot take down the generation it is describing.
+   */
+  private guard<T>(work: () => T, fallback: T): T {
+    try {
+      return work()
+    } catch (error) {
+      console.warn('[activity] Recording failed (non-fatal):', error)
+      return fallback
+    }
+  }
+
+  startTurn(entryId: string) {
+    this.guard(() => this.recorder.startTurn(entryId), undefined)
+  }
+
+  endTurn() {
+    this.guard(() => this.recorder.endTurn(), undefined)
+  }
+
+  startStep(label: string, options?: StartStepOptions): string {
+    return this.guard(() => this.recorder.startStep(label, options), '')
+  }
+
+  endStep(id: string, status?: Exclude<ActivityStatus, 'running'>, detail?: string) {
+    this.guard(() => this.recorder.endStep(id, status, detail), undefined)
+  }
+
+  recordStep(
+    label: string,
+    options?: StartStepOptions & {
+      status?: Exclude<ActivityStatus, 'running'>
+      durationMs?: number
+    },
+  ): string {
+    return this.guard(() => this.recorder.recordStep(label, options), '')
+  }
+
+  /** The turn in flight. Touches `version` so callers re-read as it grows. */
+  get activeTurn(): ActivityTurn | null {
+    void this.version
+    return this.recorder.activeTurn
+  }
+
+  /** The retained record for an entry, or null once evicted. */
+  recordFor(entryId: string): ActivityTurn | null {
+    void this.version
+    return findTurnByEntryId(this.recorder.snapshot(), entryId)
+  }
+
+  /** True while an entry's record is still retained. */
+  hasRecord(entryId: string): boolean {
+    return this.recordFor(entryId) !== null
+  }
+
+  /**
+   * The reads below touch `version` for the same reason `activeTurn` does: a turn is one
+   * object whose `steps` array is mutated in place, so nothing about it changes identity as
+   * the turn runs. Without the rune read, a `$derived` over these computes once -- against an
+   * empty step list -- and never again.
+   */
+  tree(turn: ActivityTurn): ActivityNode[] {
+    void this.version
+    return buildTree(turn.steps)
+  }
+
+  deepestRunning(turn: ActivityTurn): ActivityStep | null {
+    void this.version
+    return deepestRunningStep(turn.steps)
+  }
+
+  clear() {
+    this.recorder.clear()
+  }
+}
+
+export const activity = new ActivityStore()

--- a/src/lib/stores/activity.svelte.ts
+++ b/src/lib/stores/activity.svelte.ts
@@ -12,7 +12,6 @@ import {
   ActivityRecorder,
   buildTree,
   deepestRunningStep,
-  findTurnByEntryId,
   type ActivityNode,
   type ActivityReporting,
   type ActivityStatus,
@@ -90,7 +89,7 @@ class ActivityStore {
   /** The retained record for an entry, or null once evicted. */
   recordFor(entryId: string): ActivityTurn | null {
     void this.version
-    return findTurnByEntryId(this.recorder.snapshot(), entryId)
+    return this.recorder.find(entryId)
   }
 
   /** True while an entry's record is still retained. */

--- a/src/lib/stores/activity.svelte.ts
+++ b/src/lib/stores/activity.svelte.ts
@@ -51,8 +51,8 @@ class ActivityStore {
     }
   }
 
-  startTurn(entryId: string) {
-    this.guard(() => this.recorder.startTurn(entryId), undefined)
+  startTurn(entryId: string, startedAt?: number) {
+    this.guard(() => this.recorder.startTurn(entryId, startedAt), undefined)
   }
 
   endTurn() {
@@ -61,6 +61,10 @@ class ActivityStore {
 
   startStep(label: string, options?: StartStepOptions): string {
     return this.guard(() => this.recorder.startStep(label, options), '')
+  }
+
+  updateStep(id: string, detail: string) {
+    this.guard(() => this.recorder.updateStep(id, detail), undefined)
   }
 
   endStep(id: string, status?: Exclude<ActivityStatus, 'running'>, detail?: string) {

--- a/src/lib/stores/activity.svelte.ts
+++ b/src/lib/stores/activity.svelte.ts
@@ -8,6 +8,7 @@
  * All logic lives in `$lib/services/activity`; this file only wires it to a rune.
  */
 
+import { SvelteMap } from 'svelte/reactivity'
 import {
   ActivityRecorder,
   buildTree,
@@ -23,8 +24,27 @@ import {
 class ActivityStore {
   /** Increments on every recorded change. Read it to make a derivation reactive. */
   version = $state(0)
-  /** Entry whose finished record the reader has opened, if any. */
-  openRecordEntryId = $state<string | null>(null)
+
+  /**
+   * Advances while a turn is in flight, so elapsed times tick. Shared rather than owned by a
+   * component: the streaming entry and the finished one both read it, and the report has to
+   * keep counting across the handover between them.
+   */
+  now = $state(Date.now())
+  private clock: ReturnType<typeof setInterval> | null = null
+
+  /**
+   * Two independent controls, both keyed by entry rather than held per component: a report
+   * opened during generation has to survive the streaming entry giving way to the finished
+   * one, which is what keeps the post-narrative steps on screen.
+   *
+   * Each map holds only what the reader has actually chosen. Absent means "whatever the
+   * default is here", which differs by context -- the report shows itself while a turn runs
+   * and hides once it is over, while the tree follows the reporting setting.
+   */
+  private reportVisible = new SvelteMap<string, boolean>()
+  private treeExpanded = new SvelteMap<string, boolean>()
+  private reporting: ActivityReporting = 'off'
 
   private recorder = new ActivityRecorder(() => this.version++)
 
@@ -33,8 +53,40 @@ class ActivityStore {
   }
 
   setReporting(reporting: ActivityReporting) {
+    this.reporting = reporting
     this.recorder.setReporting(reporting)
+    if (reporting === 'off') this.stopClock()
     this.version++
+  }
+
+  /** Whether the report shows at all. `whileRunning` is the default before the reader chooses. */
+  isReportVisible(entryId: string, whileRunning: boolean): boolean {
+    return this.reportVisible.get(entryId) ?? whileRunning
+  }
+
+  setReportVisible(entryId: string, visible: boolean) {
+    this.reportVisible.set(entryId, visible)
+  }
+
+  /** Whether the report is showing the full timeline rather than the line. */
+  isTreeExpanded(entryId: string): boolean {
+    return this.treeExpanded.get(entryId) ?? this.reporting === 'tree'
+  }
+
+  setTreeExpanded(entryId: string, expanded: boolean) {
+    this.treeExpanded.set(entryId, expanded)
+  }
+
+  private startClock() {
+    if (this.clock) return
+    // Once a second, matching the resolution durations are shown at.
+    this.clock = setInterval(() => (this.now = Date.now()), 1000)
+  }
+
+  private stopClock() {
+    if (!this.clock) return
+    clearInterval(this.clock)
+    this.clock = null
   }
 
   /**
@@ -52,10 +104,15 @@ class ActivityStore {
 
   startTurn(entryId: string, startedAt?: number) {
     this.guard(() => this.recorder.startTurn(entryId, startedAt), undefined)
+    if (!this.recorder.enabled) return
+    this.now = Date.now()
+    this.startClock()
   }
 
   endTurn() {
     this.guard(() => this.recorder.endTurn(), undefined)
+    this.now = Date.now()
+    this.stopClock()
   }
 
   startStep(label: string, options?: StartStepOptions): string {
@@ -92,11 +149,6 @@ class ActivityStore {
     return this.recorder.find(entryId)
   }
 
-  /** True while an entry's record is still retained. */
-  hasRecord(entryId: string): boolean {
-    return this.recordFor(entryId) !== null
-  }
-
   /**
    * The reads below touch `version` for the same reason `activeTurn` does: a turn is one
    * object whose `steps` array is mutated in place, so nothing about it changes identity as
@@ -115,6 +167,9 @@ class ActivityStore {
 
   clear() {
     this.recorder.clear()
+    this.reportVisible.clear()
+    this.treeExpanded.clear()
+    this.stopClock()
   }
 }
 

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -42,8 +42,10 @@ import { MAX_SIDEBAR_WIDTH, MIN_SIDEBAR_WIDTH } from '$lib/constants/layout'
 import { SvelteSet, SvelteMap } from 'svelte/reactivity'
 import { dedupeTextModels } from '$lib/utils/dedupeTextModels'
 import { applyIncognitoKeyboard } from '$lib/utils/platform'
+import type { ActivityReporting } from '$lib/services/activity'
 import type { ImageGenerationServiceSettings, TimelineFillSettings } from '$lib/services/ai'
 import { debug } from './debug.svelte'
+import { activity } from './activity.svelte'
 import { modelHealth } from './modelHealth.svelte'
 import {
   isPingEligible,
@@ -1203,6 +1205,7 @@ export function getDefaultUISettings(): UISettings {
     highlightDialogue: false,
     dialogueColor: '',
     incognitoKeyboard: false,
+    activityReporting: 'off',
   }
 }
 
@@ -1593,6 +1596,16 @@ class SettingsStore {
 
       const debugMode = await database.getSetting('debug_mode')
       if (debugMode !== null) debug.isActive = this.uiSettings.debugMode = debugMode === 'true'
+
+      const activityReporting = await database.getSetting('activity_reporting')
+      if (
+        activityReporting === 'off' ||
+        activityReporting === 'line' ||
+        activityReporting === 'tree'
+      ) {
+        this.uiSettings.activityReporting = activityReporting
+      }
+      activity.setReporting(this.uiSettings.activityReporting)
 
       const sidebarWidth = await database.getSetting('sidebar_width')
       if (sidebarWidth) this.uiSettings.sidebarWidth = parseInt(sidebarWidth, 10)
@@ -2730,6 +2743,12 @@ class SettingsStore {
   async setDebugMode(enabled: boolean) {
     debug.isActive = this.uiSettings.debugMode = enabled
     await database.setSetting('debug_mode', enabled.toString())
+  }
+
+  async setActivityReporting(reporting: ActivityReporting) {
+    this.uiSettings.activityReporting = reporting
+    activity.setReporting(reporting)
+    await database.setSetting('activity_reporting', reporting)
   }
 
   async setAdvancedManualMode(enabled: boolean) {

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -3126,6 +3126,9 @@ class SettingsStore {
     // Reset UI settings
     this.uiSettings = getDefaultUISettings()
     await this.setNavPanelWidth(this.uiSettings.navPanelWidth)
+    // Through the setter: the defaults object alone leaves the live recorder on its old mode
+    // and never writes the key, so the previous mode came back on the next start.
+    await this.setActivityReporting(this.uiSettings.activityReporting)
     await ui.setNavPanelOpen(false)
 
     // Reset font to default

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -3126,8 +3126,8 @@ class SettingsStore {
     // Reset UI settings
     this.uiSettings = getDefaultUISettings()
     await this.setNavPanelWidth(this.uiSettings.navPanelWidth)
-    // Through the setter: the defaults object alone leaves the live recorder on its old mode
-    // and never writes the key, so the previous mode came back on the next start.
+    // Through the setter, which is what reaches the live recorder and the persisted key;
+    // assigning the defaults object updates neither.
     await this.setActivityReporting(this.uiSettings.activityReporting)
     await ui.setNavPanelOpen(false)
 

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -710,6 +710,8 @@ export type ReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | '
 import type { ThemeId as ThemeIdImport } from '../../themes/themes'
 export type ThemeId = ThemeIdImport
 
+import type { ActivityReporting } from '$lib/services/activity'
+
 export type FontSource = 'default' | 'system' | 'google'
 
 export type FontSizeOption = 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'
@@ -742,6 +744,12 @@ export interface UISettings {
   dialogueColor: string
   /** Android-only: ask the keyboard not to learn from what is typed. */
   incognitoKeyboard: boolean
+  /**
+   * How much of a turn's own progress the story view reports while generating.
+   * `line` is the collapsed status line, `tree` opens the full timeline. Independent of
+   * `debugMode`: that captures request payloads, this captures what ran and for how long.
+   */
+  activityReporting: ActivityReporting
 }
 
 /**

--- a/src/lib/utils/async.test.ts
+++ b/src/lib/utils/async.test.ts
@@ -46,6 +46,9 @@ describe('pLimit', () => {
 })
 
 describe('mergeGenerators cleanup', () => {
+  /** Cleanup is started but not awaited, so let the queued `return()` calls land. */
+  const settle = () => new Promise((resolve) => setTimeout(resolve, 0))
+
   /** A generator that records whether its own cleanup ran. */
   function tracked(values: string[], cleanup: { closed: boolean }) {
     return (async function* () {
@@ -74,6 +77,7 @@ describe('mergeGenerators cleanup', () => {
       })(),
     ).rejects.toThrow('boom')
 
+    await settle()
     // Without this the sibling's `finally` never runs, so anything it owns stays open.
     expect(survivor.closed).toBe(true)
   })
@@ -89,6 +93,7 @@ describe('mergeGenerators cleanup', () => {
     await merged.next()
     await merged.return({} as never)
 
+    await settle()
     expect(first.closed).toBe(true)
     expect(second.closed).toBe(true)
   })
@@ -115,5 +120,34 @@ describe('mergeGenerators cleanup', () => {
       seen.push(next.value)
     }
     expect([...seen].sort()).toEqual(['x', 'y'])
+  })
+})
+
+describe('mergeGenerators cleanup is not blocking', () => {
+  it('propagates the failure without waiting on a sibling read that has not answered', async () => {
+    let releaseSibling: (() => void) | undefined
+    const merged = mergeGenerators({
+      thrower: (async function* () {
+        yield 'a'
+        throw new Error('boom')
+      })(),
+      // Stands in for a phase whose model call has not come back. `return()` on this
+      // generator queues behind the pending `next()`, so awaiting cleanup would hang here.
+      stuck: (async function* () {
+        yield 'b'
+        await new Promise<void>((resolve) => {
+          releaseSibling = resolve
+        })
+        yield 'c'
+      })(),
+    })
+
+    await expect(
+      (async () => {
+        for await (const _ of merged) void _
+      })(),
+    ).rejects.toThrow('boom')
+
+    releaseSibling?.()
   })
 })

--- a/src/lib/utils/async.test.ts
+++ b/src/lib/utils/async.test.ts
@@ -126,9 +126,18 @@ describe('mergeGenerators cleanup', () => {
 describe('mergeGenerators cleanup is not blocking', () => {
   it('propagates the failure without waiting on a sibling read that has not answered', async () => {
     let releaseSibling: (() => void) | undefined
+    let siblingIsReading!: () => void
+    // The failure is held until the sibling is parked, so the test cannot pass by winning a
+    // race -- without a pending read there is nothing for cleanup to block on, and awaited
+    // cleanup would return promptly too.
+    const siblingParked = new Promise<void>((resolve) => {
+      siblingIsReading = resolve
+    })
+
     const merged = mergeGenerators({
       thrower: (async function* () {
         yield 'a'
+        await siblingParked
         throw new Error('boom')
       })(),
       // Stands in for a phase whose model call has not come back. `return()` on this
@@ -137,6 +146,7 @@ describe('mergeGenerators cleanup is not blocking', () => {
         yield 'b'
         await new Promise<void>((resolve) => {
           releaseSibling = resolve
+          siblingIsReading()
         })
         yield 'c'
       })(),
@@ -148,6 +158,7 @@ describe('mergeGenerators cleanup is not blocking', () => {
       })(),
     ).rejects.toThrow('boom')
 
-    releaseSibling?.()
+    expect(releaseSibling).toBeDefined()
+    releaseSibling!()
   })
 })

--- a/src/lib/utils/async.test.ts
+++ b/src/lib/utils/async.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { pLimit } from './async'
+import { mergeGenerators, pLimit } from './async'
 
 describe('pLimit', () => {
   it('throws on invalid concurrency inputs', () => {
@@ -42,5 +42,78 @@ describe('pLimit', () => {
     await limit(nextTask)
 
     expect(ranNext).toBe(true)
+  })
+})
+
+describe('mergeGenerators cleanup', () => {
+  /** A generator that records whether its own cleanup ran. */
+  function tracked(values: string[], cleanup: { closed: boolean }) {
+    return (async function* () {
+      try {
+        for (const v of values) yield v
+        return 'done'
+      } finally {
+        cleanup.closed = true
+      }
+    })()
+  }
+
+  it('closes its siblings when one of them throws', async () => {
+    const survivor = { closed: false }
+    const merged = mergeGenerators({
+      thrower: (async function* () {
+        yield 'a'
+        throw new Error('boom')
+      })(),
+      other: tracked(['b', 'c', 'd', 'e'], survivor),
+    })
+
+    await expect(
+      (async () => {
+        for await (const _ of merged) void _
+      })(),
+    ).rejects.toThrow('boom')
+
+    // Without this the sibling's `finally` never runs, so anything it owns stays open.
+    expect(survivor.closed).toBe(true)
+  })
+
+  it('closes its generators when the consumer walks away', async () => {
+    const first = { closed: false }
+    const second = { closed: false }
+    const merged = mergeGenerators({
+      a: tracked(['1', '2', '3'], first),
+      b: tracked(['4', '5', '6'], second),
+    })
+
+    await merged.next()
+    await merged.return({} as never)
+
+    expect(first.closed).toBe(true)
+    expect(second.closed).toBe(true)
+  })
+
+  it('still returns every result on the ordinary path', async () => {
+    const merged = mergeGenerators({
+      a: (async function* () {
+        yield 'x'
+        return 'ra'
+      })(),
+      b: (async function* () {
+        yield 'y'
+        return 'rb'
+      })(),
+    })
+
+    const seen: unknown[] = []
+    for (;;) {
+      const next = await merged.next()
+      if (next.done) {
+        expect(next.value).toEqual({ a: 'ra', b: 'rb' })
+        break
+      }
+      seen.push(next.value)
+    }
+    expect([...seen].sort()).toEqual(['x', 'y'])
   })
 })

--- a/src/lib/utils/async.ts
+++ b/src/lib/utils/async.ts
@@ -63,17 +63,26 @@ export async function* mergeGenerators<
     getNext(key)
   }
 
-  while (activeGenerators.size > 0) {
-    const { key, res } = await Promise.race(Array.from(pendingPromises.values()))
+  try {
+    while (activeGenerators.size > 0) {
+      const { key, res } = await Promise.race(Array.from(pendingPromises.values()))
 
-    if (res.done) {
-      results[key] = res.value
-      activeGenerators.delete(key)
-      pendingPromises.delete(key)
-    } else {
-      yield res.value
-      getNext(key)
+      if (res.done) {
+        results[key] = res.value
+        activeGenerators.delete(key)
+        pendingPromises.delete(key)
+      } else {
+        yield res.value
+        getNext(key)
+      }
     }
+  } finally {
+    // One generator throwing, or the consumer walking away, leaves the rest mid-iteration.
+    // They are owned here, so their cleanup is closed here rather than left to collection --
+    // `allSettled` because a sibling failing to close must not mask the original failure.
+    await Promise.allSettled(
+      Array.from(activeGenerators.values()).map((gen) => gen.return(undefined)),
+    )
   }
 
   return results

--- a/src/lib/utils/async.ts
+++ b/src/lib/utils/async.ts
@@ -78,9 +78,13 @@ export async function* mergeGenerators<
     }
   } finally {
     // One generator throwing, or the consumer walking away, leaves the rest mid-iteration.
-    // They are owned here, so their cleanup is closed here rather than left to collection --
-    // `allSettled` because a sibling failing to close must not mask the original failure.
-    await Promise.allSettled(
+    // They are owned here, so closing them is started here rather than left to collection.
+    //
+    // Started, not awaited: an async generator serialises its own requests, so `return()`
+    // queues behind whatever `next()` is already in flight -- a model call, here -- and that
+    // read cannot be cancelled from outside. Awaiting would hold the caller, and the failure
+    // it is propagating, for as long as an unrelated sibling takes to answer.
+    void Promise.allSettled(
       Array.from(activeGenerators.values()).map((gen) => gen.return(undefined)),
     )
   }


### PR DESCRIPTION
## Why

The wait before the first narration token could run to forty seconds behind a three-dot animation. A single turn can make two tier-3 selections, a chapter query per agentic step, and up to three narrative retries — none of it visible. Debug Mode answers a different question (what was sent and received) through a modal or a second window, and is uncomfortable to leave running while reading.

## What this does

A turn records its work as a tree of timed steps.

- **While generating**, the story view replaces the ellipsis with the **deepest step currently running** — `query ch.12 · 6.2s` rather than "Retrieving" — plus the turn's elapsed time, expandable to the full timeline.
- **After the turn**, the record stays reachable from the finished entry for the **last five turns** of the session, so a turn that felt slow can be examined afterwards.
- **LLM-backed steps are marked**, so the expensive work is distinguishable from the free work at a glance.
- A new **three-state interface setting** (`Off` / `Status line` / `Full timeline`) controls it, independent of Debug Mode.

Newly visible: world state and lorebook tier-3 selection, each agentic step and tool call against its budget, each chapter query, timeline fill, narrative prompt assembly and time-to-first-token, and **narrative empty-response retries** — which were previously invisible even in Debug Mode.

## Approach

- `services/activity/` holds the record and the reading views (nesting, deepest running step, durations, retention), all plain TypeScript. `stores/activity.svelte.ts` is the reactive shell over it, following the `debug.svelte.ts` pattern.
- Phases reach an injected `ActivityReporter` on `PipelineDependencies` rather than importing the store — the rule `docs/architecture/overview.md` names as what keeps them testable without a provider. `NO_ACTIVITY` stands in where none is wired, so existing phase tests needed no changes.
- Services under `services/ai/` write to the store directly, following the debug store's precedent; their tests mock it the same way.
- Nesting is by explicit parent id threaded through existing options objects. An implicit stack would not survive Stage A's two concurrent branches or the parallel post-narrative phases.
- Retrieval reports through the `RetrievalEvent` record it already keeps; chapter queries reuse the `durationMs` the query budget already measured.
- Phases with several completion paths are wrapped by `trackPhase` rather than instrumented one exit at a time — `ImagePhase` alone has five.

## Reporting does not alter the turn

No prompt, request count, or retry policy changes. The narrative retry loop is reported but untouched, with a test asserting the attempt count and outcome are unchanged. Every store write is guarded and the display sits inside a `<svelte:boundary>`, so a fault in the record cannot take down the generation it describes. Records are session-only: nothing is persisted, exported, or carried across a restart. No migration.

## Verification

`npm run check` 0 errors · `npm test` 1425 passed · `npm run lint` 0 errors · `vite build` succeeds.

**Not verified:** the in-app checks. There is no DOM in the test environment, so the Svelte half is unexercised by the suite, and I could not run the Tauri app here. Worth a look before merge:

- the collapsed line tracking through a long retrieval, and how the tie-break between the two concurrent Stage A branches reads
- Stop mid-turn, then opening that turn's record
- toggling the setting mid-turn (the in-flight record is discarded by design)
- the mobile path — the badge is desktop-only like the token badge beside it, with an overflow-menu equivalent

Planning artifacts live in the `aventuras-specs` store under `generation-activity-timeline`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional Generation Activity reporting during AI responses.
  - Choose Off, Status line, or Full timeline in Interface settings.
  - View live progress, nested steps, statuses, and elapsed durations for generation and retrieval tasks.
  - Activity details appear in story entries and streaming responses without interrupting narration.

- **Bug Fixes**
  - Activity tracking now closes reliably after successful, interrupted, or failed operations.
  - Display errors no longer hide story content.
  - Improved cleanup when generation streams stop unexpectedly.

- **Tests**
  - Added coverage for activity tracking, timelines, durations, retention, cleanup, and generation workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->