### PR TITLE
Keyword scan surface — match keywords against narrative text (1/3)

### DIFF
--- a/bench/fixture.ts
+++ b/bench/fixture.ts
@@ -359,6 +359,8 @@ export function passInputs(
     embedRows: async () => [],
     runInTransaction: async () => {},
   }
+  const userAction = prose(rand, 20)
+  const lastNarrativeContent = prose(rand, 150)
   const params = {
     branchId: BRANCH,
     modelId: MODEL_ID,
@@ -368,15 +370,18 @@ export function passInputs(
       ...(chapterBudget === 'off' ? { chapters: 0 } : {}),
     },
     query: {
-      userAction: prose(rand, 20),
+      userAction,
       eraName: null,
       piggybackSummary: null,
-      lastNarrativeContent: prose(rand, 150),
+      lastNarrativeContent,
     },
     sceneCharacterIds,
     sceneEntityIds: sceneCharacterIds,
     currentLocationId: 'char_000000',
     recentProse: prose(rand, 200),
+    // The default one-entry surface, so the matchTerms cost measured here is the
+    // one a turn actually pays.
+    scanText: `${userAction}\n${lastNarrativeContent}`,
   }
   return { deps, params }
 }

--- a/bench/probe-capture-cost.test.ts
+++ b/bench/probe-capture-cost.test.ts
@@ -64,6 +64,8 @@ function captureInputFor(outcome: RetrievalOutcome, mode: 'light' | 'deep'): Cap
     // One scalar, so it moves neither the payload size nor the assemble cost
     // this harness reports; a representative value keeps the shape honest.
     promptBufferTokens: 2_400,
+    // The default one-entry surface, so the payload is sized like a real one.
+    scanText: 'What does the party do next?\nThe bridge fell during the third night of the siege.',
     outcome,
   }
 }

--- a/components/story-settings/memory-panel.stories.tsx
+++ b/components/story-settings/memory-panel.stories.tsx
@@ -32,6 +32,7 @@ function buildSettings(overrides: Partial<StorySettings> = {}): StorySettings {
     embeddingBackend: 'local',
     embedding_model_id: MINILM,
     retrievalBudgets: STORY_SETTINGS_DEFAULTS.retrievalBudgets,
+    keywordRetrieval: STORY_SETTINGS_DEFAULTS.keywordRetrieval,
     composerModesEnabled: true,
     composerWrapPov: 'third',
     suggestionsEnabled: true,

--- a/docs/implementation/roadmap.md
+++ b/docs/implementation/roadmap.md
@@ -230,7 +230,9 @@ Carried deferrals, routed out of [`triage.md`](./triage.md)
 the story-open swap prompt and failed-turn text custody — moved to
 [`followups.md`](../followups.md) 2026-09-05: both want a design pass
 before any slice can own them, and neither was owned by an M4 slice as
-sketched.
+sketched. The last two entries below arrive from the other direction —
+canon that landed ahead of its surface, rather than a deferral routed
+out of implementation.
 
 - **M4.4 — The phone list state hides a dirty save bar.** `StorySettingsShell`
   renders the bar inside the detail pane, and `MasterDetailLayout`
@@ -282,6 +284,31 @@ sketched.
   so this is unbounded dead weight that survives an embedder swap, not
   wrong results. Surfaced by Slice 3.12a review (2026-08-19), verified and
   routed 2026-08-20.
+- **M4.2 — Entity and lore keyword editors are specced with no surface.**
+  The 2026-09-06 keyword-retrieval design added `keywords` and
+  `priority` to the entity Settings tab
+  ([`world.md → Settings`](../ui/screens/world/world.md#settings--entity-management-chrome))
+  and `keywords` to lore's
+  ([`world.md → Settings tab — lore`](../ui/screens/world/world.md#settings-tab--lore)),
+  both wireframed in `world.html`. The lore one is new scope rather than
+  a field added to an existing panel: lore had no documented edit
+  surface anywhere before that commit. Until they ship, entity keywords
+  reach the database only through the periodic classifier and lore
+  keywords only through seed data, so the user-authored half of a
+  pathway canon calls load-bearing has no way in. Introduced by the
+  keyword-retrieval design (2026-09-06).
+- **M4.4 — The Keyword retrieval settings panel is specced with no
+  surface.** Five `keywordRetrieval` knobs — `mode`, `budgetShare`,
+  `scanEntries`, `cascade`, `cascadeMaxDepth` — are specced and
+  wireframed at
+  [`story-settings.md → Keyword retrieval`](../ui/screens/story-settings/story-settings.md#keyword-retrieval)
+  and land in `stories.settings` ahead of the panel. Settings-only with
+  no UI is the established pattern here, not a gap — `piggybackMode` and
+  the composer modes both shipped that way — but `mode: 'inject'` is a
+  behaviour users will expect to reach, and the entry above is what
+  makes its keywords authorable in the first place, so the two want
+  sequencing together. Introduced by the keyword-retrieval design
+  (2026-09-06).
 
 **Gates.** M3 for real-data validation (no entities without the
 classifier; no awareness without it; no retrieval scores without

--- a/docs/memory/probe.md
+++ b/docs/memory/probe.md
@@ -134,6 +134,16 @@ Per capture:
   [heuristic prose extract](./retrieval.md#q3-heuristic-prose-extract).
   Query **vectors are never stored**, in either mode — see
   [Deep mode](#deep-mode-per-capture-opt-in).
+- **Keyword scan surface.** `scan_text` — the narrative text
+  `kw_boost_value` was matched against, per
+  [`retrieval.md → Keyword scan surface`](./retrieval.md#keyword-scan-surface).
+  Captured in both modes, because a keyword hit adjusts a ranked score
+  under `boost` as much as it seats a row under `inject`. It is a
+  separate field rather than a fourth query because it is not one: the
+  queries are embedded and the scan surface is not, and it is defined
+  independently of them by design. Without it a non-zero
+  `kw_boost_value` has no readable cause anywhere in the capture — the
+  matched term lives in neither the candidate row nor the queries.
 - **Per-type candidate pool.** For each type
   (entities / lore / happenings / threads / chapters), one row per
   candidate that entered the type's ranker pool:

--- a/docs/memory/retrieval.md
+++ b/docs/memory/retrieval.md
@@ -1858,7 +1858,7 @@ copy of this table.
 ### Pseudocode
 
 ```python
-def rank_per_type(candidates, queries, scan_text, type_budget, λ_type, type_overhead, *, matched_chapters=None):
+def rank_per_type(candidates, queries, scan_text, type_budget, λ_type, type_overhead, *, matched_chapters=None, keyword_injected=()):
     # 1. Compute raw score per candidate
     scored = []
     for c in candidates:
@@ -1909,25 +1909,28 @@ def rank_per_type(candidates, queries, scan_text, type_budget, λ_type, type_ove
 
     return selected
 
-def rank_all(pools, queries, budgets, type_config):
+def rank_all(pools, queries, scan_text, budgets, type_config, injected_by_type):
     # Chapters first — small pool, ranks fast, output feeds happenings
     matched_chapters = rank_per_type(
-        pools['chapters'], queries, budgets['chapters'],
+        pools['chapters'], queries, scan_text, budgets['chapters'],
         type_config['chapters'].λ, type_config['chapters'].overhead
     )
 
     # Happenings depend on matched_chapters (chapter-match boost)
     happenings = rank_per_type(
-        pools['happenings'], queries, budgets['happenings'],
+        pools['happenings'], queries, scan_text, budgets['happenings'],
         type_config['happenings'].λ, type_config['happenings'].overhead,
         matched_chapters=matched_chapters
     )
 
-    # Other types run independently — no inter-type dependencies
+    # Other types run independently — no inter-type dependencies. Only these
+    # carry a keyword-injected set: chapters and happenings stay on `boost`
+    # unconditionally (→ Keyword injection), so theirs is always empty.
     others = {
         type: rank_per_type(
-            pools[type], queries, budgets[type],
-            type_config[type].λ, type_config[type].overhead
+            pools[type], queries, scan_text, budgets[type],
+            type_config[type].λ, type_config[type].overhead,
+            keyword_injected=injected_by_type.get(type, ())
         )
         for type in ('entities', 'lore', 'threads')
     }

--- a/lib/actions/classifier/run-now.test.ts
+++ b/lib/actions/classifier/run-now.test.ts
@@ -32,6 +32,13 @@ const SETTINGS = storySettingsSchema.parse({
   embeddingBackend: 'local',
   embedding_model_id: 'm',
   retrievalBudgets: { entities: 1, lore: 1, happenings: 1, threads: 1, chapters: 1 },
+  keywordRetrieval: {
+    mode: 'boost',
+    budgetShare: 0.5,
+    scanEntries: 1,
+    cascade: false,
+    cascadeMaxDepth: 2,
+  },
   composerModesEnabled: true,
   composerWrapPov: 'first',
   suggestionsEnabled: false,

--- a/lib/actions/stories/load-open-story.test.ts
+++ b/lib/actions/stories/load-open-story.test.ts
@@ -37,6 +37,13 @@ const STORY_SETTINGS = storySettingsSchema.parse({
   embeddingBackend: 'local',
   embedding_model_id: 'm',
   retrievalBudgets: { entities: 1, lore: 1, happenings: 1, threads: 1, chapters: 1 },
+  keywordRetrieval: {
+    mode: 'boost',
+    budgetShare: 0.5,
+    scanEntries: 1,
+    cascade: false,
+    cascadeMaxDepth: 2,
+  },
   composerModesEnabled: true,
   composerWrapPov: 'first',
   suggestionsEnabled: false,

--- a/lib/actions/stories/operational.test.ts
+++ b/lib/actions/stories/operational.test.ts
@@ -48,6 +48,13 @@ const STORY_SETTINGS = storySettingsSchema.parse({
   embeddingBackend: 'local',
   embedding_model_id: 'm',
   retrievalBudgets: { entities: 1, lore: 1, happenings: 1, threads: 1, chapters: 1 },
+  keywordRetrieval: {
+    mode: 'boost',
+    budgetShare: 0.5,
+    scanEntries: 1,
+    cascade: false,
+    cascadeMaxDepth: 2,
+  },
   composerModesEnabled: true,
   composerWrapPov: 'first',
   suggestionsEnabled: false,

--- a/lib/actions/turns/__tests__/fixtures.ts
+++ b/lib/actions/turns/__tests__/fixtures.ts
@@ -79,6 +79,13 @@ export const STORY_SETTINGS = storySettingsSchema.parse({
   // Embed failure is blocking).
   embedding_model_id: 'Xenova/all-MiniLM-L6-v2',
   retrievalBudgets: { entities: 1, lore: 1, happenings: 1, threads: 1, chapters: 1 },
+  keywordRetrieval: {
+    mode: 'boost',
+    budgetShare: 0.5,
+    scanEntries: 1,
+    cascade: false,
+    cascadeMaxDepth: 2,
+  },
   composerModesEnabled: true,
   composerWrapPov: 'first',
   suggestionsEnabled: false,

--- a/lib/boot/classifier-scheduler.test.ts
+++ b/lib/boot/classifier-scheduler.test.ts
@@ -30,6 +30,13 @@ const SETTINGS = storySettingsSchema.parse({
   embeddingBackend: 'local',
   embedding_model_id: 'm',
   retrievalBudgets: { entities: 1, lore: 1, happenings: 1, threads: 1, chapters: 1 },
+  keywordRetrieval: {
+    mode: 'boost',
+    budgetShare: 0.5,
+    scanEntries: 1,
+    cascade: false,
+    cascadeMaxDepth: 2,
+  },
   composerModesEnabled: true,
   composerWrapPov: 'first',
   suggestionsEnabled: false,

--- a/lib/db/__tests__/migrate-m3-keyword-retrieval.test.ts
+++ b/lib/db/__tests__/migrate-m3-keyword-retrieval.test.ts
@@ -1,0 +1,157 @@
+import { readFileSync } from 'node:fs'
+import { DatabaseSync } from 'node:sqlite'
+
+import { getLoadablePath } from 'sqlite-vec'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { STORY_SETTINGS_DEFAULTS } from '@/lib/db'
+
+const MIGRATIONS_DIR = 'lib/db/migrations'
+const TAG = '0011_keyword_retrieval_settings'
+
+function migrationTags(): string[] {
+  const journal = JSON.parse(readFileSync(`${MIGRATIONS_DIR}/meta/_journal.json`, 'utf8')) as {
+    entries: { idx: number; tag: string }[]
+  }
+  return [...journal.entries].sort((a, b) => a.idx - b.idx).map((e) => e.tag)
+}
+
+function applyMigration(sqlite: DatabaseSync, tag: string): void {
+  const sql = readFileSync(`${MIGRATIONS_DIR}/${tag}.sql`, 'utf8')
+  for (const statement of sql.split('--> statement-breakpoint')) {
+    const trimmed = statement.trim()
+    if (trimmed) sqlite.exec(trimmed)
+  }
+}
+
+// The pre-slice shape: no keywordRetrieval key at all, plus enough sibling keys
+// to prove the migration writes one subtree rather than the settings blob.
+const LEGACY_SETTINGS = {
+  chapterTokenThreshold: 24000,
+  classifierCadence: 5,
+  piggybackMode: 'off',
+  retrievalBudgets: { entities: 1200, lore: 1800, happenings: 1500, threads: 400, chapters: 600 },
+  embedding_model_id: 'Xenova/all-MiniLM-L6-v2',
+  packVariables: { tone: 'wry' },
+}
+
+function settingsOf(db: DatabaseSync, storyId: string): Record<string, unknown> | null {
+  const row = db.prepare('select settings from stories where id = ?').get(storyId) as
+    | { settings: string | null }
+    | undefined
+  return row?.settings == null ? null : (JSON.parse(row.settings) as Record<string, unknown>)
+}
+
+function insertStory(db: DatabaseSync, id: string, settings: unknown): void {
+  db.prepare(
+    'insert into stories (id, title, settings, created_at, updated_at) values (?,?,?,?,?)',
+  ).run(id, id, settings === null ? null : JSON.stringify(settings), 1, 1)
+}
+
+describe(TAG, () => {
+  let db: DatabaseSync
+
+  beforeEach(() => {
+    db = new DatabaseSync(':memory:', { allowExtension: true })
+    db.loadExtension(getLoadablePath())
+    for (const tag of migrationTags()) {
+      if (tag === TAG) break
+      applyMigration(db, tag)
+    }
+  })
+
+  // Applying by filename would stay green against a migration the app never
+  // runs. keywordRetrieval is required by storySettingsSchema, so an unjournalled
+  // 0011 makes every upgraded story fail to parse its own settings — and a fresh
+  // DB never needs the migration, so E2E cannot catch it either.
+  it('is wired into the upgrade path, not just present on disk', () => {
+    expect(migrationTags()).toContain(TAG)
+    const runtime = readFileSync(`${MIGRATIONS_DIR}/migrations.js`, 'utf8')
+    expect(runtime).toContain(`${TAG}.sql`)
+  })
+
+  it('creates the key on a settings blob that predates it', () => {
+    insertStory(db, 's1', LEGACY_SETTINGS)
+    expect(settingsOf(db, 's1')?.keywordRetrieval).toBeUndefined()
+
+    applyMigration(db, TAG)
+
+    expect(settingsOf(db, 's1')?.keywordRetrieval).toEqual(STORY_SETTINGS_DEFAULTS.keywordRetrieval)
+  })
+
+  it('leaves every sibling settings key untouched', () => {
+    insertStory(db, 's1', LEGACY_SETTINGS)
+
+    applyMigration(db, TAG)
+
+    expect(settingsOf(db, 's1')).toEqual({
+      ...LEGACY_SETTINGS,
+      keywordRetrieval: STORY_SETTINGS_DEFAULTS.keywordRetrieval,
+    })
+  })
+
+  // The guard that separates this from 0007: a user-chosen mode must survive a
+  // re-run, so the statement is idempotent rather than a blind overwrite.
+  it('leaves a story that already carries the key alone', () => {
+    const chosen = { ...STORY_SETTINGS_DEFAULTS.keywordRetrieval, mode: 'inject', scanEntries: 4 }
+    insertStory(db, 's1', { ...LEGACY_SETTINGS, keywordRetrieval: chosen })
+
+    applyMigration(db, TAG)
+    applyMigration(db, TAG)
+
+    expect(settingsOf(db, 's1')?.keywordRetrieval).toEqual(chosen)
+  })
+
+  // json_set raises on non-JSON text, which aborts the whole UPDATE: without the
+  // guard one unparseable blob leaves every other story unmigrated and the app
+  // unable to boot past migrate(), rather than badging that one story.
+  it.each([
+    ['unparseable text', '{not json'],
+    ['an empty string', ''],
+    ['a top-level array', '[1,2]'],
+    ['a top-level scalar', '42'],
+  ])('migrates good rows beside %s', (_label, raw) => {
+    insertStory(db, 's_good', LEGACY_SETTINGS)
+    db.prepare(
+      'insert into stories (id, title, settings, created_at, updated_at) values (?,?,?,?,?)',
+    ).run('s_bad', 's_bad', raw, 1, 1)
+
+    expect(() => applyMigration(db, TAG)).not.toThrow()
+
+    expect(settingsOf(db, 's_good')?.keywordRetrieval).toEqual(
+      STORY_SETTINGS_DEFAULTS.keywordRetrieval,
+    )
+    const bad = db.prepare('select settings from stories where id = ?').get('s_bad') as {
+      settings: string
+    }
+    expect(bad.settings).toBe(raw)
+  })
+
+  // json_valid alone would admit these: json_set then writes the column back
+  // re-serialized, silently normalizing a row the migration has no business
+  // touching. The spacing is the assertion — it survives only if the row is
+  // never written.
+  it.each([
+    ['a spaced top-level array', '[1, 2]'],
+    ['a quoted scalar', '"already gone"'],
+  ])('does not rewrite %s', (_label, raw) => {
+    db.prepare(
+      'insert into stories (id, title, settings, created_at, updated_at) values (?,?,?,?,?)',
+    ).run('s_odd', 's_odd', raw, 1, 1)
+
+    applyMigration(db, TAG)
+
+    const after = db.prepare('select settings from stories where id = ?').get('s_odd') as {
+      settings: string
+    }
+    expect(after.settings).toBe(raw)
+  })
+
+  it('leaves a wizard draft with no settings blob null rather than writing one', () => {
+    insertStory(db, 's1', null)
+
+    applyMigration(db, TAG)
+
+    expect(settingsOf(db, 's1')).toBeNull()
+  })
+})

--- a/lib/db/devtools/seed-dataset.ts
+++ b/lib/db/devtools/seed-dataset.ts
@@ -150,6 +150,13 @@ function settings(overrides: Partial<StorySettings> = {}): StorySettings {
     embeddingBackend: 'local',
     embedding_model_id: 'Xenova/all-MiniLM-L6-v2',
     retrievalBudgets: { entities: 1200, lore: 1800, happenings: 1500, threads: 400, chapters: 600 },
+    keywordRetrieval: {
+      mode: 'boost',
+      budgetShare: 0.5,
+      scanEntries: 1,
+      cascade: false,
+      cascadeMaxDepth: 2,
+    },
     composerModesEnabled: true,
     composerWrapPov: 'third',
     suggestionsEnabled: true,

--- a/lib/db/migrations/0011_keyword_retrieval_settings.sql
+++ b/lib/db/migrations/0011_keyword_retrieval_settings.sql
@@ -1,0 +1,20 @@
+-- stories.settings.keywordRetrieval is new here. Settings writes are key-scoped
+-- json_set (settings-ops.ts), so a Zod-side default would never materialise in an
+-- existing blob: reads would apply it while the stored column stayed short.
+-- Guarded on the key being absent rather than written unconditionally like 0007,
+-- so the statement is idempotent once users can choose a mode of their own.
+UPDATE stories
+SET settings = json_set(
+	settings,
+	'$.keywordRetrieval',
+	json('{"mode":"boost","budgetShare":0.5,"scanEntries":1,"cascade":false,"cascadeMaxDepth":2}')
+)
+-- json_set raises on non-JSON text, and one such row would abort the whole
+-- statement: no story migrates and the app cannot boot past migrate(). A corrupt
+-- settings blob is already a per-story recoverable state elsewhere
+-- (lib/actions/stories/operational.ts sets a settings-corrupt open failure), so
+-- skip those rows and leave the rest of the database migratable.
+WHERE settings IS NOT NULL
+	AND json_valid(settings)
+	AND json_type(settings) = 'object'
+	AND json_extract(settings, '$.keywordRetrieval') IS NULL;

--- a/lib/db/migrations/meta/0011_snapshot.json
+++ b/lib/db/migrations/meta/0011_snapshot.json
@@ -1,0 +1,2130 @@
+{
+  "id": "56430581-2368-490f-b5fb-8498f508d4f7",
+  "prevId": "f95b4279-c1da-4dc4-a04d-79eeeecd9078",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {
+    "app_settings": {
+      "name": "app_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providers": {
+          "name": "providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "profiles": {
+          "name": "profiles",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "assignments": {
+          "name": "assignments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "default_provider_id": {
+          "name": "default_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding_model_id": {
+          "name": "embedding_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding_provider_id": {
+          "name": "embedding_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_story_settings": {
+          "name": "default_story_settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "default_calendar_id": {
+          "name": "default_calendar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_suggestion_categories": {
+          "name": "default_suggestion_categories",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{\"adventure\":[],\"creative\":[]}'"
+        },
+        "appearance": {
+          "name": "appearance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "ui_language": {
+          "name": "ui_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "diagnostics": {
+          "name": "diagnostics",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{\"enabled\":false,\"debug_level_enabled\":false}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "assets": {
+      "name": "assets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pending_delete_at": {
+          "name": "pending_delete_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "branch_era_flips": {
+      "name": "branch_era_flips",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch_id": {
+          "name": "branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "at_worldtime": {
+          "name": "at_worldtime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "era_name": {
+          "name": "era_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "era_flips_branch_worldtime_uniq": {
+          "name": "era_flips_branch_worldtime_uniq",
+          "columns": [
+            "branch_id",
+            "at_worldtime"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "branch_era_flips_branch_id_branches_id_fk": {
+          "name": "branch_era_flips_branch_id_branches_id_fk",
+          "tableFrom": "branch_era_flips",
+          "columnsFrom": [
+            "branch_id"
+          ],
+          "tableTo": "branches",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "branch_era_flips_branch_id_id_pk": {
+          "columns": [
+            "branch_id",
+            "id"
+          ],
+          "name": "branch_era_flips_branch_id_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "era_flips_worldtime_nonneg": {
+          "name": "era_flips_worldtime_nonneg",
+          "value": "\"branch_era_flips\".\"at_worldtime\" >= 0"
+        }
+      }
+    },
+    "branches": {
+      "name": "branches",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "story_id": {
+          "name": "story_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_branch_id": {
+          "name": "parent_branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fork_entry_id": {
+          "name": "fork_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "classifier_status": {
+          "name": "classifier_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "branches_story_id_stories_id_fk": {
+          "name": "branches_story_id_stories_id_fk",
+          "tableFrom": "branches",
+          "columnsFrom": [
+            "story_id"
+          ],
+          "tableTo": "stories",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "branches_parent_branch_id_branches_id_fk": {
+          "name": "branches_parent_branch_id_branches_id_fk",
+          "tableFrom": "branches",
+          "columnsFrom": [
+            "parent_branch_id"
+          ],
+          "tableTo": "branches",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chapters": {
+      "name": "chapters",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch_id": {
+          "name": "branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence_number": {
+          "name": "sequence_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "start_entry_id": {
+          "name": "start_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_entry_id": {
+          "name": "end_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding_stale": {
+          "name": "embedding_stale",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chapters_stale_idx": {
+          "name": "chapters_stale_idx",
+          "columns": [
+            "branch_id"
+          ],
+          "where": "\"chapters\".\"embedding_stale\" = 1",
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chapters_branch_id_branches_id_fk": {
+          "name": "chapters_branch_id_branches_id_fk",
+          "tableFrom": "chapters",
+          "columnsFrom": [
+            "branch_id"
+          ],
+          "tableTo": "branches",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "chapters_branch_id_id_pk": {
+          "columns": [
+            "branch_id",
+            "id"
+          ],
+          "name": "chapters_branch_id_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "character_relationships": {
+      "name": "character_relationships",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch_id": {
+          "name": "branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "a_id": {
+          "name": "a_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "b_id": {
+          "name": "b_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inverse_kind": {
+          "name": "inverse_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "char_rel_pair_uniq": {
+          "name": "char_rel_pair_uniq",
+          "columns": [
+            "branch_id",
+            "a_id",
+            "b_id"
+          ],
+          "isUnique": true
+        },
+        "char_rel_branch_a_idx": {
+          "name": "char_rel_branch_a_idx",
+          "columns": [
+            "branch_id",
+            "a_id"
+          ],
+          "isUnique": false
+        },
+        "char_rel_branch_b_idx": {
+          "name": "char_rel_branch_b_idx",
+          "columns": [
+            "branch_id",
+            "b_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "character_relationships_branch_id_branches_id_fk": {
+          "name": "character_relationships_branch_id_branches_id_fk",
+          "tableFrom": "character_relationships",
+          "columnsFrom": [
+            "branch_id"
+          ],
+          "tableTo": "branches",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "character_relationships_branch_id_id_pk": {
+          "columns": [
+            "branch_id",
+            "id"
+          ],
+          "name": "character_relationships_branch_id_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "char_rel_canonical_order": {
+          "name": "char_rel_canonical_order",
+          "value": "\"character_relationships\".\"a_id\" < \"character_relationships\".\"b_id\""
+        },
+        "char_rel_one_pov": {
+          "name": "char_rel_one_pov",
+          "value": "\"character_relationships\".\"kind\" IS NOT NULL OR \"character_relationships\".\"inverse_kind\" IS NOT NULL"
+        }
+      }
+    },
+    "deltas": {
+      "name": "deltas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch_id": {
+          "name": "branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action_id": {
+          "name": "action_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "log_position": {
+          "name": "log_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_table": {
+          "name": "target_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "op": {
+          "name": "op",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "undo_payload": {
+          "name": "undo_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "encoding_version": {
+          "name": "encoding_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "deltas_chain_idx": {
+          "name": "deltas_chain_idx",
+          "columns": [
+            "branch_id",
+            "target_id",
+            "log_position"
+          ],
+          "isUnique": false
+        },
+        "deltas_log_position_uniq": {
+          "name": "deltas_log_position_uniq",
+          "columns": [
+            "branch_id",
+            "log_position"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "deltas_branch_id_branches_id_fk": {
+          "name": "deltas_branch_id_branches_id_fk",
+          "tableFrom": "deltas",
+          "columnsFrom": [
+            "branch_id"
+          ],
+          "tableTo": "branches",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "entities": {
+      "name": "entities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch_id": {
+          "name": "branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "retired_reason": {
+          "name": "retired_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "injection_mode": {
+          "name": "injection_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_collision_flag": {
+          "name": "name_collision_flag",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "embedding_stale": {
+          "name": "embedding_stale",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "entities_stale_idx": {
+          "name": "entities_stale_idx",
+          "columns": [
+            "branch_id"
+          ],
+          "where": "\"entities\".\"embedding_stale\" = 1",
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "entities_branch_id_branches_id_fk": {
+          "name": "entities_branch_id_branches_id_fk",
+          "tableFrom": "entities",
+          "columnsFrom": [
+            "branch_id"
+          ],
+          "tableTo": "branches",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "entities_branch_id_id_pk": {
+          "columns": [
+            "branch_id",
+            "id"
+          ],
+          "name": "entities_branch_id_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "entry_assets": {
+      "name": "entry_assets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch_id": {
+          "name": "branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "entry_assets_branch_id_branches_id_fk": {
+          "name": "entry_assets_branch_id_branches_id_fk",
+          "tableFrom": "entry_assets",
+          "columnsFrom": [
+            "branch_id"
+          ],
+          "tableTo": "branches",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "entry_assets_asset_id_assets_id_fk": {
+          "name": "entry_assets_asset_id_assets_id_fk",
+          "tableFrom": "entry_assets",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "tableTo": "assets",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "entry_assets_branch_id_id_pk": {
+          "columns": [
+            "branch_id",
+            "id"
+          ],
+          "name": "entry_assets_branch_id_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "happening_awareness": {
+      "name": "happening_awareness",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch_id": {
+          "name": "branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "happening_id": {
+          "name": "happening_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "learned_at_entry_id": {
+          "name": "learned_at_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decay_resistance": {
+          "name": "decay_resistance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retrieval_count": {
+          "name": "retrieval_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "haw_natural_uniq": {
+          "name": "haw_natural_uniq",
+          "columns": [
+            "branch_id",
+            "character_id",
+            "happening_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "happening_awareness_branch_id_branches_id_fk": {
+          "name": "happening_awareness_branch_id_branches_id_fk",
+          "tableFrom": "happening_awareness",
+          "columnsFrom": [
+            "branch_id"
+          ],
+          "tableTo": "branches",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "happening_awareness_branch_id_id_pk": {
+          "columns": [
+            "branch_id",
+            "id"
+          ],
+          "name": "happening_awareness_branch_id_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "happening_involvements": {
+      "name": "happening_involvements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch_id": {
+          "name": "branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "happening_id": {
+          "name": "happening_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "happening_involvements_branch_id_branches_id_fk": {
+          "name": "happening_involvements_branch_id_branches_id_fk",
+          "tableFrom": "happening_involvements",
+          "columnsFrom": [
+            "branch_id"
+          ],
+          "tableTo": "branches",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "happening_involvements_branch_id_id_pk": {
+          "columns": [
+            "branch_id",
+            "id"
+          ],
+          "name": "happening_involvements_branch_id_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "happenings": {
+      "name": "happenings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch_id": {
+          "name": "branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "temporal": {
+          "name": "temporal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "occurred_at_entry_id": {
+          "name": "occurred_at_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "common_knowledge": {
+          "name": "common_knowledge",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "embedding_stale": {
+          "name": "embedding_stale",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "happenings_stale_idx": {
+          "name": "happenings_stale_idx",
+          "columns": [
+            "branch_id"
+          ],
+          "where": "\"happenings\".\"embedding_stale\" = 1",
+          "isUnique": false
+        },
+        "happenings_occurred_idx": {
+          "name": "happenings_occurred_idx",
+          "columns": [
+            "branch_id",
+            "occurred_at_entry_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "happenings_branch_id_branches_id_fk": {
+          "name": "happenings_branch_id_branches_id_fk",
+          "tableFrom": "happenings",
+          "columnsFrom": [
+            "branch_id"
+          ],
+          "tableTo": "branches",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "happenings_branch_id_id_pk": {
+          "columns": [
+            "branch_id",
+            "id"
+          ],
+          "name": "happenings_branch_id_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "happenings_mutual_excl": {
+          "name": "happenings_mutual_excl",
+          "value": "\"happenings\".\"occurred_at_entry_id\" IS NULL OR \"happenings\".\"temporal\" IS NULL"
+        }
+      }
+    },
+    "lore": {
+      "name": "lore",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch_id": {
+          "name": "branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "injection_mode": {
+          "name": "injection_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "embedding_stale": {
+          "name": "embedding_stale",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "lore_stale_idx": {
+          "name": "lore_stale_idx",
+          "columns": [
+            "branch_id"
+          ],
+          "where": "\"lore\".\"embedding_stale\" = 1",
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "lore_branch_id_branches_id_fk": {
+          "name": "lore_branch_id_branches_id_fk",
+          "tableFrom": "lore",
+          "columnsFrom": [
+            "branch_id"
+          ],
+          "tableTo": "branches",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "lore_branch_id_id_pk": {
+          "columns": [
+            "branch_id",
+            "id"
+          ],
+          "name": "lore_branch_id_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pipeline_runs": {
+      "name": "pipeline_runs",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_id": {
+          "name": "action_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "story_id": {
+          "name": "story_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "probe_captures": {
+      "name": "probe_captures",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch_id": {
+          "name": "branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_entry_id": {
+          "name": "target_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "capture_mode": {
+          "name": "capture_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding_model_id": {
+          "name": "embedding_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload_size": {
+          "name": "payload_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "probe_captures_branch_id_branches_id_fk": {
+          "name": "probe_captures_branch_id_branches_id_fk",
+          "tableFrom": "probe_captures",
+          "columnsFrom": [
+            "branch_id"
+          ],
+          "tableTo": "branches",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "probe_captures_branch_id_id_pk": {
+          "columns": [
+            "branch_id",
+            "id"
+          ],
+          "name": "probe_captures_branch_id_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stories": {
+      "name": "stories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "cover_asset_id": {
+          "name": "cover_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accent_color": {
+          "name": "accent_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "favorite": {
+          "name": "favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "definition": {
+          "name": "definition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_branch_id": {
+          "name": "current_branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "story_entries": {
+      "name": "story_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch_id": {
+          "name": "branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "story_entries_position_idx": {
+          "name": "story_entries_position_idx",
+          "columns": [
+            "branch_id",
+            "position"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "story_entries_branch_id_branches_id_fk": {
+          "name": "story_entries_branch_id_branches_id_fk",
+          "tableFrom": "story_entries",
+          "columnsFrom": [
+            "branch_id"
+          ],
+          "tableTo": "branches",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "story_entries_branch_id_id_pk": {
+          "columns": [
+            "branch_id",
+            "id"
+          ],
+          "name": "story_entries_branch_id_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "threads": {
+      "name": "threads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch_id": {
+          "name": "branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "injection_mode": {
+          "name": "injection_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "triggered_at_entry_id": {
+          "name": "triggered_at_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_at_entry_id": {
+          "name": "resolved_at_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding_stale": {
+          "name": "embedding_stale",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "threads_stale_idx": {
+          "name": "threads_stale_idx",
+          "columns": [
+            "branch_id"
+          ],
+          "where": "\"threads\".\"embedding_stale\" = 1",
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "threads_branch_id_branches_id_fk": {
+          "name": "threads_branch_id_branches_id_fk",
+          "tableFrom": "threads",
+          "columnsFrom": [
+            "branch_id"
+          ],
+          "tableTo": "branches",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "threads_branch_id_id_pk": {
+          "columns": [
+            "branch_id",
+            "id"
+          ],
+          "name": "threads_branch_id_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "translations": {
+      "name": "translations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch_id": {
+          "name": "branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field": {
+          "name": "field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "translated_text": {
+          "name": "translated_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "translations_natural_uniq": {
+          "name": "translations_natural_uniq",
+          "columns": [
+            "branch_id",
+            "target_kind",
+            "target_id",
+            "field",
+            "language"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "translations_branch_id_branches_id_fk": {
+          "name": "translations_branch_id_branches_id_fk",
+          "tableFrom": "translations",
+          "columnsFrom": [
+            "branch_id"
+          ],
+          "tableTo": "branches",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "translations_branch_id_id_pk": {
+          "columns": [
+            "branch_id",
+            "id"
+          ],
+          "name": "translations_branch_id_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vault_calendars": {
+      "name": "vault_calendars",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "definition": {
+          "name": "definition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "favorite": {
+          "name": "favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wizard_sessions": {
+      "name": "wizard_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "story_id": {
+          "name": "story_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1787932402772,
       "tag": "0010_entries_position_idx",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1788666500428,
+      "tag": "0011_keyword_retrieval_settings",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/migrations/migrations.js
+++ b/lib/db/migrations/migrations.js
@@ -12,6 +12,7 @@ import m0007 from './0007_retrieval_budget_tokens.sql'
 import m0008 from './0008_happenings_occurred_idx.sql'
 import m0009 from './0009_blue_pet_avengers.sql'
 import m0010 from './0010_entries_position_idx.sql'
+import m0011 from './0011_keyword_retrieval_settings.sql'
 
 export default {
   journal,
@@ -27,5 +28,6 @@ export default {
     m0008,
     m0009,
     m0010,
+    m0011,
   },
 }

--- a/lib/db/probe-capture-types.ts
+++ b/lib/db/probe-capture-types.ts
@@ -90,7 +90,7 @@ type CaptureTokenizer = { encoding: string; version: string }
  * Bumped when a captured field's shape or meaning changes, so a decode can
  * warn instead of silently misreading an older payload as the current type.
  */
-export const CAPTURE_VERSION = 3 as const
+export const CAPTURE_VERSION = 4 as const
 
 export type ProbeCapturePayload = {
   capture_version: number
@@ -103,6 +103,13 @@ export type ProbeCapturePayload = {
   tokenizer: CaptureTokenizer
   params: CaptureParamsSnapshot
   queries: [CaptureQuery, CaptureQuery, CaptureQuery]
+  /**
+   * The narrative text kw_boost_value was matched against — separate from
+   * `queries` because the scan surface is defined independently of them and is
+   * never embedded (probe.md → Keyword scan surface). Captured in both modes;
+   * without it a non-zero kw_boost_value has no readable cause in the capture.
+   */
+  scan_text: string
   pools: Record<RetrievalType, CaptureCandidate[]>
   funnels: Record<RetrievalType, PoolFunnelSummary>
   structural_floor: StructuralFloorRow[]

--- a/lib/db/stories/settings-ops.test.ts
+++ b/lib/db/stories/settings-ops.test.ts
@@ -50,6 +50,13 @@ describe('story settings ops', () => {
         threads: 400,
         chapters: 600,
       },
+      keywordRetrieval: {
+        mode: 'boost',
+        budgetShare: 0.5,
+        scanEntries: 1,
+        cascade: false,
+        cascadeMaxDepth: 2,
+      },
       probe_mode_active: false,
       composerModesEnabled: false,
       composerWrapPov: 'third',

--- a/lib/db/stories/story-config-schema.test.ts
+++ b/lib/db/stories/story-config-schema.test.ts
@@ -30,6 +30,13 @@ const VALID_SETTINGS = {
   embeddingBackend: 'local' as const,
   embedding_model_id: 'bge-small',
   retrievalBudgets: { entities: 100, lore: 100, happenings: 100, threads: 100, chapters: 100 },
+  keywordRetrieval: {
+    mode: 'boost' as const,
+    budgetShare: 0.5,
+    scanEntries: 1,
+    cascade: false,
+    cascadeMaxDepth: 2,
+  },
   probe_mode_active: false,
   composerModesEnabled: false,
   composerWrapPov: 'first' as const,
@@ -219,6 +226,47 @@ describe('storySettingsSchema spec-pinned defaults', () => {
       expect(r.success).toBe(false)
     },
   )
+})
+
+describe('storySettingsSchema keywordRetrieval', () => {
+  const withKeyword = (over: Record<string, unknown>) => ({
+    ...VALID_SETTINGS,
+    keywordRetrieval: { ...VALID_SETTINGS.keywordRetrieval, ...over },
+  })
+
+  // Required, not defaulted: settings writes are key-scoped json_set, so a
+  // default here would never reach an existing story's blob. Migration 0011
+  // backfills it instead, and this assertion is what keeps the two in step.
+  it('requires the key', () => {
+    const { keywordRetrieval: _omitted, ...without } = VALID_SETTINGS
+    expect(storySettingsSchema.safeParse(without).success).toBe(false)
+  })
+
+  it('accepts both modes', () => {
+    expect(storySettingsSchema.safeParse(withKeyword({ mode: 'boost' })).success).toBe(true)
+    expect(storySettingsSchema.safeParse(withKeyword({ mode: 'inject' })).success).toBe(true)
+    expect(storySettingsSchema.safeParse(withKeyword({ mode: 'always' })).success).toBe(false)
+  })
+
+  it('bounds budgetShare to 0..1', () => {
+    expect(storySettingsSchema.safeParse(withKeyword({ budgetShare: 0 })).success).toBe(true)
+    expect(storySettingsSchema.safeParse(withKeyword({ budgetShare: 1 })).success).toBe(true)
+    expect(storySettingsSchema.safeParse(withKeyword({ budgetShare: 1.5 })).success).toBe(false)
+    expect(storySettingsSchema.safeParse(withKeyword({ budgetShare: -0.1 })).success).toBe(false)
+  })
+
+  // The user action is always scanned, so this counts the trailing entries
+  // beside it and one is the floor rather than zero.
+  it('floors scanEntries at one whole entry', () => {
+    expect(storySettingsSchema.safeParse(withKeyword({ scanEntries: 1 })).success).toBe(true)
+    expect(storySettingsSchema.safeParse(withKeyword({ scanEntries: 0 })).success).toBe(false)
+    expect(storySettingsSchema.safeParse(withKeyword({ scanEntries: 1.5 })).success).toBe(false)
+  })
+
+  it('floors cascadeMaxDepth at one', () => {
+    expect(storySettingsSchema.safeParse(withKeyword({ cascadeMaxDepth: 1 })).success).toBe(true)
+    expect(storySettingsSchema.safeParse(withKeyword({ cascadeMaxDepth: 0 })).success).toBe(false)
+  })
 })
 
 describe('storySettingsPartialSchema', () => {

--- a/lib/db/stories/story-config-schema.ts
+++ b/lib/db/stories/story-config-schema.ts
@@ -73,6 +73,23 @@ const retrievalBudgetsSchema = z.object({
   chapters: tokenBudget,
 })
 
+// A second axis beside injection_mode, which answers whether a row injects at
+// all; this answers what a keyword HIT does (docs/memory/retrieval.md → Keyword
+// injection). Only scanEntries is live while mode is 'boost' — it sizes the
+// keyword haystack in both modes.
+const keywordRetrievalSchema = z.object({
+  mode: z.enum(['boost', 'inject']),
+  // A share of each per-type budget, bounded here for the reason tokenBudget is:
+  // out of range it silently starves or floods one partition, and the trace
+  // blames the candidates.
+  budgetShare: z.number().min(0).max(1),
+  // Counts the trailing entries BESIDE the user action, which is always scanned —
+  // so one is the floor, not zero.
+  scanEntries: z.number().int().min(1),
+  cascade: z.boolean(),
+  cascadeMaxDepth: z.number().int().min(1),
+})
+
 const translationSchema = z.object({
   enabled: z.boolean(),
   targetLanguage: z.string().nullable(),
@@ -122,6 +139,7 @@ export const storySettingsSchema = z.object({
   embedding_swap_target_dim: z.number().int().positive().optional(),
   embedding_provider_id: z.string().optional(),
   retrievalBudgets: retrievalBudgetsSchema,
+  keywordRetrieval: keywordRetrievalSchema,
   effectiveDim: z.number().int().positive().optional(),
   probe_mode_active: z.boolean().default(false),
   composerModesEnabled: z.boolean(),

--- a/lib/db/stories/story-settings-defaults.test.ts
+++ b/lib/db/stories/story-settings-defaults.test.ts
@@ -23,6 +23,17 @@ describe('STORY_SETTINGS_DEFAULTS', () => {
   it('is a complete, parseable StorySettings', () => {
     expect(() => storySettingsSchema.parse(STORY_SETTINGS_DEFAULTS)).not.toThrow()
   })
+  // 'boost' is the shipped behaviour, so a story migrating in behaves exactly as
+  // it did. The rest are inert until keyword injection lands.
+  it('starts the keyword pathway on boost with a one-entry scan', () => {
+    expect(STORY_SETTINGS_DEFAULTS.keywordRetrieval).toEqual({
+      mode: 'boost',
+      budgetShare: 0.5,
+      scanEntries: 1,
+      cascade: false,
+      cascadeMaxDepth: 2,
+    })
+  })
   it('has all M2-inert features off', () => {
     expect(STORY_SETTINGS_DEFAULTS.translation.enabled).toBe(false)
     expect(STORY_SETTINGS_DEFAULTS.composerModesEnabled).toBe(false)

--- a/lib/db/stories/story-settings-defaults.ts
+++ b/lib/db/stories/story-settings-defaults.ts
@@ -21,6 +21,15 @@ export const STORY_SETTINGS_DEFAULTS: StorySettings = {
   // entity block's macro wrapping alone costs 11 tokens before a word of the
   // row itself, so a count-shaped value here seats nothing.
   retrievalBudgets: { entities: 1200, lore: 1800, happenings: 1500, threads: 400, chapters: 600 },
+  // budgetShare 0.5 is a starting guess wanting calibration against real stories,
+  // in the same sense as the blend weights — not a derived value.
+  keywordRetrieval: {
+    mode: 'boost',
+    budgetShare: 0.5,
+    scanEntries: 1,
+    cascade: false,
+    cascadeMaxDepth: 2,
+  },
   probe_mode_active: false,
   composerModesEnabled: false,
   composerWrapPov: 'third',

--- a/lib/pipeline/definitions/per-turn-retrieval.test.ts
+++ b/lib/pipeline/definitions/per-turn-retrieval.test.ts
@@ -1180,6 +1180,72 @@ describe('retrieval phase — RetrievalParams assembly', () => {
     expect(recentProse).not.toContain('ancient-prose')
   })
 
+  it('scans this turn\u2019s action and the entry standing before it', async () => {
+    seedOpenStory({
+      entries: [
+        entry(1, 'opening', 'The keep stands.', meta()),
+        entry(2, 'ai_reply', 'The Veilstone hummed.', meta()),
+        entry(3, 'user_action', 'I draw the blade.', meta()),
+      ],
+    })
+
+    await runRetrievalPhase()
+
+    const { scanText } = lastParams()
+    expect(scanText).toContain('I draw the blade.')
+    expect(scanText).toContain('The Veilstone hummed.')
+    // scanEntries defaults to one, so the opening stays out.
+    expect(scanText).not.toContain('The keep stands.')
+  })
+
+  it('carries the action once, not twice', async () => {
+    seedOpenStory({
+      entries: [
+        entry(1, 'ai_reply', 'The Veilstone hummed.', meta()),
+        entry(2, 'user_action', 'I draw the blade.', meta()),
+      ],
+    })
+
+    await runRetrievalPhase()
+
+    expect(lastParams().scanText.split('I draw the blade.')).toHaveLength(2)
+  })
+
+  // The whole reason the surface has its own read: protectedBuffer 0 with a
+  // one-entry partial window would otherwise hand it less prose than the story
+  // asked for, and say nothing about it.
+  it('reaches scanEntries deep regardless of the prompt-buffer knobs', async () => {
+    seedOpenStory({
+      settings: {
+        partialChapterBuffer: 1,
+        protectedBuffer: 0,
+        keywordRetrieval: {
+          mode: 'boost',
+          budgetShare: 0.5,
+          scanEntries: 3,
+          cascade: false,
+          cascadeMaxDepth: 2,
+        },
+      },
+      entries: [
+        entry(1, 'opening', 'ancient-prose', meta()),
+        entry(2, 'ai_reply', 'older-prose', meta()),
+        entry(3, 'ai_reply', 'recent-prose', meta()),
+        entry(4, 'user_action', 'newest-prose', meta()),
+      ],
+    })
+
+    await runRetrievalPhase()
+
+    const { scanText, recentProse } = lastParams()
+    expect(scanText).toContain('older-prose')
+    expect(scanText).toContain('recent-prose')
+    expect(scanText).toContain('newest-prose')
+    // Positive control: the prompt buffer really is narrower here, so the
+    // assertions above are about the dedicated read and not a wide window.
+    expect(recentProse).not.toContain('older-prose')
+  })
+
   // entriesStore holds the reader's window, which grows and shrinks with scroll
   // position — sourcing the buffer from it makes the prompt a function of where
   // the reader happened to be looking.

--- a/lib/pipeline/definitions/per-turn-retrieval.test.ts
+++ b/lib/pipeline/definitions/per-turn-retrieval.test.ts
@@ -1324,6 +1324,23 @@ describe('retrieval phase — probe capture', () => {
     })
   })
 
+  // The scan surface is defined independently of the queries, so a kw_boost_value
+  // has no readable cause in the capture unless the text itself is carried.
+  it('captures the scan surface the pass matched keywords against', async () => {
+    const { db, sqlite, runInTransaction } = await probeDb()
+    await setAppGate(db, true)
+    seedProbeStory({ probe_mode_active: true })
+    runRetrievalMock.mockResolvedValue(retrievalSuccess({ queries: queryStack() }))
+
+    await runRetrievalPhase(undefined, runInTransaction)
+
+    const payload = payloadOf(captureRows(sqlite)[0])
+    expect(payload.scan_text).toContain('I draw the blade.')
+    expect(payload.scan_text).toContain('The keep stands.')
+    // Sourced from the pass, not re-derived from the queries beside it.
+    expect(payload.queries.map((q) => q.text)).not.toContain(payload.scan_text)
+  })
+
   it('captures a failed pass with its reason and the queries it reached', async () => {
     const { db, sqlite, runInTransaction } = await probeDb()
     await setAppGate(db, true)

--- a/lib/pipeline/definitions/per-turn-retrieval.ts
+++ b/lib/pipeline/definitions/per-turn-retrieval.ts
@@ -10,9 +10,11 @@ import { generateId } from '@/lib/ids'
 import { promptProse } from '@/lib/piggyback'
 import { commitCaptureMode, reserveCaptureMode, writeProbeCapture } from '@/lib/probe'
 import {
+  buildScanText,
   countTokens,
   RANKER_DEFAULTS,
   readPromptBuffer,
+  readScanEntries,
   runRetrieval,
   type RetrievalOutcome,
 } from '@/lib/retrieval'
@@ -77,6 +79,15 @@ export async function* retrievalPhase(
     .map((e) => promptProse(e))
     .join('\n')
 
+  // Its own read, not a slice of the buffer above: the keyword scan surface is
+  // defined independently of the prompt window (retrieval.md → Keyword scan
+  // surface), which protectedBuffer can make narrower than scanEntries.
+  const scanEntries = await readScanEntries(
+    ctx.db,
+    branchId,
+    open.settings.keywordRetrieval.scanEntries,
+  )
+
   // A provider that accepts the connection and stalls would otherwise park the
   // turn forever holding the hard gate, with the pill still offering a Cancel
   // that reaches nothing.
@@ -132,6 +143,10 @@ export async function* retrievalPhase(
         // under partialChapterBuffer and under-suppressing past it (cadence.md →
         // User-tunable knobs).
         recentProse: promptBuffer,
+        scanText: buildScanText({
+          userAction: tail?.kind === 'user_action' ? tail.content : '',
+          trailing: scanEntries,
+        }),
       },
     )
   } finally {

--- a/lib/pipeline/definitions/per-turn-retrieval.ts
+++ b/lib/pipeline/definitions/per-turn-retrieval.ts
@@ -87,6 +87,10 @@ export async function* retrievalPhase(
     branchId,
     open.settings.keywordRetrieval.scanEntries,
   )
+  const scanText = buildScanText({
+    userAction: tail?.kind === 'user_action' ? tail.content : '',
+    trailing: scanEntries,
+  })
 
   // A provider that accepts the connection and stalls would otherwise park the
   // turn forever holding the hard gate, with the pill still offering a Cancel
@@ -143,10 +147,7 @@ export async function* retrievalPhase(
         // under partialChapterBuffer and under-suppressing past it (cadence.md →
         // User-tunable knobs).
         recentProse: promptBuffer,
-        scanText: buildScanText({
-          userAction: tail?.kind === 'user_action' ? tail.content : '',
-          trailing: scanEntries,
-        }),
+        scanText,
       },
     )
   } finally {
@@ -199,6 +200,7 @@ export async function* retrievalPhase(
           protectedBuffer: open.settings.protectedBuffer,
         },
         promptBufferTokens: countTokens(promptBuffer),
+        scanText,
         outcome: probed,
       },
     )

--- a/lib/probe/__tests__/fixtures.ts
+++ b/lib/probe/__tests__/fixtures.ts
@@ -88,6 +88,7 @@ export const captureInput = (overrides: Partial<CaptureWriteInput> = {}): Captur
   params: RANKER_DEFAULTS,
   settings,
   promptBufferTokens: 0,
+  scanText: '',
   outcome: successOutcome(),
   ...overrides,
 })

--- a/lib/probe/compress.test.ts
+++ b/lib/probe/compress.test.ts
@@ -49,6 +49,7 @@ const capturePayload = (): ProbeCapturePayload => ({
       sentence_scores: [0.9, 0.6, 0.4],
     },
   ],
+  scan_text: 'What does the party do next?\nThe bridge fell during the third night of the siege.',
   // Three bands mirror rankPerType (lib/retrieval/ranker.ts:196-211): a
   // pre-filtered row never reaches MMR, so only it gets null text/tokens.
   pools: {

--- a/lib/probe/payload.test.ts
+++ b/lib/probe/payload.test.ts
@@ -36,6 +36,7 @@ const identity = {
   capturedAt: 1_700_000_000_000,
   embeddingModelId: 'Xenova/all-MiniLM-L6-v2',
   promptBufferTokens: 0,
+  scanText: '',
 }
 
 const zeroFunnel = {
@@ -207,6 +208,7 @@ describe('buildCapturePayload', () => {
       'pools',
       'prompt_buffer_tokens',
       'queries',
+      'scan_text',
       'stale_counts',
       'structural_floor',
       'target_entry_id',
@@ -228,6 +230,7 @@ describe('buildCapturePayload', () => {
       settings,
       params: RANKER_DEFAULTS,
       promptBufferTokens: 0,
+      scanText: '',
       outcome: successOutcome(),
     })
 
@@ -238,7 +241,7 @@ describe('buildCapturePayload', () => {
       captured_at: 1_700_000_000_123,
       embedding_model_id: 'Xenova/all-MiniLM-L6-v2',
       capture_mode: 'light',
-      capture_version: 3,
+      capture_version: 4,
     })
   })
 
@@ -450,6 +453,36 @@ describe('buildCapturePayload', () => {
     expect(payload.pools.chapters[0].target_id).toBe('ch_1')
     expect(payload.funnels.chapters.pool_size).toBe(1)
     expectEmptyPools(payload, ['chapters'])
+  })
+
+  it('carries the scan surface the keyword pathway matched against', () => {
+    // The queries are the wrong place to look for it: the scan surface is
+    // defined independently of them, so a kw_boost_value has no readable cause
+    // anywhere else in the capture.
+    const payload = buildCapturePayload({
+      ...identity,
+      scanText: 'I draw the blade.\nThe Veilstone hummed.',
+      mode: 'light',
+      settings,
+      params: RANKER_DEFAULTS,
+      outcome: successOutcome(),
+    })
+
+    expect(payload.scan_text).toBe('I draw the blade.\nThe Veilstone hummed.')
+    expect(payload.queries.map((q) => q.text)).not.toContain(payload.scan_text)
+  })
+
+  it('captures the scan surface in deep mode too, since kw_boost fires in both', () => {
+    const payload = buildCapturePayload({
+      ...identity,
+      scanText: 'The Veilstone hummed.',
+      mode: 'deep',
+      settings,
+      params: RANKER_DEFAULTS,
+      outcome: successOutcome(),
+    })
+
+    expect(payload.scan_text).toBe('The Veilstone hummed.')
   })
 
   it('carries the prompt buffer cost the phase priced, and no failure reason on a good pass', () => {

--- a/lib/probe/payload.ts
+++ b/lib/probe/payload.ts
@@ -38,6 +38,8 @@ export type CapturePayloadInput = {
   /** Priced on the composed buffer, not re-derived: the mode-dependent rule and
    * protected-buffer spillover are the phase's to resolve, not the capture's. */
   promptBufferTokens: number
+  /** The scan surface the pass ran with (retrieval.md → Keyword scan surface). */
+  scanText: string
   outcome: RetrievalOutcome
 }
 
@@ -190,6 +192,7 @@ export function buildCapturePayload(input: CapturePayloadInput): ProbeCapturePay
       retrievalBudgets: { ...input.settings.retrievalBudgets },
     },
     queries: queriesOf(stack),
+    scan_text: input.scanText,
     pools: {
       entities: poolOf(bundles.entities, mode),
       lore: poolOf(bundles.lore, mode),

--- a/lib/retrieval/index.ts
+++ b/lib/retrieval/index.ts
@@ -23,6 +23,8 @@ export type {
   RetrievalSuccess,
   RetrievalTimings,
 } from './run'
+export { buildScanText, readScanEntries } from './scan-surface'
+export type { ScanSurfaceInput } from './scan-surface'
 export { runSyncStage } from './sync'
 export type { SyncStageDeps, SyncStageResult } from './sync'
 export { countEntryTokens, countTokens, TOKENIZER_IDENTITY } from './tokens'

--- a/lib/retrieval/name-index.test.ts
+++ b/lib/retrieval/name-index.test.ts
@@ -163,7 +163,34 @@ describe('matchTerms — per-term script rule', () => {
     expect(matchTerms('その月光 剣士', [normalizeTerm('月光 剣')])).toEqual([])
   })
 
-  it('still escapes regex metacharacters in a mixed-script term', () => {
-    expect(matchTerms('the 月光*剣 hummed', [normalizeTerm('月光*剣')])).toEqual(['月光*剣'])
+  // A single CJK character must not drag a mostly-Latin term into substring
+  // mode — the failure the per-term rule exists to prevent.
+  it('denies substring mode to a term carrying a letter from another script', () => {
+    expect(matchTerms('a veilstone月stone', [normalizeTerm('veilstone月')])).toEqual([])
+  })
+
+  it('counts characters, not UTF-16 units, at the two-character floor', () => {
+    // U+20BB7 is one ideograph and two code units; length >= 2 would admit it.
+    expect(matchTerms('彼は𠮷を見た。', [normalizeTerm('\u{20BB7}')])).toEqual([])
+  })
+
+  // The positive half of the same rule: iterating UTF-16 units instead of code
+  // points leaves every char a lone surrogate, which is neither Han nor a
+  // letter, so an astral term would fall out of substring mode entirely.
+  it('matches an astral ideograph pair by substring', () => {
+    const term = '\u{20BB7}\u{20BB7}'
+    expect(matchTerms(`彼は${term}を見た。`, [normalizeTerm(term)])).toEqual([term])
+  })
+
+  it('treats the ideographic space as an author-supplied delimiter', () => {
+    // U+3000 is the space a CJK author actually types; ' ' alone misses it.
+    expect(matchTerms('その月光\u3000剣士', [normalizeTerm('月光\u3000剣')])).toEqual([])
+  })
+
+  // Metacharacters only reach escape() on the boundary branch, so the term has
+  // to be one that stays there — a substring-mode term never sees it.
+  it('escapes regex metacharacters in a term the script rule sends to boundaries', () => {
+    expect(matchTerms('the vex*月 hummed', [normalizeTerm('vex*月')])).toEqual(['vex*月'])
+    expect(matchTerms('the vexX月 hummed', [normalizeTerm('vex*月')])).toEqual([])
   })
 })

--- a/lib/retrieval/name-index.test.ts
+++ b/lib/retrieval/name-index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { matchTerms, nameKeywordIndexFrom, parseKeywords } from './name-index'
+import { matchTerms, nameKeywordIndexFrom, normalizeTerm, parseKeywords } from './name-index'
 
 const named = (...names: string[]) => names.map((name) => ({ name }))
 const keyworded = (...lists: string[][]) => lists.map((keywords) => ({ keywords }))
@@ -122,5 +122,48 @@ describe('matchTerms', () => {
       'mira',
       'veilstone',
     ])
+  })
+})
+
+// docs/memory/retrieval.md → Keyword scan surface: the match rule follows the
+// script of the keyword, per keyword.
+describe('matchTerms — per-term script rule', () => {
+  it('matches an unspaced Han term by substring', () => {
+    // Japanese prose supplies no inter-word space to anchor a boundary against,
+    // so the \p{L}\p{N} lookarounds can never fire inside it.
+    expect(matchTerms('彼女は月光剣を抜いた。', [normalizeTerm('月光剣')])).toEqual(['月光剣'])
+  })
+
+  it('matches a kana term', () => {
+    expect(matchTerms('カラたちは村へ戻った。', [normalizeTerm('カラ')])).toEqual(['カラ'])
+  })
+
+  it('matches a hangul term carrying an attached particle', () => {
+    expect(matchTerms('그는 은빛검을 들었다.', [normalizeTerm('은빛검')])).toEqual(['은빛검'])
+  })
+
+  it('keeps boundary matching for Latin terms', () => {
+    expect(matchTerms('he made a start on it', [normalizeTerm('art')])).toEqual([])
+  })
+
+  it('keeps boundary matching for Cyrillic terms', () => {
+    expect(matchTerms('Незоя вошла', [normalizeTerm('зоя')])).toEqual([])
+  })
+
+  it('denies substring mode to a single-character term', () => {
+    // One ideograph appears inside too much to carry signal.
+    expect(matchTerms('彼女は月光剣を抜いた。', [normalizeTerm('剣')])).toEqual([])
+  })
+
+  // An internal space means the author supplied a delimiter, so the term keeps
+  // boundary mode — which in CJK prose means it matches only where real
+  // punctuation or spacing brackets it, never mid-run.
+  it('denies substring mode to a term the author already delimited', () => {
+    expect(matchTerms('月光 剣。', [normalizeTerm('月光 剣')])).toEqual(['月光 剣'])
+    expect(matchTerms('その月光 剣士', [normalizeTerm('月光 剣')])).toEqual([])
+  })
+
+  it('still escapes regex metacharacters in a mixed-script term', () => {
+    expect(matchTerms('the 月光*剣 hummed', [normalizeTerm('月光*剣')])).toEqual(['月光*剣'])
   })
 })

--- a/lib/retrieval/name-index.ts
+++ b/lib/retrieval/name-index.ts
@@ -65,12 +65,25 @@ function boundaryPattern(term: string): RegExp {
 // morphemes — the "art" inside "start" risk boundaries exist to prevent is far
 // lower. docs/memory/retrieval.md → Keyword scan surface.
 const UNSPACED_SCRIPT = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u
+const LETTER = /\p{L}/u
+// \s, not ' ': U+3000 IDEOGRAPHIC SPACE is the delimiter a CJK author actually
+// types, so the ASCII space alone covers the wrong half of the set.
+const ANY_SPACE = /\s/u
 
-// Per term, not per haystack: a story mixing scripts must not put its Latin
-// keywords into substring mode. An internal space is an author-supplied
-// delimiter, and one character appears inside too much to carry signal.
+// Composed of those scripts, not merely containing one — a mostly-Latin term
+// with a single CJK character must keep boundary anchoring. Iterated by code
+// point so an astral ideograph counts as the one character it is rather than as
+// two UTF-16 units. An internal space is an author-supplied delimiter, and one
+// character appears inside too much to carry signal.
 function usesSubstringMatch(term: string): boolean {
-  return term.length >= 2 && !term.includes(' ') && UNSPACED_SCRIPT.test(term)
+  const chars = [...term]
+  if (chars.length < 2 || ANY_SPACE.test(term)) return false
+  let sawUnspacedScript = false
+  for (const char of chars) {
+    if (UNSPACED_SCRIPT.test(char)) sawUnspacedScript = true
+    else if (LETTER.test(char)) return false
+  }
+  return sawUnspacedScript
 }
 
 export function matchTerms(text: string, terms: Iterable<string>): string[] {

--- a/lib/retrieval/name-index.ts
+++ b/lib/retrieval/name-index.ts
@@ -54,10 +54,23 @@ function escape(term: string): string {
 
 // Plain \b is ASCII-only and misses accented/Cyrillic names entirely (e.g.
 // "Zoë" never matches). \p{L}/\p{N} lookarounds cover any script with
-// letter/number boundaries; scripts without word delimiters (CJK) are a
-// separate segmentation problem this doesn't attempt to solve.
+// letter/number boundaries.
 function boundaryPattern(term: string): RegExp {
   return new RegExp(String.raw`(?<![\p{L}\p{N}_])${escape(term)}(?![\p{L}\p{N}_])`, 'u')
+}
+
+// Han, kana and hangul supply no inter-word delimiter (Korean attaches particles
+// straight onto nouns), so boundary lookarounds silently never fire inside their
+// prose. Substring is safe for these scripts because their characters are
+// morphemes — the "art" inside "start" risk boundaries exist to prevent is far
+// lower. docs/memory/retrieval.md → Keyword scan surface.
+const UNSPACED_SCRIPT = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u
+
+// Per term, not per haystack: a story mixing scripts must not put its Latin
+// keywords into substring mode. An internal space is an author-supplied
+// delimiter, and one character appears inside too much to carry signal.
+function usesSubstringMatch(term: string): boolean {
+  return term.length >= 2 && !term.includes(' ') && UNSPACED_SCRIPT.test(term)
 }
 
 export function matchTerms(text: string, terms: Iterable<string>): string[] {
@@ -68,6 +81,10 @@ export function matchTerms(text: string, terms: Iterable<string>): string[] {
   for (const term of terms) {
     if (term === '') continue
     if (!haystack.includes(term)) continue
+    if (usesSubstringMatch(term)) {
+      hits.push(term)
+      continue
+    }
     // Boundary-anchored: a substring hit (e.g. "Mira" inside "miracle") would
     // wrongly fire Layer-A suppression / kw_boost on ordinary prose.
     if (boundaryPattern(term).test(haystack)) hits.push(term)

--- a/lib/retrieval/run.test.ts
+++ b/lib/retrieval/run.test.ts
@@ -214,13 +214,7 @@ const params = (
   over: Partial<Omit<RetrievalParams, 'query'>> & {
     query?: Partial<RetrievalParams['query']>
   } = {},
-): RetrievalParams => {
-  const query = { ...BASE.query, ...over.query }
-  // Production derives both from the same turn, so a test that varies the action
-  // would otherwise keep scanning BASE's prose. An explicit scanText still wins.
-  const scanText = [query.userAction, query.lastNarrativeContent].filter((s) => s !== '').join('\n')
-  return { ...BASE, scanText, ...over, query }
-}
+): RetrievalParams => ({ ...BASE, ...over, query: { ...BASE.query, ...over.query } })
 
 function expectOk(out: RetrievalOutcome): RetrievalSuccess {
   if (!out.ok)
@@ -1629,7 +1623,7 @@ describe('runRetrieval — keyword boost', () => {
     expect(boost('lore_scalar')).toBe(0)
   })
 
-  it('matches a decomposed keyword against composed query prose', async () => {
+  it('matches a decomposed keyword against composed scan prose', async () => {
     // matchTerms NFC-normalizes its haystack but not its terms, so a keyword
     // stored decomposed never matches composed prose unless the term is
     // normalized the same way.
@@ -1645,7 +1639,7 @@ describe('runRetrieval — keyword boost', () => {
           knn: [hit('lore_nfd'), hit('lore_ascii')],
         }),
       }),
-      params({ query: { userAction: `I ask ${nfc} about the amulet.` } }),
+      params({ scanText: `I ask ${nfc} about the amulet.` }),
     )
 
     const ok = expectOk(out)

--- a/lib/retrieval/run.test.ts
+++ b/lib/retrieval/run.test.ts
@@ -207,13 +207,20 @@ const BASE: RetrievalParams = {
   sceneEntityIds: ['char_a'],
   currentLocationId: null,
   recentProse: '',
+  scanText: 'I ask about the amulet.\nKara Vex drew the blade.',
 }
 
 const params = (
   over: Partial<Omit<RetrievalParams, 'query'>> & {
     query?: Partial<RetrievalParams['query']>
   } = {},
-): RetrievalParams => ({ ...BASE, ...over, query: { ...BASE.query, ...over.query } })
+): RetrievalParams => {
+  const query = { ...BASE.query, ...over.query }
+  // Production derives both from the same turn, so a test that varies the action
+  // would otherwise keep scanning BASE's prose. An explicit scanText still wins.
+  const scanText = [query.userAction, query.lastNarrativeContent].filter((s) => s !== '').join('\n')
+  return { ...BASE, scanText, ...over, query }
+}
 
 function expectOk(out: RetrievalOutcome): RetrievalSuccess {
   if (!out.ok)
@@ -1550,25 +1557,53 @@ describe('runRetrieval — name/keyword index', () => {
 })
 
 describe('runRetrieval — keyword boost', () => {
-  it('matches the candidate keyword surface against the query texts, Q2 included', async () => {
+  const twoLoreRows = () =>
+    makeQueryAll({
+      lore: [
+        loreRow('lore_hit', 'The Veil', { keywords: ['Veilstone'] }),
+        loreRow('lore_miss', 'The Drift', { keywords: ['Driftmark'] }),
+      ],
+      knn: [hit('lore_hit'), hit('lore_miss')],
+    })
+
+  it('matches the candidate keyword surface against the scan text', async () => {
     const out = await runRetrieval(
-      deps({
-        queryAll: makeQueryAll({
-          lore: [
-            loreRow('lore_hit', 'The Veil', { keywords: ['Veilstone'] }),
-            loreRow('lore_miss', 'The Drift', { keywords: ['Driftmark'] }),
-          ],
-          knn: [hit('lore_hit'), hit('lore_miss')],
-        }),
-      }),
-      // The era name reaches the query stack through Q2 only.
-      params({ query: { eraName: 'Veilstone' } }),
+      deps({ queryAll: twoLoreRows() }),
+      params({ scanText: 'The Veilstone hummed under her hand.' }),
     )
 
     const ok = expectOk(out)
     const boost = (id: string) => ok.bundles.lore.traces.find((t) => t.id === id)?.kwBoostValue
     expect(boost('lore_hit')).toBeGreaterThan(0)
     expect(boost('lore_miss')).toBe(0)
+  })
+
+  // The digest is assembled from entity names, the location and thread titles —
+  // synthetic text, not something the prose said. Matching it manufactured a hit
+  // on every turn the named row was on stage.
+  it('does not boost on a term reaching only the structural digest', async () => {
+    const out = await runRetrieval(
+      deps({ queryAll: twoLoreRows() }),
+      // The era name reaches the query stack through Q2 only.
+      params({ query: { eraName: 'Veilstone' }, scanText: 'I ask about the amulet.' }),
+    )
+
+    expect(expectOk(out).bundles.lore.traces.find((t) => t.id === 'lore_hit')?.kwBoostValue).toBe(0)
+  })
+
+  // Q3 selects top-K sentences, so a proper noun in a sentence the extract
+  // skipped could never fire while the haystack came from the query stack.
+  it('boosts on prose Q3 left out of its extract', async () => {
+    const out = await runRetrieval(
+      deps({ queryAll: twoLoreRows() }),
+      params({
+        scanText: `${'Rain fell over the long grey afternoon. '.repeat(12)}The Veilstone hummed.`,
+      }),
+    )
+
+    expect(
+      expectOk(out).bundles.lore.traces.find((t) => t.id === 'lore_hit')?.kwBoostValue,
+    ).toBeGreaterThan(0)
   })
 
   it('keeps ranking a lore row whose keywords blob is unusable', async () => {

--- a/lib/retrieval/run.ts
+++ b/lib/retrieval/run.ts
@@ -84,6 +84,12 @@ export type RetrievalParams = {
   currentLocationId: string | null
   /** Un-classified buffer prose, for Layer-A suppression. */
   recentProse: string
+  /**
+   * The keyword haystack: this turn's action plus the trailing entries
+   * (retrieval.md → Keyword scan surface). Independent of `query` by design —
+   * see buildScanText.
+   */
+  scanText: string
 }
 
 /**
@@ -313,10 +319,7 @@ async function runRetrievalPass(
     happenings: [] as readonly LoadedHappeningRow[],
     awareness,
     recentProse: params.recentProse,
-    // kw_boost is keyword_boost(c, queries) (retrieval.md → Pseudocode): the
-    // present query texts, which is where the era name and the piggyback
-    // summary become keyword surfaces.
-    queryText: queries.embedTexts.join('\n'),
+    scanText: params.scanText,
   }
 
   // A literal, not a built-up Record, so a missing key is a build error here
@@ -486,7 +489,7 @@ type PoolCtx = {
   happenings: readonly LoadedHappeningRow[]
   awareness: readonly AwarenessRow[]
   recentProse: string
-  queryText: string
+  scanText: string
 }
 
 /**
@@ -662,12 +665,12 @@ function assembleCandidates(
     sim(vector, queryVectors[2]),
   ]
 
-  // kw = keyword_boost(c, queries) (retrieval.md → Pseudocode) runs the
-  // candidate's own keyword surface against this turn's queries. The other
-  // direction — a candidate against the name index — is degenerate, since every
-  // row's own terms are in that index by construction.
+  // kw = keyword_boost(c, scan_text) (retrieval.md → Pseudocode) runs the
+  // candidate's own keyword surface against the scan text, NOT `queries`. The
+  // other direction — a candidate against the name index — is degenerate, since
+  // every row's own terms are in that index by construction.
   const kwHits = (surface: readonly string[]): string[] =>
-    matchTerms(ctx.queryText, surface.map(normalizeTerm))
+    matchTerms(ctx.scanText, surface.map(normalizeTerm))
 
   const inPool = <T extends { id: string }>(rows: readonly T[]): T[] =>
     rows.filter((r) => wanted.has(r.id))

--- a/lib/retrieval/scan-surface.test.ts
+++ b/lib/retrieval/scan-surface.test.ts
@@ -135,6 +135,17 @@ describe('readScanEntries', () => {
     expect(ids(await readScanEntries(db, 'br_1', 5))).toEqual(['e1'])
   })
 
+  // storySettingsSchema declares .int().min(1), so these harden against a blob
+  // that never went through it rather than pinning reachable values — the same
+  // hardening readPromptBuffer's toCount carries.
+  it.each([0, -3, 1.7, Number.NaN, undefined])(
+    'floors an unvalidated scanEntries of %s at one trailing entry',
+    async (take) => {
+      const db = await seed([entry(1), entry(2), entry(3, 'user_action')])
+      expect(ids(await readScanEntries(db, 'br_1', take as number))).toEqual(['e2'])
+    },
+  )
+
   it('warns when two entries share a position', async () => {
     const db = await seed([entry(1), { ...entry(2), position: 1 }, entry(3, 'user_action')])
     await readScanEntries(db, 'br_1', 2)

--- a/lib/retrieval/scan-surface.test.ts
+++ b/lib/retrieval/scan-surface.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { branches, stories, storyEntries, type StoryEntry } from '@/lib/db'
+import { createTestDb } from '@/lib/db/__tests__/test-db'
+
+import { buildScanText, readScanEntries } from './scan-surface'
+
+const warnSpy = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/diagnostics', () => ({ logger: { warn: warnSpy } }))
+
+beforeEach(() => warnSpy.mockClear())
+
+type E = {
+  id: string
+  position: number
+  kind: StoryEntry['kind']
+  content: string
+}
+
+const entry = (n: number, kind: StoryEntry['kind'] = 'ai_reply', content = `entry ${n}`): E => ({
+  id: `e${n}`,
+  position: n,
+  kind,
+  content,
+})
+
+const ids = (entries: readonly { id: string }[]): string[] => entries.map((e) => e.id)
+
+async function seed(rows: E[], branchId = 'br_1') {
+  const { db } = await createTestDb()
+  await db.insert(stories).values({ id: 'story_1', title: 'T', createdAt: 1, updatedAt: 1 })
+  await db.insert(branches).values([
+    { id: 'br_1', storyId: 'story_1', name: 'main', createdAt: 1 },
+    { id: 'br_2', storyId: 'story_1', name: 'alt', createdAt: 1 },
+  ])
+  await db.insert(storyEntries).values(
+    rows.map((r) => ({
+      ...r,
+      branchId,
+      chapterId: null,
+      metadata: null,
+      createdAt: 1000 - r.position,
+    })),
+  )
+  return db
+}
+
+const row = (content: string, kind: StoryEntry['kind'] = 'ai_reply') =>
+  ({ kind, content }) as StoryEntry
+
+describe('buildScanText', () => {
+  it('joins the user action with the trailing prose', () => {
+    const text = buildScanText({
+      userAction: 'I draw the blade',
+      trailing: [row('The Veilstone hummed.')],
+    })
+    expect(text).toBe('I draw the blade\nThe Veilstone hummed.')
+  })
+
+  it('keeps the trailing entries in the order given', () => {
+    const text = buildScanText({
+      userAction: 'I wait',
+      trailing: [row('older'), row('newer')],
+    })
+    expect(text).toBe('I wait\nolder\nnewer')
+  })
+
+  it('is the user action alone when nothing trails it', () => {
+    expect(buildScanText({ userAction: 'I wait', trailing: [] })).toBe('I wait')
+  })
+
+  // An empty haystack matches nothing, which is the honest answer for a turn
+  // with no prose — not a surface that reads present and scores zero.
+  it('is empty when there is no action and no trailing prose', () => {
+    expect(buildScanText({ userAction: '   ', trailing: [row('')] })).toBe('')
+  })
+
+  // promptProse, not raw content: a keyword has to match what the model read,
+  // and a tagged trailing block is not part of that.
+  it('strips the piggyback block from a narrative entry', () => {
+    const text = buildScanText({
+      userAction: '',
+      trailing: [row('The Veilstone hummed.\n<state>\n<summary>Kara found it</summary>\n</state>')],
+    })
+    expect(text).toBe('The Veilstone hummed.')
+  })
+})
+
+describe('readScanEntries', () => {
+  it('returns the entry standing before this turn’s action', async () => {
+    const db = await seed([entry(1), entry(2, 'user_action'), entry(3), entry(4, 'user_action')])
+    expect(ids(await readScanEntries(db, 'br_1', 1))).toEqual(['e3'])
+  })
+
+  it('returns the last take entries oldest-first', async () => {
+    const db = await seed([entry(1), entry(2), entry(3), entry(4, 'user_action')])
+    expect(ids(await readScanEntries(db, 'br_1', 3))).toEqual(['e1', 'e2', 'e3'])
+  })
+
+  it('takes the tail as-is when it is not a user action', async () => {
+    // Regenerate and the opening turn both leave a narrative row at the tail.
+    const db = await seed([entry(1), entry(2), entry(3)])
+    expect(ids(await readScanEntries(db, 'br_1', 2))).toEqual(['e2', 'e3'])
+  })
+
+  it('returns what exists when the branch is shorter than take', async () => {
+    const db = await seed([entry(1), entry(2, 'user_action')])
+    expect(ids(await readScanEntries(db, 'br_1', 5))).toEqual(['e1'])
+  })
+
+  it('returns nothing on a branch holding only this turn’s action', async () => {
+    const db = await seed([entry(1, 'user_action')])
+    expect(await readScanEntries(db, 'br_1', 3)).toEqual([])
+  })
+
+  // A failure notice carries no narrative prose, and scanning it would let a
+  // system message decide what lore gets seated.
+  it('excludes system entries', async () => {
+    const db = await seed([entry(1), entry(2, 'system'), entry(3, 'user_action')])
+    expect(ids(await readScanEntries(db, 'br_1', 2))).toEqual(['e1'])
+  })
+
+  it('does not reach into another branch', async () => {
+    const db = await seed([entry(1), entry(2, 'user_action')])
+    await db.insert(storyEntries).values({
+      id: 'other',
+      branchId: 'br_2',
+      position: 9,
+      kind: 'ai_reply',
+      chapterId: null,
+      content: 'elsewhere',
+      metadata: null,
+      createdAt: 1,
+    })
+    expect(ids(await readScanEntries(db, 'br_1', 5))).toEqual(['e1'])
+  })
+
+  it('warns when two entries share a position', async () => {
+    const db = await seed([entry(1), { ...entry(2), position: 1 }, entry(3, 'user_action')])
+    await readScanEntries(db, 'br_1', 2)
+    expect(warnSpy).toHaveBeenCalledWith(
+      'retrieval.duplicate_entry_positions',
+      expect.objectContaining({ branchId: 'br_1' }),
+    )
+  })
+})

--- a/lib/retrieval/scan-surface.ts
+++ b/lib/retrieval/scan-surface.ts
@@ -5,6 +5,13 @@ import { promptProse } from '@/lib/piggyback'
 
 import { warnOnDuplicatePositions } from './buffer'
 
+// Hardening against settings that never went through storySettingsSchema, the
+// same threat readPromptBuffer's toCount covers: a fractional or NaN limit
+// reaches SQLite raw. One trailing entry is the floor the surface is defined on.
+function toTake(value: number): number {
+  return Number.isFinite(value) ? Math.max(1, Math.floor(value)) : 1
+}
+
 export type ScanSurfaceInput = {
   /** This turn's action, already committed ahead of the run. */
   userAction: string
@@ -26,7 +33,7 @@ export function buildScanText(input: ScanSurfaceInput): string {
 }
 
 /**
- * The last `take` entries standing before this turn's action, oldest-last.
+ * The last `take` entries standing before this turn's action, oldest first.
  *
  * Its own read rather than a slice of `readPromptBuffer`: the scan surface is
  * defined independently of the prompt window, whose depth `protectedBuffer` and
@@ -44,10 +51,10 @@ export async function readScanEntries(
     .from(storyEntries)
     .where(and(eq(storyEntries.branchId, branchId), ne(storyEntries.kind, 'system')))
     .orderBy(desc(storyEntries.position), desc(storyEntries.createdAt))
-    .limit(take + 1)
+    .limit(toTake(take) + 1)
   warnOnDuplicatePositions(rows, branchId)
   // The action reaches the surface through `userAction`; leaving it here too
   // would weight this turn's own words twice against every keyword.
   const trailing = rows[0]?.kind === 'user_action' ? rows.slice(1) : rows
-  return trailing.slice(0, take).reverse()
+  return trailing.slice(0, toTake(take)).reverse()
 }

--- a/lib/retrieval/scan-surface.ts
+++ b/lib/retrieval/scan-surface.ts
@@ -1,0 +1,53 @@
+import { and, desc, eq, ne } from 'drizzle-orm'
+
+import { storyEntries, type DbCtx, type StoryEntry } from '@/lib/db'
+import { promptProse } from '@/lib/piggyback'
+
+import { warnOnDuplicatePositions } from './buffer'
+
+export type ScanSurfaceInput = {
+  /** This turn's action, already committed ahead of the run. */
+  userAction: string
+  /** The entries standing before it, oldest first. */
+  trailing: readonly StoryEntry[]
+}
+
+/**
+ * The haystack the keyword pathway matches against, deliberately independent of
+ * the query stack so the lexical complement does not inherit the dense
+ * pathway's inputs (docs/memory/retrieval.md → Keyword scan surface).
+ *
+ * `promptProse` so a keyword matches what the model was actually shown.
+ */
+export function buildScanText(input: ScanSurfaceInput): string {
+  return [input.userAction.trim(), ...input.trailing.map((e) => promptProse(e))]
+    .filter((s) => s !== '')
+    .join('\n')
+}
+
+/**
+ * The last `take` entries standing before this turn's action, oldest-last.
+ *
+ * Its own read rather than a slice of `readPromptBuffer`: the scan surface is
+ * defined independently of the prompt window, whose depth `protectedBuffer` and
+ * `partialChapterBuffer` govern — with `protectedBuffer` at 0 that window can be
+ * shorter than `scanEntries`, which would scan less than configured and report
+ * nothing.
+ */
+export async function readScanEntries(
+  db: DbCtx['db'],
+  branchId: string,
+  take: number,
+): Promise<StoryEntry[]> {
+  const rows = await db
+    .select()
+    .from(storyEntries)
+    .where(and(eq(storyEntries.branchId, branchId), ne(storyEntries.kind, 'system')))
+    .orderBy(desc(storyEntries.position), desc(storyEntries.createdAt))
+    .limit(take + 1)
+  warnOnDuplicatePositions(rows, branchId)
+  // The action reaches the surface through `userAction`; leaving it here too
+  // would weight this turn's own words twice against every keyword.
+  const trailing = rows[0]?.kind === 'user_action' ? rows.slice(1) : rows
+  return trailing.slice(0, take).reverse()
+}

--- a/lib/retrieval/types.ts
+++ b/lib/retrieval/types.ts
@@ -48,7 +48,7 @@ type CandidateBase = {
   chaptersOld: number
   /** decay_resistance for awareness, priority/100 for lore, 0 for the rest. */
   pinSignal: number
-  /** Keyword-index terms this row matched; empty means no boost. */
+  /** This row's own keyword terms found in the scan text; empty means no boost. */
   keywordHits: readonly string[]
   /** Flag at pool-build time. Stale rows never enter a pool, so this is false today. */
   embeddingStale: boolean

--- a/lib/stores/current-story/current-story.test.ts
+++ b/lib/stores/current-story/current-story.test.ts
@@ -20,6 +20,13 @@ const settings = storySettingsSchema.parse({
   embeddingBackend: 'local',
   embedding_model_id: 'm',
   retrievalBudgets: { entities: 1, lore: 1, happenings: 1, threads: 1, chapters: 1 },
+  keywordRetrieval: {
+    mode: 'boost',
+    budgetShare: 0.5,
+    scanEntries: 1,
+    cascade: false,
+    cascadeMaxDepth: 2,
+  },
   composerModesEnabled: true,
   composerWrapPov: 'first',
   suggestionsEnabled: false,


### PR DESCRIPTION
Restores the keyword pathway to what canon specifies, and lands the `keywordRetrieval` settings block that governs it. First of three stacked PRs implementing the 2026-09-06 keyword-retrieval design (`f3f1016d`).

| PR | Owns | Branches off |
| --- | --- | --- |
| **1 (this)** | Scan surface, `keywordRetrieval` settings, CJK match rule | `main` |
| 2 | `entities.keywords` + `entities.priority` and its readers | PR 1 |
| 3 | `mode: 'inject'` — seating, budget share, cascade | PR 2 |

## The defect

`run.ts` set the keyword haystack to `queries.embedTexts.join('\n')`. Since Q1 is already the user action verbatim (`queries.ts:57`), that was wrong in two directions at once:

- **False positives.** The haystack also carried Q2's structural digest — a synthetic list of in-scene entity names, the location and thread titles — so a lore keyword equal to an entity's name fired `kw_boost` on every turn that entity was on stage, whether prose said it or not.
- **False negatives.** Its only view of the previous reply was Q3's top-K sentence extract, so a proper noun in a sentence the extract skipped could never match.

Canon calls the lore keyword pathway load-bearing ("embedding models have no semantic prior on user-authored proper nouns") and specifies the surface independently of the query stack. It was instead gated on Q3's selection — the component `followups.md` now records as slated for removal.

## What changed

- `keywordRetrieval` on `stories.settings`: `mode`, `budgetShare`, `scanEntries`, `cascade`, `cascadeMaxDepth`. Required rather than defaulted, matching `retrievalBudgets` — settings writes are key-scoped `json_set`, so a Zod default never reaches an existing story's blob. Migration `0011` backfills it.
- `buildScanText` / `readScanEntries` (`lib/retrieval/scan-surface.ts`) build the haystack from the user action plus `scanEntries` trailing entries.
- `matchTerms` picks its rule per keyword: Han / kana / hangul terms with no internal space and at least two characters match by substring; everything else keeps the `\p{L}\p{N}` boundary lookarounds.
- The probe capture gains `scan_text` (capture version 4).

Only `mode: 'boost'` is reachable — `inject` is inert until PR 3, and no UI writes any of these knobs until M4.4.

## Decisions worth flagging in review

- **The scan surface gets its own branch-tail read**, not a slice of `readPromptBuffer`. The prompt window's depth is governed by `protectedBuffer` / `partialChapterBuffer`, and at `protectedBuffer: 0` it can be shorter than `scanEntries` — scanning less than configured while reporting nothing. That silent-degradation shape is exactly what the design session found wrong with Q3; reintroducing it one file over would be a poor trade for one saved query.
- **Script detection is per term, not per haystack**, so a story mixing scripts keeps boundary semantics for its Latin keywords.
- **The change reaches two call sites outside the keyword pathway** — Layer-A same-name suppression and the happenings awareness-source surface — because both have the identical segmentation problem.
- **`capture_version` bumps to 4.** `read.ts:43` already refuses non-current payloads, so existing captures drop rather than mis-decode.

## Conformance review

A fresh-context agent checked the diff against the canonical sections and returned 20 findings — 11 cleared, 7 fixed here, 2 notes. The three that mattered were all in the script rule and all reproduced in `node` before I touched anything:

- The predicate tested for *any* CJK character rather than a term *composed of* them, so `veilstone月` lost boundary anchoring — the exact failure the per-term rule exists to prevent, and the opposite of what its own comment claimed.
- The two-character floor counted UTF-16 units, so a single astral ideograph (`𠮷`, `.length === 2`) qualified.
- The internal-space rule matched U+0020 only, missing U+3000 — the space a CJK author actually types, and the only one the rule is really for.

It also caught that my regex-escaping test was vacuous: a substring-mode term short-circuits before `escape()` is ever reached, so deleting `escape()` outright left the test green. Rewritten around a term the script rule sends to the boundary branch.

**One finding was a defect in canon, not in this branch.** `retrieval.md`'s `rank_all` pseudocode still passed five positional arguments to `rank_per_type`'s six-positional signature — so read literally, `budgets` bound to `scan_text` and the decay rate to `type_budget`, in the one artefact an implementer consults to answer which types get the scan surface. It came in with the design commit and shipped uncorrected on `main`. Fixed here, and the block now parses under `ast.parse` with every call site binding correctly.

## Known sharp edge

A CJK keyword written *with* an internal space keeps boundary mode, and CJK prose supplies a non-letter boundary almost nowhere — so `月光 剣` matches `月光 剣。` but not `その月光 剣士`. That is what canon specifies and the tests assert it, but a user authoring a spaced alias gets a term that fires far more rarely than they would expect, and nothing tells them. Worth revisiting when the keyword TagInput ships (M4.2).

## Testing

Full suite green: 443 files / 4620 tests, plus `typecheck`, `lint`, `db:check`, `db:check:format`.

Every new assertion was mutation-checked rather than assumed. Four survived on the first pass and gained real coverage as a result: `json_type(settings) = 'object'` (it stops a non-object blob being reserialized through `json_set`), the phase→capture hand-off of `scanText`, and — after the script-rule fix — both the code-point iteration and the `\s` space class, whose first tests passed for the wrong reason. A lone surrogate is neither Han nor a letter, so the astral term returned `false` under either implementation; it took a two-ideograph term to tell them apart.

The test that pinned the old behaviour (`'matches the candidate keyword surface against the query texts, Q2 included'`) is rewritten as its inverse rather than deleted: a term reaching only the structural digest must now score zero.

**Not run: the manual smoke.** There is no surface to author entity or lore keywords through — that is the M4 gap this work recorded in `roadmap.md` — so a desktop pass could confirm a turn completes but could not exercise the pathway with anything a user typed. E2E is not the right substitute either: it drives through the UI, and the scan surface is `lib/` logic already covered at the unit layer.

Reviewers most worth a second pair of eyes: the `usesSubstringMatch` rule in `lib/retrieval/name-index.ts`, and whether `readScanEntries` picks the right entries at a chapter boundary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable keyword retrieval settings, including matching mode, scan size, budget share, and cascade controls.
  - Keyword matching now supports substring searches for multi-character Han, kana, katakana, and hangul terms.
  - Retrieval scans recent story content and the current user action independently of the prompt window.

- **Data & Compatibility**
  - Existing story settings are automatically updated with default keyword retrieval values.
  - Probe captures now include the scan text and use capture format version 4.

- **Tests**
  - Expanded coverage for retrieval, migration, matching, validation, and capture behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->