### PR TITLE
Keyword injection mode — seat a keyword hit directly (3/3)

### DIFF
--- a/bench/fixture.ts
+++ b/bench/fixture.ts
@@ -379,8 +379,7 @@ export function passInputs(
     sceneEntityIds: sceneCharacterIds,
     currentLocationId: 'char_000000',
     recentProse: prose(rand, 200),
-    // The default one-entry surface, so the matchTerms cost measured here is the
-    // one a turn actually pays.
+    // The default one-entry surface: the matchTerms cost measured is what a turn actually pays.
     scanText: `${userAction}\n${lastNarrativeContent}`,
     // Shipped default: the pre-pass short-circuits, so the ranker cost measured
     // here is the one every story pays until a user turns injection on.

--- a/bench/fixture.ts
+++ b/bench/fixture.ts
@@ -382,6 +382,9 @@ export function passInputs(
     // The default one-entry surface, so the matchTerms cost measured here is the
     // one a turn actually pays.
     scanText: `${userAction}\n${lastNarrativeContent}`,
+    // Shipped default: the pre-pass short-circuits, so the ranker cost measured
+    // here is the one every story pays until a user turns injection on.
+    keywordRetrieval: STORY_SETTINGS_DEFAULTS.keywordRetrieval,
   }
   return { deps, params }
 }

--- a/components/compounds/collision-resolve-dialog.stories.tsx
+++ b/components/compounds/collision-resolve-dialog.stories.tsx
@@ -42,8 +42,7 @@ const entityB = baseEntity({
   description: 'A city guardsman posted at the eastern gate.',
   status: 'staged',
   tags: ['guard', 'sword'],
-  // 'The Swordsman' is A's 'the swordsman' spelled differently — the two sides
-  // authored their aliases independently, and only one may survive the merge.
+  // 'The Swordsman' is A's 'the swordsman' recased — only one survives the merge.
   keywords: ['the gate guard', 'The Swordsman'],
   state: { hp: 90, post: 'east-gate' },
   relationCounts: {
@@ -192,7 +191,6 @@ export const MergeKeywordUnion: Story = {
   play: async () => {
     lastResolution = null
     // ControlledDialog opens by default; the Open button sits behind the overlay.
-    // Both sides' keywords are offered, deduplicated and sorted.
     await userEvent.click(await screen.findByRole('button', { name: 'the wanderer' }))
     await userEvent.click(await screen.findByRole('button', { name: /^Merge into / }))
 

--- a/components/compounds/collision-resolve-dialog.tsx
+++ b/components/compounds/collision-resolve-dialog.tsx
@@ -217,9 +217,8 @@ function MergeBody({
     return [...diff.keywords.both, ...diff.keywords.onlyInA, ...diff.keywords.onlyInB].sort()
   }, [diff.keywords, entityA.keywords])
 
-  // Deselects first (chips are what the user acted on), then the normalization
-  // collapse: collision-resolve.md requires that a case variant of the same alias
-  // not survive as a second entry, and the two sides spell them independently.
+  // Deselects first (what the user acted on), then the normalization collapse —
+  // collision-resolve.md: a case variant must not survive as a second entry.
   const finalKeywords = useMemo(() => {
     const seen = new Set<string>()
     return allKeywords

--- a/components/compounds/collision-resolve-diff.test.ts
+++ b/components/compounds/collision-resolve-diff.test.ts
@@ -184,8 +184,7 @@ describe('computeDivergence', () => {
 })
 
 describe('keywords', () => {
-  // Keywords are retrieval-targeted, not decorative: taking the canonical side's
-  // set alone silently narrows what the merged entity can be matched by.
+  // Keywords are retrieval-targeted: canonical-only silently narrows what the merge can match.
   it('partitions keywords the way it partitions tags', () => {
     const diff = computeDivergence(
       baseEntity({ keywords: ['the grey wolf', 'shared'] }),
@@ -206,8 +205,7 @@ describe('keywords', () => {
     expect(diff.keywords).toBeNull()
   })
 
-  // The two channels are independent: diverging tags must not manufacture a
-  // keyword row, which is what a single shared partition call would do.
+  // Independent channels: a shared partition call would let diverging tags invent a keyword row.
   it('keeps the tag and keyword channels independent', () => {
     const diff = computeDivergence(
       baseEntity({ keywords: ['a'], tags: ['x'] }),

--- a/components/compounds/collision-resolve-machine.test.ts
+++ b/components/compounds/collision-resolve-machine.test.ts
@@ -225,8 +225,7 @@ describe('keyword deselection', () => {
     expect(after.deselectedKeywords).toEqual(['the grey wolf'])
   })
 
-  // The two deselect sets must not share storage: toggling one would otherwise
-  // strike the other's chip in the dialog.
+  // The two deselect sets must not share storage — toggling one would strike the other's chip.
   it('keeps the tag and keyword deselect sets apart', () => {
     const after = mergeReducer(start(), { type: 'toggle-keyword', keyword: 'the grey wolf' })
     expect(after.deselectedTags).toEqual([])

--- a/docs/memory/retrieval.md
+++ b/docs/memory/retrieval.md
@@ -1859,9 +1859,15 @@ copy of this table.
 
 ```python
 def rank_per_type(candidates, queries, scan_text, type_budget, λ_type, type_overhead, *, matched_chapters=None, keyword_injected=()):
-    # 1. Compute raw score per candidate
+    # 1. Compute raw score per candidate. A keyword-injected row is dropped from
+    #    the pool outright rather than skipped during the fill: it is seated
+    #    already, and never reaching the ranker is what keeps it out of the
+    #    candidate records entirely (→ Keyword injection).
+    seated_ids = {c.id for c in keyword_injected}
     scored = []
     for c in candidates:
+        if c.id in seated_ids:
+            continue
         sim = blend_similarity(c, queries)
         # Keyword hits match the scan surface — the user action plus the
         # trailing entries — NOT `queries`. See → Keyword scan surface.

--- a/lib/classifier/plan.test.ts
+++ b/lib/classifier/plan.test.ts
@@ -642,8 +642,7 @@ describe('entity keywords', () => {
 
   const decide = (decision: ReconcileDecision) => new Map([['new:k', decision]])
 
-  // classifier.md → Entity keywords: the brand-new-entity object carries the
-  // epithets prose used for the character alongside its name.
+  // classifier.md → Entity keywords.
   it('seeds keywords on a created character', () => {
     const { planned } = buildClassifierActions(candidate(['the grey wolf']), {
       ...base,
@@ -654,8 +653,7 @@ describe('entity keywords', () => {
     ])
   })
 
-  // "Writes are strictly append-and-deduplicate and never remove, so user-authored
-  // aliases survive every subsequent pass."
+  // Append-and-dedupe, never remove — authored aliases survive every pass.
   it('appends to a known entity without dropping its authored aliases', () => {
     const { planned } = buildClassifierActions(candidate(['the grey wolf']), {
       ...base,

--- a/lib/classifier/plan.ts
+++ b/lib/classifier/plan.ts
@@ -33,10 +33,8 @@ export type PlanDeps = {
 const SOURCE = 'periodic_classifier' as const
 
 /**
- * retrieval.md → Keywords schema: appends de-duplicate under the normalization
- * matchTerms uses, and never remove — a user's authored aliases have to survive
- * every later pass. null when nothing is new, so a character the prose names
- * again costs no delta row.
+ * retrieval.md → Keywords schema: append-only, de-duped under matchTerms' normalization — authored
+ * aliases must survive every pass. null when nothing is new, so a repeated name writes no delta.
  */
 function appendKeywords(current: readonly string[], incoming: readonly string[]): string[] | null {
   const seen = new Set(current.map(normalizeTerm))
@@ -125,9 +123,8 @@ export function buildClassifierActions(
       })
       continue
     }
-    // A known character emits a write only when the prose named it by something it
-    // does not already hold: keywords are not frozen after first introduction, but a
-    // recurring name must not cost a delta row per pass.
+    // A known character writes only when the prose named it by something new: keywords aren't
+    // frozen after introduction, but a recurring name must not cost a delta row per pass.
     if (decision.kind === 'known') {
       handleMap.set(candidate.handle, decision.entityId)
       const known = index.get(decision.entityId)

--- a/lib/db/__tests__/migrate-m3-keyword-retrieval.test.ts
+++ b/lib/db/__tests__/migrate-m3-keyword-retrieval.test.ts
@@ -24,8 +24,7 @@ function applyMigration(sqlite: DatabaseSync, tag: string): void {
   }
 }
 
-// The pre-slice shape: no keywordRetrieval key at all, plus enough sibling keys
-// to prove the migration writes one subtree rather than the settings blob.
+// No keywordRetrieval key, plus enough siblings to prove the migration writes one subtree.
 const LEGACY_SETTINGS = {
   chapterTokenThreshold: 24000,
   classifierCadence: 5,
@@ -60,10 +59,9 @@ describe(TAG, () => {
     }
   })
 
-  // Applying by filename would stay green against a migration the app never
-  // runs. keywordRetrieval is required by storySettingsSchema, so an unjournalled
-  // 0011 makes every upgraded story fail to parse its own settings — and a fresh
-  // DB never needs the migration, so E2E cannot catch it either.
+  // Applying by filename stays green against a migration the app never runs; an
+  // unjournalled 0011 fails storySettingsSchema on every upgraded story. A fresh DB
+  // never needs the migration, so E2E cannot catch it either.
   it('is wired into the upgrade path, not just present on disk', () => {
     expect(migrationTags()).toContain(TAG)
     const runtime = readFileSync(`${MIGRATIONS_DIR}/migrations.js`, 'utf8')
@@ -90,8 +88,7 @@ describe(TAG, () => {
     })
   })
 
-  // The guard that separates this from 0007: a user-chosen mode must survive a
-  // re-run, so the statement is idempotent rather than a blind overwrite.
+  // A user-chosen mode must survive a re-run, so the statement is idempotent, unlike 0007.
   it('leaves a story that already carries the key alone', () => {
     const chosen = { ...STORY_SETTINGS_DEFAULTS.keywordRetrieval, mode: 'inject', scanEntries: 4 }
     insertStory(db, 's1', { ...LEGACY_SETTINGS, keywordRetrieval: chosen })
@@ -102,9 +99,8 @@ describe(TAG, () => {
     expect(settingsOf(db, 's1')?.keywordRetrieval).toEqual(chosen)
   })
 
-  // json_set raises on non-JSON text, which aborts the whole UPDATE: without the
-  // guard one unparseable blob leaves every other story unmigrated and the app
-  // unable to boot past migrate(), rather than badging that one story.
+  // json_set raises on non-JSON text and aborts the whole UPDATE: without the guard one
+  // unparseable blob leaves every other story unmigrated and the app unable to boot.
   it.each([
     ['unparseable text', '{not json'],
     ['an empty string', ''],
@@ -127,10 +123,8 @@ describe(TAG, () => {
     expect(bad.settings).toBe(raw)
   })
 
-  // json_valid alone would admit these: json_set then writes the column back
-  // re-serialized, silently normalizing a row the migration has no business
-  // touching. The spacing is the assertion — it survives only if the row is
-  // never written.
+  // json_valid alone admits these, and json_set then rewrites the column re-serialized,
+  // normalizing a row the migration must not touch. The spacing is the assertion.
   it.each([
     ['a spaced top-level array', '[1, 2]'],
     ['a quoted scalar', '"already gone"'],

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -43,7 +43,12 @@ export type { TranslationWrite } from './translations/translations-schema'
 export { branchEraFlipWriteSchema } from './stories/era-flip-schema'
 export type { BranchEraFlipWrite } from './stories/era-flip-schema'
 export { CAPTURE_VERSION } from './probe-capture-types'
-export type { CaptureCandidate, DropReason, ProbeCapturePayload } from './probe-capture-types'
+export type {
+  CaptureCandidate,
+  CaptureKeywordInjection,
+  DropReason,
+  ProbeCapturePayload,
+} from './probe-capture-types'
 export type { ClassifierLifecycleState, ClassifierStatus } from './world-json-types'
 export type {
   StoryDefinition,

--- a/lib/db/probe-capture-types.ts
+++ b/lib/db/probe-capture-types.ts
@@ -49,6 +49,23 @@ type CaptureCandidate = {
   vector?: number[]
 }
 
+/**
+ * One row a keyword hit matched (probe.md → Keyword injections). Deliberately
+ * NOT a CaptureCandidate: these rows never reached the ranker, so they have no
+ * sim_blend, final_score or kw_boost_value, and filing them as candidates would
+ * invent scores that never existed. `seated` false means the budget cap cut it;
+ * `priority` is recorded so the overflow order stays inspectable.
+ */
+type CaptureKeywordInjection = {
+  target_kind: VecTargetKind
+  target_id: string
+  display_name: string
+  terms: string[]
+  tokens_estimated: number
+  seated: boolean
+  priority: number
+}
+
 type PoolFunnelSummary = {
   pool_size: number
   pre_filtered_size: number
@@ -89,8 +106,9 @@ type CaptureTokenizer = { encoding: string; version: string }
 /**
  * Bumped when a captured field's shape or meaning changes, so a decode can
  * warn instead of silently misreading an older payload as the current type.
+ * 5: keyword_injections.
  */
-export const CAPTURE_VERSION = 4 as const
+export const CAPTURE_VERSION = 5 as const
 
 export type ProbeCapturePayload = {
   capture_version: number
@@ -114,6 +132,12 @@ export type ProbeCapturePayload = {
   funnels: Record<RetrievalType, PoolFunnelSummary>
   structural_floor: StructuralFloorRow[]
   /**
+   * Present only while `keywordRetrieval.mode` is `inject`, empty otherwise.
+   * Without it the probe under-reports what reached the prompt: a seated row
+   * consumed budget the ranked pools then competed for and appears in no pool.
+   */
+  keyword_injections: CaptureKeywordInjection[]
+  /**
    * Prompt-buffer cost as one number, not floor rows: the floor is a token
    * ledger and buffered entries carry no retrieval identity, so N rows would
    * add bulk without adding a tunable. Normally the largest floor term, so a
@@ -129,4 +153,4 @@ export type ProbeCapturePayload = {
   failure_reason: EmbedderErrorKind | null
 }
 
-export type { CaptureCandidate }
+export type { CaptureCandidate, CaptureKeywordInjection }

--- a/lib/db/probe-capture-types.ts
+++ b/lib/db/probe-capture-types.ts
@@ -50,11 +50,9 @@ type CaptureCandidate = {
 }
 
 /**
- * One row a keyword hit matched (probe.md → Keyword injections). Deliberately
- * NOT a CaptureCandidate: these rows never reached the ranker, so they have no
- * sim_blend, final_score or kw_boost_value, and filing them as candidates would
- * invent scores that never existed. `seated` false means the budget cap cut it;
- * `priority` is recorded so the overflow order stays inspectable.
+ * One row a keyword hit matched (probe.md → Keyword injections). Not a
+ * CaptureCandidate: these never reached the ranker, so scoring them would invent
+ * numbers. `seated` false = cut by the budget cap; `priority` = overflow order.
  */
 type CaptureKeywordInjection = {
   target_kind: VecTargetKind
@@ -104,9 +102,8 @@ type CaptureParamsSnapshot = {
 type CaptureTokenizer = { encoding: string; version: string }
 
 /**
- * Bumped when a captured field's shape or meaning changes, so a decode can
- * warn instead of silently misreading an older payload as the current type.
- * 5: keyword_injections.
+ * Bumped when a captured field's shape or meaning changes, so a decode warns
+ * rather than misreading an older payload. 5 added keyword_injections.
  */
 export const CAPTURE_VERSION = 5 as const
 
@@ -122,19 +119,16 @@ export type ProbeCapturePayload = {
   params: CaptureParamsSnapshot
   queries: [CaptureQuery, CaptureQuery, CaptureQuery]
   /**
-   * The narrative text kw_boost_value was matched against — separate from
-   * `queries` because the scan surface is defined independently of them and is
-   * never embedded (probe.md → Keyword scan surface). Captured in both modes;
-   * without it a non-zero kw_boost_value has no readable cause in the capture.
+   * The narrative text kw_boost_value matched against, never embedded and defined
+   * independently of `queries` (probe.md → Keyword scan surface). Both modes.
    */
   scan_text: string
   pools: Record<RetrievalType, CaptureCandidate[]>
   funnels: Record<RetrievalType, PoolFunnelSummary>
   structural_floor: StructuralFloorRow[]
   /**
-   * Present only while `keywordRetrieval.mode` is `inject`, empty otherwise.
-   * Without it the probe under-reports what reached the prompt: a seated row
-   * consumed budget the ranked pools then competed for and appears in no pool.
+   * Present only while `keywordRetrieval.mode` is `inject`, empty otherwise. A
+   * seated row consumed budget and appears in no pool, so it is reported here.
    */
   keyword_injections: CaptureKeywordInjection[]
   /**

--- a/lib/db/stories/story-config-schema.test.ts
+++ b/lib/db/stories/story-config-schema.test.ts
@@ -234,9 +234,8 @@ describe('storySettingsSchema keywordRetrieval', () => {
     keywordRetrieval: { ...VALID_SETTINGS.keywordRetrieval, ...over },
   })
 
-  // Required, not defaulted: settings writes are key-scoped json_set, so a
-  // default here would never reach an existing story's blob. Migration 0011
-  // backfills it instead, and this assertion is what keeps the two in step.
+  // Required, not defaulted: key-scoped json_set writes never reach an existing story's blob, so
+  // migration 0011 backfills it — this assertion keeps schema and migration in step.
   it('requires the key', () => {
     const { keywordRetrieval: _omitted, ...without } = VALID_SETTINGS
     expect(storySettingsSchema.safeParse(without).success).toBe(false)
@@ -255,8 +254,7 @@ describe('storySettingsSchema keywordRetrieval', () => {
     expect(storySettingsSchema.safeParse(withKeyword({ budgetShare: -0.1 })).success).toBe(false)
   })
 
-  // The user action is always scanned, so this counts the trailing entries
-  // beside it and one is the floor rather than zero.
+  // Counts the trailing entries beside the always-scanned user action, so the floor is one.
   it('floors scanEntries at one whole entry', () => {
     expect(storySettingsSchema.safeParse(withKeyword({ scanEntries: 1 })).success).toBe(true)
     expect(storySettingsSchema.safeParse(withKeyword({ scanEntries: 0 })).success).toBe(false)

--- a/lib/db/stories/story-config-schema.ts
+++ b/lib/db/stories/story-config-schema.ts
@@ -73,18 +73,14 @@ const retrievalBudgetsSchema = z.object({
   chapters: tokenBudget,
 })
 
-// A second axis beside injection_mode, which answers whether a row injects at
-// all; this answers what a keyword HIT does (docs/memory/retrieval.md → Keyword
-// injection). Only scanEntries is live while mode is 'boost' — it sizes the
-// keyword haystack in both modes.
+// What a keyword HIT does, beside injection_mode's whether-it-injects-at-all (retrieval.md →
+// Keyword injection). Only scanEntries is live under 'boost'; it sizes the haystack in both modes.
 const keywordRetrievalSchema = z.object({
   mode: z.enum(['boost', 'inject']),
-  // A share of each per-type budget, bounded here for the reason tokenBudget is:
-  // out of range it silently starves or floods one partition, and the trace
-  // blames the candidates.
+  // A share of each per-type budget, bounded here for tokenBudget's reason: out of range it
+  // silently starves or floods a partition while the trace blames the candidates.
   budgetShare: z.number().min(0).max(1),
-  // Counts the trailing entries BESIDE the user action, which is always scanned —
-  // so one is the floor, not zero.
+  // Counts trailing entries BESIDE the always-scanned user action, so the floor is one, not zero.
   scanEntries: z.number().int().min(1),
   cascade: z.boolean(),
   cascadeMaxDepth: z.number().int().min(1),

--- a/lib/db/stories/story-settings-defaults.test.ts
+++ b/lib/db/stories/story-settings-defaults.test.ts
@@ -23,8 +23,7 @@ describe('STORY_SETTINGS_DEFAULTS', () => {
   it('is a complete, parseable StorySettings', () => {
     expect(() => storySettingsSchema.parse(STORY_SETTINGS_DEFAULTS)).not.toThrow()
   })
-  // 'boost' is the shipped behaviour, so a story migrating in behaves exactly as
-  // it did. The rest are inert until keyword injection lands.
+  // 'boost' is the shipped behaviour, so a migrating story is unchanged; the rest are inert.
   it('starts the keyword pathway on boost with a one-entry scan', () => {
     expect(STORY_SETTINGS_DEFAULTS.keywordRetrieval).toEqual({
       mode: 'boost',

--- a/lib/db/stories/story-settings-defaults.ts
+++ b/lib/db/stories/story-settings-defaults.ts
@@ -21,8 +21,7 @@ export const STORY_SETTINGS_DEFAULTS: StorySettings = {
   // entity block's macro wrapping alone costs 11 tokens before a word of the
   // row itself, so a count-shaped value here seats nothing.
   retrievalBudgets: { entities: 1200, lore: 1800, happenings: 1500, threads: 400, chapters: 600 },
-  // budgetShare 0.5 is a starting guess wanting calibration against real stories,
-  // in the same sense as the blend weights — not a derived value.
+  // budgetShare 0.5 is an uncalibrated starting guess like the blend weights, not derived.
   keywordRetrieval: {
     mode: 'boost',
     budgetShare: 0.5,

--- a/lib/keyword-terms.ts
+++ b/lib/keyword-terms.ts
@@ -1,8 +1,6 @@
 /**
- * The shape every keyword term is compared under. It lives outside `lib/retrieval`
- * because the producers of terms — the classifier, the merge dialog's union, the
- * user's own edits — must normalize identically to the matcher, and a producer
- * reaching for the retrieval barrel to get it would drag the embedder in behind it.
+ * The shape every keyword term is compared under. Outside `lib/retrieval` so every
+ * producer of terms normalizes identically without dragging the embedder in behind it.
  */
 export function normalizeTerm(s: string): string {
   return s.trim().toLowerCase().normalize('NFC')

--- a/lib/pipeline/definitions/generation-context.ts
+++ b/lib/pipeline/definitions/generation-context.ts
@@ -5,10 +5,10 @@ import { buildSuggestionSlots, NARRATIVE_KINDS, promptProse } from '@/lib/piggyb
 import { templateReads, type TemplateId } from '@/lib/prompts'
 import {
   readPromptBuffer,
-  type Candidate,
   type EntityRow,
   type LoreRow,
   type RetrievalSuccess,
+  type SeatedRow,
   type ThreadRow,
 } from '@/lib/retrieval'
 import { currentStoryStore, entitiesStore } from '@/lib/stores'
@@ -90,7 +90,7 @@ function promptEntity(entity: Entity): Pick<Entity, (typeof PROMPT_ENTITY_FIELDS
 // Only the fields a prompt renders: `renderedText` is the exact string the
 // ranker measured the type budget against, and the Float32Array vector beside
 // it would be walked into a numeric-keyed object by substituteIds.
-function promptRows(selected: readonly Candidate[] | undefined): RetrievedRow[] {
+function promptRows(selected: readonly SeatedRow[] | undefined): RetrievedRow[] {
   return (selected ?? []).map((c) => ({
     id: c.id,
     displayName: c.displayName,

--- a/lib/pipeline/definitions/per-turn-retrieval.test.ts
+++ b/lib/pipeline/definitions/per-turn-retrieval.test.ts
@@ -968,8 +968,7 @@ describe('retrieval phase — RetrievalParams assembly', () => {
     expect(runRetrievalMock.mock.calls.at(-1)?.[0]).not.toHaveProperty('branchIds')
   })
 
-  // Every value differs from STORY_SETTINGS_DEFAULTS, so a phase reading the
-  // constant instead of the story fails rather than agreeing by coincidence.
+  // Every value differs from STORY_SETTINGS_DEFAULTS, so reading the constant fails here.
   it('passes the story keywordRetrieval block through to the pass', async () => {
     seedOpenStory({
       settings: {
@@ -985,8 +984,7 @@ describe('retrieval phase — RetrievalParams assembly', () => {
 
     await runRetrievalPhase()
 
-    // scanEntries is absent on purpose: readScanEntries already spent it, and
-    // lib/retrieval declares its own settings shape without it.
+    // scanEntries absent on purpose: readScanEntries spent it; lib/retrieval omits it.
     expect(lastParams().keywordRetrieval).toEqual({
       mode: 'inject',
       budgetShare: 0.25,
@@ -1240,9 +1238,8 @@ describe('retrieval phase — RetrievalParams assembly', () => {
     expect(lastParams().scanText.split('I draw the blade.')).toHaveLength(2)
   })
 
-  // The whole reason the surface has its own read: protectedBuffer 0 with a
-  // one-entry partial window would otherwise hand it less prose than the story
-  // asked for, and say nothing about it.
+  // Why the surface has its own read: protectedBuffer 0 with a one-entry partial
+  // window would silently hand it less prose than the story asked for.
   it('reaches scanEntries deep regardless of the prompt-buffer knobs', async () => {
     seedOpenStory({
       settings: {
@@ -1270,8 +1267,7 @@ describe('retrieval phase — RetrievalParams assembly', () => {
     expect(scanText).toContain('older-prose')
     expect(scanText).toContain('recent-prose')
     expect(scanText).toContain('newest-prose')
-    // Positive control: the prompt buffer really is narrower here, so the
-    // assertions above are about the dedicated read and not a wide window.
+    // Positive control: the buffer is narrower here, so the above pins the dedicated read.
     expect(recentProse).not.toContain('older-prose')
   })
 

--- a/lib/pipeline/definitions/per-turn-retrieval.test.ts
+++ b/lib/pipeline/definitions/per-turn-retrieval.test.ts
@@ -968,6 +968,33 @@ describe('retrieval phase — RetrievalParams assembly', () => {
     expect(runRetrievalMock.mock.calls.at(-1)?.[0]).not.toHaveProperty('branchIds')
   })
 
+  // Every value differs from STORY_SETTINGS_DEFAULTS, so a phase reading the
+  // constant instead of the story fails rather than agreeing by coincidence.
+  it('passes the story keywordRetrieval block through to the pass', async () => {
+    seedOpenStory({
+      settings: {
+        keywordRetrieval: {
+          mode: 'inject',
+          budgetShare: 0.25,
+          scanEntries: 3,
+          cascade: true,
+          cascadeMaxDepth: 4,
+        },
+      },
+    })
+
+    await runRetrievalPhase()
+
+    // scanEntries is absent on purpose: readScanEntries already spent it, and
+    // lib/retrieval declares its own settings shape without it.
+    expect(lastParams().keywordRetrieval).toEqual({
+      mode: 'inject',
+      budgetShare: 0.25,
+      cascade: true,
+      cascadeMaxDepth: 4,
+    })
+  })
+
   it("takes the budgets from the story's settings, not the code defaults", async () => {
     seedOpenStory({
       settings: {

--- a/lib/pipeline/definitions/per-turn-retrieval.ts
+++ b/lib/pipeline/definitions/per-turn-retrieval.ts
@@ -79,9 +79,8 @@ export async function* retrievalPhase(
     .map((e) => promptProse(e))
     .join('\n')
 
-  // Its own read, not a slice of the buffer above: the keyword scan surface is
-  // defined independently of the prompt window (retrieval.md → Keyword scan
-  // surface), which protectedBuffer can make narrower than scanEntries.
+  // Its own read, not a slice of the buffer above — protectedBuffer can make the prompt window
+  // narrower than scanEntries (retrieval.md → Keyword scan surface).
   const scanEntries = await readScanEntries(
     ctx.db,
     branchId,
@@ -148,9 +147,8 @@ export async function* retrievalPhase(
         // User-tunable knobs).
         recentProse: promptBuffer,
         scanText,
-        // Destructured rather than spread: `scanEntries` is already spent above,
-        // and lib/retrieval declares its own settings shape (BufferSettings'
-        // precedent) so it does not follow whatever else stories.settings grows.
+        // Destructured rather than spread: `scanEntries` is already spent above, and lib/retrieval
+        // owns its settings shape (BufferSettings' precedent), not stories.settings' growth.
         keywordRetrieval: {
           mode: open.settings.keywordRetrieval.mode,
           budgetShare: open.settings.keywordRetrieval.budgetShare,

--- a/lib/pipeline/definitions/per-turn-retrieval.ts
+++ b/lib/pipeline/definitions/per-turn-retrieval.ts
@@ -148,6 +148,15 @@ export async function* retrievalPhase(
         // User-tunable knobs).
         recentProse: promptBuffer,
         scanText,
+        // Destructured rather than spread: `scanEntries` is already spent above,
+        // and lib/retrieval declares its own settings shape (BufferSettings'
+        // precedent) so it does not follow whatever else stories.settings grows.
+        keywordRetrieval: {
+          mode: open.settings.keywordRetrieval.mode,
+          budgetShare: open.settings.keywordRetrieval.budgetShare,
+          cascade: open.settings.keywordRetrieval.cascade,
+          cascadeMaxDepth: open.settings.keywordRetrieval.cascadeMaxDepth,
+        },
       },
     )
   } finally {

--- a/lib/probe/compress.test.ts
+++ b/lib/probe/compress.test.ts
@@ -109,6 +109,19 @@ const capturePayload = (): ProbeCapturePayload => ({
     chapters: emptyFunnel(200),
   },
   structural_floor: [{ target_kind: 'chapter', target_id: 'chap_1', tokens: 120 }],
+  // Populated, not empty: the round-trip has to prove the field survives gzip,
+  // and an empty array would pass whether or not it was written.
+  keyword_injections: [
+    {
+      target_kind: 'lore',
+      target_id: 'lore_1',
+      display_name: 'The drowned archive',
+      terms: ['tide'],
+      tokens_estimated: 42,
+      seated: true,
+      priority: 30,
+    },
+  ],
   prompt_buffer_tokens: 1840,
   stale_counts: { entities: 0, lore: 0, happenings: 0, threads: 0, chapters: 0 },
   failure_reason: null,

--- a/lib/probe/compress.test.ts
+++ b/lib/probe/compress.test.ts
@@ -109,8 +109,7 @@ const capturePayload = (): ProbeCapturePayload => ({
     chapters: emptyFunnel(200),
   },
   structural_floor: [{ target_kind: 'chapter', target_id: 'chap_1', tokens: 120 }],
-  // Populated, not empty: the round-trip has to prove the field survives gzip,
-  // and an empty array would pass whether or not it was written.
+  // Populated, not empty: an empty array round-trips identically whether or not it's written.
   keyword_injections: [
     {
       target_kind: 'lore',

--- a/lib/probe/parity.test.ts
+++ b/lib/probe/parity.test.ts
@@ -567,6 +567,40 @@ describe('replay recomputes rather than echoing', () => {
 })
 
 describe('replayType', () => {
+  const seat = (seated: boolean) => ({
+    target_kind: 'lore' as const,
+    target_id: 'lo_seat',
+    display_name: 'Seat',
+    terms: ['seat'],
+    // The whole type budget, so the reservation is unmissable: with it nothing
+    // ranked can fit; without it every row seats exactly as it does above.
+    tokens_estimated: STATES['pin-boosted'].budget,
+    seated,
+    priority: 0,
+  })
+
+  it('reserves the budget the keyword seats spent', async () => {
+    const state = STATES['pin-boosted']
+    const payload = await storedPayload(state, rankProd(state))
+
+    expect(replayType(payload, 'lore').selected.length).toBeGreaterThan(0)
+
+    const replayed = replayType({ ...payload, keyword_injections: [seat(true)] }, 'lore')
+
+    expect(replayed.selected.map((c) => c.id)).toEqual(['lo_seat'])
+    expect(replayed.traces.every((t) => t.dropReason === 'over_budget')).toBe(true)
+  })
+
+  it('ignores a cut seat, which spent nothing', async () => {
+    const state = STATES['pin-boosted']
+    const payload = await storedPayload(state, rankProd(state))
+    const cut = { ...payload, keyword_injections: [seat(false)] }
+
+    expect(replayType(cut, 'lore').selected.map((c) => c.id)).toEqual(
+      replayType(payload, 'lore').selected.map((c) => c.id),
+    )
+  })
+
   it('refuses a failed capture even though its pools would rank', async () => {
     const state = STATES.normal
     const payload = await storedPayload(state, rankProd(state))

--- a/lib/probe/payload.test.ts
+++ b/lib/probe/payload.test.ts
@@ -503,9 +503,8 @@ describe('buildCapturePayload', () => {
   })
 
   it('carries the scan surface the keyword pathway matched against', () => {
-    // The queries are the wrong place to look for it: the scan surface is
-    // defined independently of them, so a kw_boost_value has no readable cause
-    // anywhere else in the capture.
+    // The scan surface is defined independently of the queries, so without it a
+    // kw_boost_value has no readable cause anywhere in the capture.
     const payload = buildCapturePayload({
       ...identity,
       scanText: 'I draw the blade.\nThe Veilstone hummed.',

--- a/lib/probe/payload.test.ts
+++ b/lib/probe/payload.test.ts
@@ -204,6 +204,7 @@ describe('buildCapturePayload', () => {
       'embedding_model_id',
       'failure_reason',
       'funnels',
+      'keyword_injections',
       'params',
       'pools',
       'prompt_buffer_tokens',
@@ -217,6 +218,52 @@ describe('buildCapturePayload', () => {
     expect(payload.params.ranker).toEqual(RANKER_DEFAULTS)
     expect(payload.tokenizer.encoding).toBe('o200k_base')
     expect(payload.pools.lore[0].vector).toBeUndefined()
+  })
+
+  it('files a keyword seat as an injection, never as a candidate', () => {
+    const payload = buildCapturePayload({
+      ...identity,
+      mode: 'light',
+      settings,
+      params: RANKER_DEFAULTS,
+      outcome: retrievalSuccess({
+        queries: queryStack(),
+        keywordInjections: [
+          {
+            row: { kind: 'lore', id: 'l1', displayName: 'The Aetherium', renderedText: 'body' },
+            terms: ['aetherium'],
+            priority: 7,
+            tokensEstimated: 42,
+            seated: false,
+          },
+        ],
+      }),
+    })
+
+    expect(payload.keyword_injections).toEqual([
+      {
+        target_kind: 'lore',
+        target_id: 'l1',
+        display_name: 'The Aetherium',
+        terms: ['aetherium'],
+        tokens_estimated: 42,
+        seated: false,
+        priority: 7,
+      },
+    ])
+    expect(payload.pools.lore).toEqual([])
+  })
+
+  it('carries an empty injection list on a failed pass', () => {
+    const payload = buildCapturePayload({
+      ...identity,
+      mode: 'light',
+      settings,
+      params: RANKER_DEFAULTS,
+      outcome: syncStageFailureOutcome(),
+    })
+
+    expect(payload.keyword_injections).toEqual([])
   })
 
   it('stamps the capture identity fields from input, not swapped', () => {
@@ -241,7 +288,7 @@ describe('buildCapturePayload', () => {
       captured_at: 1_700_000_000_123,
       embedding_model_id: 'Xenova/all-MiniLM-L6-v2',
       capture_mode: 'light',
-      capture_version: 4,
+      capture_version: 5,
     })
   })
 

--- a/lib/probe/payload.ts
+++ b/lib/probe/payload.ts
@@ -1,6 +1,7 @@
 import {
   CAPTURE_VERSION,
   type CaptureCandidate,
+  type CaptureKeywordInjection,
   type ProbeCapturePayload,
   type VecTargetKind,
 } from '@/lib/db'
@@ -11,6 +12,7 @@ import {
   TOKENIZER_IDENTITY,
   type CandidateTrace,
   type EntityRow,
+  type KeywordInjection,
   type LoreRow,
   type QuerySpec,
   type QueryStack,
@@ -72,6 +74,16 @@ const candidateOf = (
   tokens_estimated: t.tokensEstimated,
   embedding_stale: t.embeddingStale,
   ...(mode === 'deep' && vector ? { vector: [...vector] } : {}),
+})
+
+const injectionOf = (i: KeywordInjection): CaptureKeywordInjection => ({
+  target_kind: i.row.kind,
+  target_id: i.row.id,
+  display_name: i.row.displayName,
+  terms: [...i.terms],
+  tokens_estimated: i.tokensEstimated,
+  seated: i.seated,
+  priority: i.priority,
 })
 
 const poolOf = (
@@ -171,7 +183,12 @@ const floorRowsOf = (floor: StructuralFloor | null): ProbeCapturePayload['struct
 
 export function buildCapturePayload(input: CapturePayloadInput): ProbeCapturePayload {
   const { outcome, mode } = input
-  const { queries: stack, floor, bundles } = outcome.ok ? outcome : outcome.partial
+  const {
+    queries: stack,
+    floor,
+    bundles,
+    keywordInjections,
+  } = outcome.ok ? outcome : outcome.partial
 
   return {
     branch_id: input.branchId,
@@ -204,6 +221,7 @@ export function buildCapturePayload(input: CapturePayloadInput): ProbeCapturePay
       chapters: funnelOf(bundles.chapters),
     },
     structural_floor: floorRowsOf(floor),
+    keyword_injections: keywordInjections.map(injectionOf),
     prompt_buffer_tokens: input.promptBufferTokens,
     // outcome.failure.staleCount (a failure's dirty-row count) is one scalar;
     // there is no per-type split to spread it across, so this stays zero

--- a/lib/probe/payload.ts
+++ b/lib/probe/payload.ts
@@ -7,6 +7,7 @@ import {
 import {
   countTokens,
   ENTITY_FRAMING,
+  lines,
   TOKENIZER_IDENTITY,
   type CandidateTrace,
   type EntityRow,
@@ -117,11 +118,6 @@ const queriesOf = (stack: QueryStack | null): ProbeCapturePayload['queries'] => 
   }
   return [queryOf(stack.q1), queryOf(stack.q2), queryOf(stack.q3)]
 }
-
-// run.ts's lines() isn't exported from lib/retrieval; reimplemented here so a
-// blank field doesn't leave its join separator behind.
-const lines = (...parts: (string | null)[]): string =>
-  parts.filter((p) => p !== null && p !== '').join('\n')
 
 const nameWithDescription = (name: string, description: string | null): string =>
   description ? `${name}: ${description}` : name

--- a/lib/probe/read.test.ts
+++ b/lib/probe/read.test.ts
@@ -139,6 +139,7 @@ describe('decodeCapture', () => {
       },
       /pools\.happenings/i,
     ],
+    ['keyword_injections', (p) => delete p.keyword_injections, /keyword_injections/i],
     ['queries', (p) => delete p.queries, /queries/i],
     [
       'a query',

--- a/lib/probe/replay.ts
+++ b/lib/probe/replay.ts
@@ -1,5 +1,11 @@
 import type { ProbeCapturePayload } from '@/lib/db'
-import { rankPerType, type Candidate, type RankedType, type RetrievalType } from '@/lib/retrieval'
+import {
+  rankPerType,
+  type Candidate,
+  type KeywordInjection,
+  type RankedType,
+  type RetrievalType,
+} from '@/lib/retrieval'
 
 import { assertRankerParams, RankerParamsError } from './validate'
 
@@ -101,7 +107,30 @@ export function replayType(
     }
   })
 
+  // The seats are not simulated — probe.md files them as non-simulatable — but
+  // the budget they spent is not optional context: replaying without it seats
+  // ranked rows into budget the real pass had already spent, and nothing errors.
+  // `renderedText` is empty because keyword_injections stores the cost, not the
+  // text, and nothing here re-costs a seat or renders one. Only entities and lore
+  // can appear, so the other three types match nothing and reserve nothing.
+  const injectedKind = type === 'entities' ? 'entity' : type === 'lore' ? 'lore' : null
+  const keywordInjected: KeywordInjection[] = payload.keyword_injections
+    .filter((i) => i.target_kind === injectedKind)
+    .map((i) => ({
+      row: {
+        kind: i.target_kind as 'entity' | 'lore',
+        id: i.target_id,
+        displayName: i.display_name,
+        renderedText: '',
+      },
+      terms: i.terms,
+      priority: i.priority,
+      tokensEstimated: i.tokens_estimated,
+      seated: i.seated,
+    }))
+
   return rankPerType(pool, type, budget, {
+    keywordInjected,
     params: payload.params.ranker,
     chapterRanges,
     matchedChapterIds: new Set([REPLAY_CHAPTER]),

--- a/lib/probe/replay.ts
+++ b/lib/probe/replay.ts
@@ -107,12 +107,9 @@ export function replayType(
     }
   })
 
-  // The seats are not simulated — probe.md files them as non-simulatable — but
-  // the budget they spent is not optional context: replaying without it seats
-  // ranked rows into budget the real pass had already spent, and nothing errors.
-  // `renderedText` is empty because keyword_injections stores the cost, not the
-  // text, and nothing here re-costs a seat or renders one. Only entities and lore
-  // can appear, so the other three types match nothing and reserve nothing.
+  // Seats aren't simulated (probe.md), but their spent budget is not optional: without
+  // it, ranked rows silently fill budget the real pass already spent. `renderedText` is
+  // empty; nothing re-costs or renders a seat. Only entities and lore carry injections.
   const injectedKind = type === 'entities' ? 'entity' : type === 'lore' ? 'lore' : null
   const keywordInjected: KeywordInjection[] = payload.keyword_injections
     .filter((i) => i.target_kind === injectedKind)

--- a/lib/probe/validate.ts
+++ b/lib/probe/validate.ts
@@ -82,6 +82,11 @@ export function assertCaptureShape(decoded: unknown): asserts decoded is ProbeCa
     if (!Array.isArray(pools[type]))
       throw new CaptureShapeError(`pools.${type}`, `must be an array, got ${typeOf(pools[type])}`)
   }
+  if (!Array.isArray(payload.keyword_injections))
+    throw new CaptureShapeError(
+      'keyword_injections',
+      `must be an array, got ${typeOf(payload.keyword_injections)}`,
+    )
   if (!Array.isArray(payload.queries) || payload.queries.length !== 3)
     throw new CaptureShapeError('queries', 'must be a three-query stack')
   // Required-and-nullable, so `undefined` is rejected rather than defaulted:

--- a/lib/retrieval/__tests__/outcome.ts
+++ b/lib/retrieval/__tests__/outcome.ts
@@ -12,6 +12,7 @@ import {
   RETRIEVAL_TYPES,
   type Candidate,
   type CandidateTrace,
+  type KeywordInjection,
   type RankedType,
   type RetrievalType,
 } from '../types'
@@ -75,6 +76,7 @@ export type RetrievalSuccessOverrides = {
   /** Whole-bundle replacement, for traces or a funnel that must not be derived. */
   bundles?: Partial<Record<RetrievalType, RankedType>>
   queries?: QueryStack
+  keywordInjections?: readonly KeywordInjection[]
   staleCounts?: Partial<Record<RetrievalType, number>>
   injectedAwareness?: InjectedAwareness[]
   selectedLocationIds?: string[]
@@ -108,6 +110,7 @@ export function retrievalSuccess(over: RetrievalSuccessOverrides = {}): Retrieva
       presence: [false, false, false],
       embedTexts: [],
     },
+    keywordInjections: over.keywordInjections ?? [],
     staleCounts: { ...perType(() => 0), ...over.staleCounts },
     injectedAwareness: over.injectedAwareness ?? [],
     selectedLocationIds: over.selectedLocationIds ?? [],
@@ -127,6 +130,6 @@ export function retrievalFailure(
   return {
     ok: false,
     failure,
-    partial: { queries: null, floor: null, bundles: {}, ...partial },
+    partial: { queries: null, floor: null, bundles: {}, keywordInjections: [], ...partial },
   }
 }

--- a/lib/retrieval/index.ts
+++ b/lib/retrieval/index.ts
@@ -10,7 +10,7 @@ export type { EntityRow, LoreRow, StructuralFloor, ThreadRow } from './pools'
 export { extractProse, splitSentences } from './prose-extract'
 export { buildQueryStack, distributeQueryVectors } from './queries'
 export type { QuerySpec, QueryStack, QueryStackInput } from './queries'
-export { rankAll, rankPerType } from './ranker'
+export { rankAll, rankPerType, tokenCost } from './ranker'
 export type { RankTypeInput } from './ranker'
 export { ENTITY_FRAMING, entityRenderedText, lines, loreRenderedText } from './rendered-text'
 export { runRetrieval } from './run'
@@ -35,6 +35,8 @@ export type {
   CandidateKind,
   CandidateTrace,
   DropReason,
+  InjectedRow,
+  KeywordInjection,
   PoolFunnel,
   QueryAll,
   QueryTextPresence,
@@ -43,5 +45,6 @@ export type {
   RankedType,
   RankerParams,
   RetrievalType,
+  SeatedRow,
 } from './types'
 export { cosine } from './vector'

--- a/lib/retrieval/index.ts
+++ b/lib/retrieval/index.ts
@@ -12,7 +12,8 @@ export { buildQueryStack, distributeQueryVectors } from './queries'
 export type { QuerySpec, QueryStack, QueryStackInput } from './queries'
 export { rankAll, rankPerType } from './ranker'
 export type { RankTypeInput } from './ranker'
-export { ENTITY_FRAMING, runRetrieval } from './run'
+export { ENTITY_FRAMING, entityRenderedText, lines, loreRenderedText } from './rendered-text'
+export { runRetrieval } from './run'
 export type {
   InjectedAwareness,
   RetrievalDeps,

--- a/lib/retrieval/index.ts
+++ b/lib/retrieval/index.ts
@@ -3,6 +3,12 @@ export type { AwarenessRow } from './awareness'
 export { promptBufferTake, readPromptBuffer } from './buffer'
 export type { BufferSettings } from './buffer'
 export { KNN_K, PROSE_EXTRACT_TOP_K, RANKER_DEFAULTS } from './constants'
+export { buildKeywordInjections } from './injection'
+export type {
+  KeywordInjectionInput,
+  KeywordInjections,
+  KeywordRetrievalSettings,
+} from './injection'
 export { matchTerms, nameKeywordIndexFrom, normalizeTerm } from './name-index'
 export type { NameKeywordIndex } from './name-index'
 export { buildStructuralFloor, filterEntityPool, filterLorePool, filterThreadPool } from './pools'

--- a/lib/retrieval/injection.test.ts
+++ b/lib/retrieval/injection.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from 'vitest'
+
+import { RANKER_DEFAULTS } from './constants'
+import { buildKeywordInjections, type KeywordInjectionInput } from './injection'
+import type { EntityRow, LoreRow } from './pools'
+
+const countTokens = (t: string): number => Math.ceil(t.length / 4)
+
+const entity = (over: Partial<KeywordInjectionInput['entities'][number]> = {}) => ({
+  id: 'e1',
+  kind: 'character' as EntityRow['kind'],
+  status: 'active' as EntityRow['status'],
+  injectionMode: 'auto' as EntityRow['injectionMode'],
+  name: 'Kael',
+  description: 'A ferryman.',
+  keywords: [] as string[],
+  priority: 0,
+  ...over,
+})
+
+const lore = (over: Partial<KeywordInjectionInput['lore'][number]> = {}) => ({
+  id: 'l1',
+  title: 'The Aetherium',
+  body: 'A drowned engine.' as string | null,
+  injectionMode: 'auto' as LoreRow['injectionMode'],
+  keywords: ['aetherium'] as string[],
+  priority: 0,
+  ...over,
+})
+
+const input = (over: Partial<KeywordInjectionInput> = {}): KeywordInjectionInput => ({
+  settings: { mode: 'inject', budgetShare: 0.5, cascade: false, cascadeMaxDepth: 2 },
+  entities: [],
+  lore: [],
+  floorIds: new Set<string>(),
+  recentProse: '',
+  scanText: '',
+  budgets: { entities: 1200, lore: 1800, happenings: 1500, threads: 400, chapters: 600 },
+  params: RANKER_DEFAULTS,
+  countTokens,
+  ...over,
+})
+
+const ids = (rows: readonly { row: { id: string } }[]): string[] => rows.map((r) => r.row.id)
+
+describe('buildKeywordInjections — mode', () => {
+  it('returns nothing at all under boost', () => {
+    const out = buildKeywordInjections(
+      input({
+        settings: { mode: 'boost', budgetShare: 0.5, cascade: false, cascadeMaxDepth: 2 },
+        lore: [lore()],
+        scanText: 'the aetherium hums',
+      }),
+    )
+
+    expect(out.lore).toEqual([])
+    expect(out.entities).toEqual([])
+  })
+
+  it('never populates the three types canon keeps on boost', () => {
+    const out = buildKeywordInjections(input({ lore: [lore()], scanText: 'the aetherium hums' }))
+
+    expect(out.happenings).toEqual([])
+    expect(out.threads).toEqual([])
+    expect(out.chapters).toEqual([])
+  })
+})
+
+describe('buildKeywordInjections — the keyword surface', () => {
+  it('matches an entity on its name', () => {
+    const out = buildKeywordInjections(input({ entities: [entity()], scanText: 'Kael waits.' }))
+
+    expect(ids(out.entities)).toEqual(['e1'])
+    expect(out.entities[0].terms).toEqual(['kael'])
+  })
+
+  it('matches an entity on an epithet the name misses', () => {
+    const out = buildKeywordInjections(
+      input({
+        entities: [entity({ keywords: ['the ferryman'] })],
+        scanText: 'You pay the ferryman.',
+      }),
+    )
+
+    expect(out.entities[0].terms).toEqual(['the ferryman'])
+  })
+
+  it('records a term once when a keyword repeats the name', () => {
+    const out = buildKeywordInjections(
+      input({ entities: [entity({ keywords: ['KAEL'] })], scanText: 'Kael waits.' }),
+    )
+
+    expect(out.entities[0].terms).toEqual(['kael'])
+  })
+
+  it('matches lore on its keywords, not its title', () => {
+    const out = buildKeywordInjections(
+      input({ lore: [lore({ keywords: ['blood-bound'] })], scanText: 'The Aetherium sings.' }),
+    )
+
+    expect(out.lore).toEqual([])
+  })
+
+  it('seats the row with the rendered text the ranker would have charged', () => {
+    const out = buildKeywordInjections(
+      input({ entities: [entity({ status: 'staged' })], scanText: 'Kael waits.' }),
+    )
+
+    expect(out.entities[0].row.renderedText).toBe('Kael (available to introduce): A ferryman.')
+    expect(out.entities[0].tokensEstimated).toBe(
+      countTokens('Kael (available to introduce): A ferryman.') +
+        RANKER_DEFAULTS.typeOverhead.entities,
+    )
+  })
+})
+
+describe('buildKeywordInjections — precedence and pool exclusions', () => {
+  it('leaves a disabled row alone however loudly it matches', () => {
+    const out = buildKeywordInjections(
+      input({
+        entities: [entity({ injectionMode: 'disabled' })],
+        lore: [lore({ injectionMode: 'disabled' })],
+        scanText: 'Kael and the aetherium.',
+      }),
+    )
+
+    expect(out.entities).toEqual([])
+    expect(out.lore).toEqual([])
+  })
+
+  it('skips a row the structural floor already seated', () => {
+    const out = buildKeywordInjections(
+      input({ entities: [entity()], floorIds: new Set(['e1']), scanText: 'Kael waits.' }),
+    )
+
+    expect(out.entities).toEqual([])
+  })
+
+  it('honours Layer-A suppression over the keyword hit', () => {
+    // The same prose is the suppression trigger and the fire condition;
+    // edge-cases.md → Layer A says suppression wins.
+    const out = buildKeywordInjections(
+      input({
+        entities: [entity({ status: 'staged' })],
+        recentProse: 'A man called Kael stepped from the fog.',
+        scanText: 'Kael waits.',
+      }),
+    )
+
+    expect(out.entities).toEqual([])
+  })
+
+  it('never seats a retired row', () => {
+    const out = buildKeywordInjections(
+      input({ entities: [entity({ status: 'retired' })], scanText: 'Kael waits.' }),
+    )
+
+    expect(out.entities).toEqual([])
+  })
+})
+
+describe('buildKeywordInjections — the budget cap', () => {
+  const wide = (id: string, priority: number) =>
+    lore({ id, title: id, body: 'x'.repeat(160), priority, keywords: [id] })
+
+  // 160 + len(id) chars of text is 41 tokens plus 4 overhead. A 100-token lore
+  // budget at budgetShare 0.5 caps the seats at 50, so exactly one fits.
+  const capped = () =>
+    input({
+      lore: [wide('aa', 1), wide('bb', 5), wide('cc', 5)],
+      budgets: { entities: 0, lore: 100, happenings: 0, threads: 0, chapters: 0 },
+      scanText: 'aa bb cc',
+    })
+
+  it('orders overflow by priority, then alphabetically, then by id', () => {
+    const out = buildKeywordInjections(capped())
+
+    expect(ids(out.lore)).toEqual(['bb', 'cc', 'aa'])
+  })
+
+  it('seats up to budgetShare of the type budget and cuts the rest', () => {
+    const out = buildKeywordInjections(capped())
+
+    expect(out.lore.map((i) => i.seated)).toEqual([true, false, false])
+  })
+
+  it('records a cut row with its priority so the order is inspectable', () => {
+    const out = buildKeywordInjections(capped())
+
+    expect(out.lore[2]).toMatchObject({ seated: false, priority: 1 })
+  })
+
+  it('tries a smaller row rather than stopping at the first that does not fit', () => {
+    const out = buildKeywordInjections(
+      input({
+        lore: [wide('aa', 9), lore({ id: 'bb', title: 'bb', body: null, keywords: ['bb'] })],
+        budgets: { entities: 0, lore: 60, happenings: 0, threads: 0, chapters: 0 },
+        scanText: 'aa bb',
+      }),
+    )
+
+    expect(out.lore.filter((i) => i.seated).map((i) => i.row.id)).toEqual(['bb'])
+  })
+
+  it('seats nothing at budgetShare 0, leaving every match to the ranked path', () => {
+    const out = buildKeywordInjections(
+      input({
+        settings: { mode: 'inject', budgetShare: 0, cascade: false, cascadeMaxDepth: 2 },
+        lore: [lore()],
+        scanText: 'the aetherium hums',
+      }),
+    )
+
+    expect(out.lore.map((i) => i.seated)).toEqual([false])
+  })
+})

--- a/lib/retrieval/injection.test.ts
+++ b/lib/retrieval/injection.test.ts
@@ -128,12 +128,18 @@ describe('buildKeywordInjections — precedence and pool exclusions', () => {
     expect(out.lore).toEqual([])
   })
 
-  it('skips a row the structural floor already seated', () => {
+  it('skips a row the structural floor already seated, on either type', () => {
     const out = buildKeywordInjections(
-      input({ entities: [entity()], floorIds: new Set(['e1']), scanText: 'Kael waits.' }),
+      input({
+        entities: [entity()],
+        lore: [lore()],
+        floorIds: new Set(['e1', 'l1']),
+        scanText: 'Kael waits where the aetherium hums.',
+      }),
     )
 
     expect(out.entities).toEqual([])
+    expect(out.lore).toEqual([])
   })
 
   it('honours Layer-A suppression over the keyword hit', () => {
@@ -202,6 +208,22 @@ describe('buildKeywordInjections — the budget cap', () => {
     expect(out.lore.filter((i) => i.seated).map((i) => i.row.id)).toEqual(['bb'])
   })
 
+  // Sorts are stable in V8, so without the id fallback these keep source order —
+  // which is SQLite's, and unordered.
+  it('breaks a full tie on the id, not on the source read order', () => {
+    const out = buildKeywordInjections(
+      input({
+        lore: [
+          lore({ id: 'z1', title: 'dup', keywords: ['alpha'], priority: 1 }),
+          lore({ id: 'a2', title: 'DUP', keywords: ['alpha'], priority: 1 }),
+        ],
+        scanText: 'alpha',
+      }),
+    )
+
+    expect(ids(out.lore)).toEqual(['a2', 'z1'])
+  })
+
   it('seats nothing at budgetShare 0, leaving every match to the ranked path', () => {
     const out = buildKeywordInjections(
       input({
@@ -212,5 +234,130 @@ describe('buildKeywordInjections — the budget cap', () => {
     )
 
     expect(out.lore.map((i) => i.seated)).toEqual([false])
+  })
+})
+
+describe('buildKeywordInjections — cascade', () => {
+  const cascading = (over: Partial<KeywordInjectionInput['settings']> = {}) => ({
+    mode: 'inject' as const,
+    budgetShare: 1,
+    cascade: true,
+    cascadeMaxDepth: 2,
+    ...over,
+  })
+
+  const sized = (id: string, body: string, keywords: string[], priority = 0) =>
+    lore({ id, title: id, body, keywords, priority })
+
+  // 'a' names 'b' in its body; 'b' names 'c'. Only 'a' is in the scan text.
+  const chain = () => [
+    lore({ id: 'a', title: 'A', body: 'It speaks of the beacon.', keywords: ['anchor'] }),
+    lore({ id: 'b', title: 'B', body: 'It speaks of the cistern.', keywords: ['beacon'] }),
+    lore({ id: 'c', title: 'C', body: 'It speaks of nothing.', keywords: ['cistern'] }),
+  ]
+
+  it('stays at depth 1 while cascade is off', () => {
+    const out = buildKeywordInjections(
+      input({
+        settings: { mode: 'inject', budgetShare: 1, cascade: false, cascadeMaxDepth: 2 },
+        lore: chain(),
+        scanText: 'The anchor holds.',
+      }),
+    )
+
+    expect(ids(out.lore)).toEqual(['a'])
+  })
+
+  it("rescans a seated row's own text to cascadeMaxDepth and no further", () => {
+    const out = buildKeywordInjections(
+      input({ settings: cascading(), lore: chain(), scanText: 'The anchor holds.' }),
+    )
+
+    expect(ids(out.lore)).toEqual(['a', 'b'])
+  })
+
+  it('reaches the third link at depth 3', () => {
+    const out = buildKeywordInjections(
+      input({
+        settings: cascading({ cascadeMaxDepth: 3 }),
+        lore: chain(),
+        scanText: 'The anchor holds.',
+      }),
+    )
+
+    expect(ids(out.lore)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('terminates on a pair whose keywords name each other', () => {
+    const out = buildKeywordInjections(
+      input({
+        settings: cascading({ cascadeMaxDepth: 8 }),
+        lore: [
+          lore({ id: 'x', title: 'X', body: 'It speaks of the yoke.', keywords: ['ex'] }),
+          lore({ id: 'y', title: 'Y', body: 'It speaks of the ex.', keywords: ['yoke'] }),
+        ],
+        scanText: 'The ex is here.',
+      }),
+    )
+
+    expect(ids(out.lore)).toEqual(['x', 'y'])
+  })
+
+  it('spends the allowance on depth-1 rows before any depth-2 row', () => {
+    // 'deep' carries the higher priority and still loses: it is only reachable at
+    // depth 2, by which point depth 1 has spent the allowance. sized('one') costs
+    // 45 and sized('deep') 43 against a cap of 100 * 0.5.
+    const out = buildKeywordInjections(
+      input({
+        settings: cascading({ budgetShare: 0.5 }),
+        lore: [
+          sized('one', `${'x'.repeat(150)} the deep`, ['one']),
+          sized('deep', 'y'.repeat(150), ['the deep'], 9),
+        ],
+        budgets: { entities: 0, lore: 100, happenings: 0, threads: 0, chapters: 0 },
+        scanText: 'one',
+      }),
+    )
+
+    expect(out.lore.filter((i) => i.seated).map((i) => i.row.id)).toEqual(['one'])
+    expect(out.lore.find((i) => i.row.id === 'deep')?.seated).toBe(false)
+  })
+
+  it('does not rescan a row the cap cut — it is not in the prompt', () => {
+    // 'two' matches at depth 1 and the cap cuts it. Its body names 'the ghost';
+    // a frontier built from matched rather than seated rows would reach it.
+    // Costs: one 43, two 11, cap 50 — so 'one' seats and 'two' overflows.
+    const out = buildKeywordInjections(
+      input({
+        settings: cascading({ budgetShare: 0.5 }),
+        lore: [
+          sized('one', 'x'.repeat(150), ['one'], 5),
+          sized('two', 'It speaks of the ghost.', ['two'], 1),
+          sized('ghost', 'Nothing more.', ['the ghost']),
+        ],
+        budgets: { entities: 0, lore: 100, happenings: 0, threads: 0, chapters: 0 },
+        scanText: 'one two',
+      }),
+    )
+
+    expect(ids(out.lore)).toEqual(['one', 'two'])
+  })
+
+  it('records a cut row once, even when a seated row names it again', () => {
+    // 'two' is cut at depth 1, and the seated 'one' names it again at depth 2.
+    // Only the visited set stops it being matched — and recorded — twice.
+    const out = buildKeywordInjections(
+      input({
+        settings: cascading({ budgetShare: 0.5 }),
+        lore: [
+          sized('one', 'It speaks of the two.', ['one'], 5),
+          sized('two', 'x'.repeat(200), ['the two'], 1),
+        ],
+        budgets: { entities: 0, lore: 100, happenings: 0, threads: 0, chapters: 0 },
+        scanText: 'The one and the two.',
+      }),
+    )
+
+    expect(ids(out.lore)).toEqual(['one', 'two'])
   })
 })

--- a/lib/retrieval/injection.test.ts
+++ b/lib/retrieval/injection.test.ts
@@ -208,6 +208,24 @@ describe('buildKeywordInjections — the budget cap', () => {
     expect(out.lore.filter((i) => i.seated).map((i) => i.row.id)).toEqual(['bb'])
   })
 
+  // The cap is a `>` comparison, so a NaN budget makes it false for every row and
+  // seats the whole match set unbounded — the opposite direction from every other
+  // reader of a bad budget, which seats nothing.
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, -100])(
+    'seats nothing when the type budget is %p',
+    (loreBudget) => {
+      const out = buildKeywordInjections(
+        input({
+          lore: [wide('aa', 0), wide('bb', 0)],
+          budgets: { entities: 0, lore: loreBudget, happenings: 0, threads: 0, chapters: 0 },
+          scanText: 'aa bb',
+        }),
+      )
+
+      expect(out.lore.map((i) => i.seated)).toEqual([false, false])
+    },
+  )
+
   // Sorts are stable in V8, so without the id fallback these keep source order —
   // which is SQLite's, and unordered.
   it('breaks a full tie on the id, not on the source read order', () => {

--- a/lib/retrieval/injection.test.ts
+++ b/lib/retrieval/injection.test.ts
@@ -143,8 +143,7 @@ describe('buildKeywordInjections — precedence and pool exclusions', () => {
   })
 
   it('honours Layer-A suppression over the keyword hit', () => {
-    // The same prose is the suppression trigger and the fire condition;
-    // edge-cases.md → Layer A says suppression wins.
+    // Same prose triggers suppression and the keyword fire; edge-cases.md → Layer A.
     const out = buildKeywordInjections(
       input({
         entities: [entity({ status: 'staged' })],
@@ -208,9 +207,8 @@ describe('buildKeywordInjections — the budget cap', () => {
     expect(out.lore.filter((i) => i.seated).map((i) => i.row.id)).toEqual(['bb'])
   })
 
-  // The cap is a `>` comparison, so a NaN budget makes it false for every row and
-  // seats the whole match set unbounded — the opposite direction from every other
-  // reader of a bad budget, which seats nothing.
+  // The cap is a `>` comparison: a NaN budget makes it false for every row and
+  // seats the whole match set — the opposite direction from other bad-budget readers.
   it.each([Number.NaN, Number.POSITIVE_INFINITY, -100])(
     'seats nothing when the type budget is %p',
     (loreBudget) => {
@@ -226,8 +224,7 @@ describe('buildKeywordInjections — the budget cap', () => {
     },
   )
 
-  // Sorts are stable in V8, so without the id fallback these keep source order —
-  // which is SQLite's, and unordered.
+  // Sorts are stable in V8: without the id fallback these keep SQLite's read order.
   it('breaks a full tie on the id, not on the source read order', () => {
     const out = buildKeywordInjections(
       input({
@@ -322,9 +319,8 @@ describe('buildKeywordInjections — cascade', () => {
   })
 
   it('spends the allowance on depth-1 rows before any depth-2 row', () => {
-    // 'deep' carries the higher priority and still loses: it is only reachable at
-    // depth 2, by which point depth 1 has spent the allowance. sized('one') costs
-    // 45 and sized('deep') 43 against a cap of 100 * 0.5.
+    // 'deep' has the higher priority and still loses: reachable only at depth 2, by
+    // which point depth 1 spent the allowance. Costs 45 and 43 against a cap of 100 * 0.5.
     const out = buildKeywordInjections(
       input({
         settings: cascading({ budgetShare: 0.5 }),
@@ -342,9 +338,8 @@ describe('buildKeywordInjections — cascade', () => {
   })
 
   it('does not rescan a row the cap cut — it is not in the prompt', () => {
-    // 'two' matches at depth 1 and the cap cuts it. Its body names 'the ghost';
-    // a frontier built from matched rather than seated rows would reach it.
-    // Costs: one 43, two 11, cap 50 — so 'one' seats and 'two' overflows.
+    // 'two' matches at depth 1 and the cap cuts it; its body names 'the ghost', which
+    // a matched-rather-than-seated frontier would reach. Costs: one 43, two 11, cap 50.
     const out = buildKeywordInjections(
       input({
         settings: cascading({ budgetShare: 0.5 }),

--- a/lib/retrieval/injection.ts
+++ b/lib/retrieval/injection.ts
@@ -10,10 +10,9 @@ import {
 } from './types'
 
 /**
- * What runRetrieval reads off `stories.settings.keywordRetrieval`. Declared here
- * rather than imported from lib/db, the way BufferSettings is, so retrieval does
- * not follow whatever else the story-settings blob grows. `scanEntries` is
- * absent because the phase spends it before the pass starts.
+ * What runRetrieval reads off `stories.settings.keywordRetrieval`. Declared here, not
+ * imported from lib/db, so retrieval does not follow whatever else that blob grows.
+ * `scanEntries` is absent — the phase spends it before the pass starts.
  */
 export type KeywordRetrievalSettings = {
   mode: 'boost' | 'inject'
@@ -60,16 +59,13 @@ const empty = (): KeywordInjections => ({
   chapters: [],
 })
 
-// Hardening against settings that never went through storySettingsSchema, the
-// same threat readPromptBuffer's toCount and readScanEntries' toTake cover. Out
-// of range, budgetShare silently starves or floods one partition.
+// Hardening against settings that never went through storySettingsSchema: out of
+// range, budgetShare silently starves or floods one partition.
 const toShare = (value: number): number =>
   Number.isFinite(value) ? Math.min(1, Math.max(0, value)) : 0
 
-// A non-finite budget makes `used + cost > cap` false for every row, so the cap
-// would not cap at all — exactly the unbounded seating budgetShare exists to
-// prevent. replayType guards the same field for the mirror-image reason; every
-// other reader of a bad budget seats nothing, and this matches that direction.
+// A non-finite budget makes `used + cost > cap` false for every row, so the cap would
+// not cap at all; 0 matches every other reader's seat-nothing direction.
 const toCap = (budget: number, share: number): number =>
   Number.isFinite(budget) ? Math.max(0, budget) * share : 0
 
@@ -78,10 +74,8 @@ const toDepth = (settings: KeywordRetrievalSettings): number =>
     ? Math.max(1, Math.floor(settings.cascadeMaxDepth))
     : 1
 
-// Code units over a normalized name, never localeCompare: the host locale would
-// make which rows seat device-dependent, and `sensitivity: 'base'` is not even a
-// total order — two rows differing only in case would tie and fall through to
-// SQLite's unordered read. The id fallback closes that.
+// Code units, never localeCompare: the host locale would make which rows seat
+// device-dependent, and case-only ties fall to SQLite's read order — hence the id key.
 const cmp = (a: string, b: string): number => (a < b ? -1 : a > b ? 1 : 0)
 
 const byOverflowOrder = (a: KeywordInjection, b: KeywordInjection): number =>
@@ -92,11 +86,8 @@ const byOverflowOrder = (a: KeywordInjection, b: KeywordInjection): number =>
 type Matchable = { row: InjectedRow; priority: number; terms: readonly string[] }
 
 function matchable(input: KeywordInjectionInput): Record<Injectable, Matchable[]> {
-  // The same filters the ranker pools run, so `disabled`, retired, floor-seated
-  // and Layer-A-suppressed rows are excluded identically (retrieval.md → Keyword
-  // injection: "the same status and pool-exclusion rules as ranked candidates").
-  // `embedding_stale` is deliberately NOT among them — it gates vector validity,
-  // and this path reads no vector.
+  // The same filters the ranker pools run (retrieval.md → Keyword injection).
+  // Not `embedding_stale`: it gates vector validity, and this path reads no vector.
   const entities = filterEntityPool(input.entities, {
     floorIds: input.floorIds,
     recentProse: input.recentProse,
@@ -112,11 +103,8 @@ function matchable(input: KeywordInjectionInput): Record<Injectable, Matchable[]
         renderedText: entityRenderedText(r),
       },
       priority: r.priority,
-      // Canon: "Keyword on `name` and `entities.keywords`". The name is implicit
-      // and carries no column of its own, hence prepended here rather than
-      // expected in `keywords`. De-duplicated post-normalization: an author who
-      // also listed the name as a keyword would otherwise get it twice in the
-      // probe's `terms`, reading as two hits where the prose had one.
+      // Canon: "Keyword on `name` and `entities.keywords`" — the name has no column,
+      // hence prepended. De-duped so a name also listed as a keyword is not two hits.
       terms: [...new Set([r.name, ...r.keywords].map(normalizeTerm))],
     })),
     lore: lore.map((r) => ({
@@ -135,13 +123,10 @@ function matchable(input: KeywordInjectionInput): Record<Injectable, Matchable[]
 }
 
 /**
- * retrieval.md → Keyword injection. Matches the scan surface against lore and
- * entity keyword sets and returns the rows a hit seats, capped per type at
- * `budgetShare` of that type's allocation. Cut rows are returned too, so the
- * probe can show the overflow order and the ranker can leave them in its pool.
- *
- * Returns everything empty under `mode='boost'` without touching the tokenizer:
- * that is the default, and every pass runs through here.
+ * retrieval.md → Keyword injection. Matches the scan surface against entity and lore
+ * keyword sets and returns the rows a hit seats, capped per type at `budgetShare` of
+ * that type's allocation. Cut rows are returned too, carrying `seated: false`. Empty
+ * under `mode='boost'` — the default — without touching the tokenizer.
  */
 export function buildKeywordInjections(input: KeywordInjectionInput): KeywordInjections {
   const out = empty()
@@ -184,9 +169,8 @@ export function buildKeywordInjections(input: KeywordInjectionInput): KeywordInj
       hits.sort(byOverflowOrder)
 
       for (const hit of hits) {
-        // Marked whether or not it seats: a cut row re-offered at a deeper depth
-        // would take a second probe entry and, on a cycle, could be re-tried
-        // until the allowance ran out.
+        // Marked whether or not it seats: a cut row re-offered deeper would take a
+        // second probe entry and, on a cycle, be re-tried until the allowance ran out.
         visited.add(hit.row.id)
         // `continue`, not `break` — canon's budget fill tries smaller rows
         // rather than stopping at the first that does not fit.

--- a/lib/retrieval/injection.ts
+++ b/lib/retrieval/injection.ts
@@ -66,6 +66,13 @@ const empty = (): KeywordInjections => ({
 const toShare = (value: number): number =>
   Number.isFinite(value) ? Math.min(1, Math.max(0, value)) : 0
 
+// A non-finite budget makes `used + cost > cap` false for every row, so the cap
+// would not cap at all — exactly the unbounded seating budgetShare exists to
+// prevent. replayType guards the same field for the mirror-image reason; every
+// other reader of a bad budget seats nothing, and this matches that direction.
+const toCap = (budget: number, share: number): number =>
+  Number.isFinite(budget) ? Math.max(0, budget) * share : 0
+
 const toDepth = (settings: KeywordRetrievalSettings): number =>
   settings.cascade && Number.isFinite(settings.cascadeMaxDepth)
     ? Math.max(1, Math.floor(settings.cascadeMaxDepth))
@@ -144,8 +151,8 @@ export function buildKeywordInjections(input: KeywordInjectionInput): KeywordInj
   // Per type, matching the hard partitions already in force: an unused keyword
   // allowance in one type does not migrate to another.
   const caps: Record<Injectable, number> = {
-    entities: input.budgets.entities * share,
-    lore: input.budgets.lore * share,
+    entities: toCap(input.budgets.entities, share),
+    lore: toCap(input.budgets.lore, share),
   }
   const used: Record<Injectable, number> = { entities: 0, lore: 0 }
   const costInput: Pick<RankTypeInput, 'params' | 'countTokens'> = {

--- a/lib/retrieval/injection.ts
+++ b/lib/retrieval/injection.ts
@@ -1,0 +1,203 @@
+import { matchTerms, normalizeTerm } from './name-index'
+import { filterEntityPool, filterLorePool, type EntityRow, type LoreRow } from './pools'
+import { tokenCost, type RankTypeInput } from './ranker'
+import { entityRenderedText, loreRenderedText } from './rendered-text'
+import {
+  type InjectedRow,
+  type KeywordInjection,
+  type RankerParams,
+  type RetrievalType,
+} from './types'
+
+/**
+ * What runRetrieval reads off `stories.settings.keywordRetrieval`. Declared here
+ * rather than imported from lib/db, the way BufferSettings is, so retrieval does
+ * not follow whatever else the story-settings blob grows. `scanEntries` is
+ * absent because the phase spends it before the pass starts.
+ */
+export type KeywordRetrievalSettings = {
+  mode: 'boost' | 'inject'
+  budgetShare: number
+  cascade: boolean
+  cascadeMaxDepth: number
+}
+
+/** An entity with the two columns the keyword path reads beyond EntityRow. */
+type InjectableEntity = EntityRow & { keywords: readonly string[]; priority: number }
+/** LoreRow already carries `priority`; only `keywords` is extra. */
+type InjectableLore = LoreRow & { keywords: readonly string[] }
+
+export type KeywordInjectionInput = {
+  settings: KeywordRetrievalSettings
+  entities: readonly InjectableEntity[]
+  lore: readonly InjectableLore[]
+  /** Every id the structural floor seated — already in the prompt, never injected. */
+  floorIds: ReadonlySet<string>
+  /** Un-classified buffer prose, for Layer-A same-name suppression. */
+  recentProse: string
+  /** The haystack (retrieval.md → Keyword scan surface). */
+  scanText: string
+  budgets: Record<RetrievalType, number>
+  params: RankerParams
+  /** Injected so this stays pure, matching the ranker's own countTokens seam. */
+  countTokens: (text: string) => number
+}
+
+/** The two types canon admits: both need a curated keyword set AND an ordering key. */
+type Injectable = Extract<RetrievalType, 'entities' | 'lore'>
+const INJECTABLE: readonly Injectable[] = ['entities', 'lore']
+
+/** Only `entities` and `lore` are ever non-empty; canon keeps the other three on `boost`. */
+export type KeywordInjections = Record<RetrievalType, KeywordInjection[]>
+
+// A literal, not a built-up Record: a type added to RETRIEVAL_TYPES is a build
+// error here rather than an undefined list rankAll would seat nothing from.
+const empty = (): KeywordInjections => ({
+  entities: [],
+  lore: [],
+  happenings: [],
+  threads: [],
+  chapters: [],
+})
+
+// Hardening against settings that never went through storySettingsSchema, the
+// same threat readPromptBuffer's toCount and readScanEntries' toTake cover. Out
+// of range, budgetShare silently starves or floods one partition.
+const toShare = (value: number): number =>
+  Number.isFinite(value) ? Math.min(1, Math.max(0, value)) : 0
+
+const toDepth = (settings: KeywordRetrievalSettings): number =>
+  settings.cascade && Number.isFinite(settings.cascadeMaxDepth)
+    ? Math.max(1, Math.floor(settings.cascadeMaxDepth))
+    : 1
+
+// Code units over a normalized name, never localeCompare: the host locale would
+// make which rows seat device-dependent, and `sensitivity: 'base'` is not even a
+// total order — two rows differing only in case would tie and fall through to
+// SQLite's unordered read. The id fallback closes that.
+const cmp = (a: string, b: string): number => (a < b ? -1 : a > b ? 1 : 0)
+
+const byOverflowOrder = (a: KeywordInjection, b: KeywordInjection): number =>
+  b.priority - a.priority ||
+  cmp(normalizeTerm(a.row.displayName), normalizeTerm(b.row.displayName)) ||
+  cmp(a.row.id, b.row.id)
+
+type Matchable = { row: InjectedRow; priority: number; terms: readonly string[] }
+
+function matchable(input: KeywordInjectionInput): Record<Injectable, Matchable[]> {
+  // The same filters the ranker pools run, so `disabled`, retired, floor-seated
+  // and Layer-A-suppressed rows are excluded identically (retrieval.md → Keyword
+  // injection: "the same status and pool-exclusion rules as ranked candidates").
+  // `embedding_stale` is deliberately NOT among them — it gates vector validity,
+  // and this path reads no vector.
+  const entities = filterEntityPool(input.entities, {
+    floorIds: input.floorIds,
+    recentProse: input.recentProse,
+  })
+  const lore = filterLorePool(input.lore, input.floorIds)
+
+  return {
+    entities: entities.map((r) => ({
+      row: {
+        kind: 'entity' as const,
+        id: r.id,
+        displayName: r.name,
+        renderedText: entityRenderedText(r),
+      },
+      priority: r.priority,
+      // Canon: "Keyword on `name` and `entities.keywords`". The name is implicit
+      // and carries no column of its own, hence prepended here rather than
+      // expected in `keywords`. De-duplicated post-normalization: an author who
+      // also listed the name as a keyword would otherwise get it twice in the
+      // probe's `terms`, reading as two hits where the prose had one.
+      terms: [...new Set([r.name, ...r.keywords].map(normalizeTerm))],
+    })),
+    lore: lore.map((r) => ({
+      row: {
+        kind: 'lore' as const,
+        id: r.id,
+        displayName: r.title,
+        renderedText: loreRenderedText(r),
+      },
+      priority: r.priority,
+      // Lore's title is deliberately absent: canon's surface is `lore.keywords`
+      // alone, and the ranked path's kwHits(r.keywords) says the same.
+      terms: [...new Set(r.keywords.map(normalizeTerm))],
+    })),
+  }
+}
+
+/**
+ * retrieval.md → Keyword injection. Matches the scan surface against lore and
+ * entity keyword sets and returns the rows a hit seats, capped per type at
+ * `budgetShare` of that type's allocation. Cut rows are returned too, so the
+ * probe can show the overflow order and the ranker can leave them in its pool.
+ *
+ * Returns everything empty under `mode='boost'` without touching the tokenizer:
+ * that is the default, and every pass runs through here.
+ */
+export function buildKeywordInjections(input: KeywordInjectionInput): KeywordInjections {
+  const out = empty()
+  if (input.settings.mode !== 'inject') return out
+
+  const share = toShare(input.settings.budgetShare)
+  // Per type, matching the hard partitions already in force: an unused keyword
+  // allowance in one type does not migrate to another.
+  const caps: Record<Injectable, number> = {
+    entities: input.budgets.entities * share,
+    lore: input.budgets.lore * share,
+  }
+  const used: Record<Injectable, number> = { entities: 0, lore: 0 }
+  const costInput: Pick<RankTypeInput, 'params' | 'countTokens'> = {
+    params: input.params,
+    countTokens: input.countTokens,
+  }
+
+  const pools = matchable(input)
+  const visited = new Set<string>()
+  let haystack = input.scanText
+
+  for (let depth = 1; depth <= toDepth(input.settings); depth++) {
+    const seatedThisDepth: string[] = []
+
+    for (const type of INJECTABLE) {
+      const hits: KeywordInjection[] = []
+      for (const m of pools[type]) {
+        if (visited.has(m.row.id)) continue
+        const terms = matchTerms(haystack, m.terms)
+        if (terms.length === 0) continue
+        hits.push({
+          row: m.row,
+          terms,
+          priority: m.priority,
+          tokensEstimated: tokenCost(m.row.renderedText, type, costInput),
+          seated: false,
+        })
+      }
+      hits.sort(byOverflowOrder)
+
+      for (const hit of hits) {
+        // Marked whether or not it seats: a cut row re-offered at a deeper depth
+        // would take a second probe entry and, on a cycle, could be re-tried
+        // until the allowance ran out.
+        visited.add(hit.row.id)
+        // `continue`, not `break` — canon's budget fill tries smaller rows
+        // rather than stopping at the first that does not fit.
+        if (used[type] + hit.tokensEstimated > caps[type]) {
+          out[type].push(hit)
+          continue
+        }
+        used[type] += hit.tokensEstimated
+        out[type].push({ ...hit, seated: true })
+        seatedThisDepth.push(hit.row.renderedText)
+      }
+    }
+
+    // Seated rows only: an unseated row is not in the prompt, so its text is not
+    // "an injected row's own text" to rescan.
+    if (seatedThisDepth.length === 0) break
+    haystack = seatedThisDepth.join('\n')
+  }
+
+  return out
+}

--- a/lib/retrieval/name-index.test.ts
+++ b/lib/retrieval/name-index.test.ts
@@ -125,8 +125,7 @@ describe('matchTerms', () => {
   })
 })
 
-// docs/memory/retrieval.md → Keyword scan surface: the match rule follows the
-// script of the keyword, per keyword.
+// docs/memory/retrieval.md → Keyword scan surface.
 describe('matchTerms — per-term script rule', () => {
   it('matches an unspaced Han term by substring', () => {
     // Japanese prose supplies no inter-word space to anchor a boundary against,
@@ -156,8 +155,7 @@ describe('matchTerms — per-term script rule', () => {
   })
 
   // An internal space means the author supplied a delimiter, so the term keeps
-  // boundary mode — which in CJK prose means it matches only where real
-  // punctuation or spacing brackets it, never mid-run.
+  // boundary mode — in CJK prose it then matches only at a bracket, never mid-run.
   it('denies substring mode to a term the author already delimited', () => {
     expect(matchTerms('月光 剣。', [normalizeTerm('月光 剣')])).toEqual(['月光 剣'])
     expect(matchTerms('その月光 剣士', [normalizeTerm('月光 剣')])).toEqual([])
@@ -174,9 +172,8 @@ describe('matchTerms — per-term script rule', () => {
     expect(matchTerms('彼は𠮷を見た。', [normalizeTerm('\u{20BB7}')])).toEqual([])
   })
 
-  // The positive half of the same rule: iterating UTF-16 units instead of code
-  // points leaves every char a lone surrogate, which is neither Han nor a
-  // letter, so an astral term would fall out of substring mode entirely.
+  // Iterating UTF-16 units instead of code points leaves every char a lone surrogate
+  // — neither Han nor letter — so an astral term would lose substring mode entirely.
   it('matches an astral ideograph pair by substring', () => {
     const term = '\u{20BB7}\u{20BB7}'
     expect(matchTerms(`彼は${term}を見た。`, [normalizeTerm(term)])).toEqual([term])
@@ -187,8 +184,7 @@ describe('matchTerms — per-term script rule', () => {
     expect(matchTerms('その月光\u3000剣士', [normalizeTerm('月光\u3000剣')])).toEqual([])
   })
 
-  // Metacharacters only reach escape() on the boundary branch, so the term has
-  // to be one that stays there — a substring-mode term never sees it.
+  // escape() only runs on the boundary branch, so the term has to be one that stays there.
   it('escapes regex metacharacters in a term the script rule sends to boundaries', () => {
     expect(matchTerms('the vex*月 hummed', [normalizeTerm('vex*月')])).toEqual(['vex*月'])
     expect(matchTerms('the vexX月 hummed', [normalizeTerm('vex*月')])).toEqual([])

--- a/lib/retrieval/name-index.ts
+++ b/lib/retrieval/name-index.ts
@@ -1,7 +1,5 @@
-// matchTerms NFC-normalizes and lowercases its haystack but leaves its terms
-// untouched, so every producer of a term has to match that shape or the lookup
-// silently misses — which is why the rule itself lives in a shared bare file
-// that a producer can reach without pulling the retrieval barrel behind it.
+// matchTerms normalizes only its haystack, so every term producer must match that
+// shape or the lookup silently misses — hence the rule in a shared barrel-free module.
 import { normalizeTerm } from '@/lib/keyword-terms'
 
 export { normalizeTerm }
@@ -53,29 +51,23 @@ function escape(term: string): string {
   return term.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`)
 }
 
-// Plain \b is ASCII-only and misses accented/Cyrillic names entirely (e.g.
-// "Zoë" never matches). \p{L}/\p{N} lookarounds cover any script with
-// letter/number boundaries.
+// Plain \b is ASCII-only — "Zoë" never matches. \p{L}/\p{N} lookarounds cover any
+// script with letter/number boundaries.
 function boundaryPattern(term: string): RegExp {
   return new RegExp(String.raw`(?<![\p{L}\p{N}_])${escape(term)}(?![\p{L}\p{N}_])`, 'u')
 }
 
-// Han, kana and hangul supply no inter-word delimiter (Korean attaches particles
-// straight onto nouns), so boundary lookarounds silently never fire inside their
-// prose. Substring is safe for these scripts because their characters are
-// morphemes — the "art" inside "start" risk boundaries exist to prevent is far
-// lower. docs/memory/retrieval.md → Keyword scan surface.
+// Han, kana and hangul carry no inter-word delimiter, so boundary lookarounds never
+// fire in their prose; substring is safe because their characters are morphemes.
+// docs/memory/retrieval.md → Keyword scan surface.
 const UNSPACED_SCRIPT = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u
 const LETTER = /\p{L}/u
-// \s, not ' ': U+3000 IDEOGRAPHIC SPACE is the delimiter a CJK author actually
-// types, so the ASCII space alone covers the wrong half of the set.
+// \s, not ' ': U+3000 IDEOGRAPHIC SPACE is the delimiter a CJK author actually types.
 const ANY_SPACE = /\s/u
 
-// Composed of those scripts, not merely containing one — a mostly-Latin term
-// with a single CJK character must keep boundary anchoring. Iterated by code
-// point so an astral ideograph counts as the one character it is rather than as
-// two UTF-16 units. An internal space is an author-supplied delimiter, and one
-// character appears inside too much to carry signal.
+// Composed of those scripts, not merely containing one: a Latin term with one CJK
+// character keeps boundary anchoring. Code-point iteration, so an astral ideograph
+// counts once. A space is an author-supplied delimiter; one character carries no signal.
 function usesSubstringMatch(term: string): boolean {
   const chars = [...term]
   if (chars.length < 2 || ANY_SPACE.test(term)) return false

--- a/lib/retrieval/ranker.test.ts
+++ b/lib/retrieval/ranker.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 
 import { RANKER_DEFAULTS } from './constants'
 import { rankAll, rankPerType } from './ranker'
-import type { Candidate, RetrievalType } from './types'
+import type { Candidate, InjectedRow, KeywordInjection, RetrievalType } from './types'
 
 const v = (...xs: number[]): Float32Array => {
   const n = Math.hypot(...xs)
@@ -33,6 +33,26 @@ function candidate(over: Partial<Candidate> & Pick<Candidate, 'id'>): Candidate 
   } as Candidate
 }
 
+const seatRow = (id: string): InjectedRow => ({
+  kind: 'lore',
+  id,
+  displayName: id,
+  renderedText: `text ${id}`,
+})
+
+const injection = (
+  over: Partial<KeywordInjection> & Pick<KeywordInjection, 'row'>,
+): KeywordInjection => ({
+  terms: ['t'],
+  priority: 0,
+  tokensEstimated: 10,
+  seated: true,
+  ...over,
+})
+
+const loreSeat = (id: string, over: Partial<KeywordInjection> = {}): KeywordInjection =>
+  injection({ row: seatRow(id), ...over })
+
 const emptyPools = (): Record<RetrievalType, Candidate[]> => ({
   entities: [],
   lore: [],
@@ -46,6 +66,7 @@ const emptyPools = (): Record<RetrievalType, Candidate[]> => ({
 // budget-fill semantics instead of re-encoding whatever the memory-blocks macro
 // happens to cost this month.
 const HAPPENING_COST = 10 + RANKER_DEFAULTS.typeOverhead.happenings
+const LORE_COST = 10 + RANKER_DEFAULTS.typeOverhead.lore
 
 const base = {
   params: RANKER_DEFAULTS,
@@ -663,5 +684,71 @@ describe('replay-facing trace fields', () => {
     expect(kept[0].renderedText).toBe('The bridge fell during the third night of the siege.')
     expect(dropped[0].renderedText).toBeNull()
     expect(out.pool.map((c) => c.id)).toEqual(['hap_b', 'hap_a'])
+  })
+})
+
+describe('rankPerType — keyword injection', () => {
+  it('seats injected rows ahead of every ranked one', () => {
+    const r = rankPerType([candidate({ id: 'ranked', sims: [0.9, 0.9, 0.9] })], 'lore', 1000, {
+      ...base,
+      keywordInjected: [loreSeat('seated')],
+    })
+
+    expect(r.selected.map((c) => c.id)).toEqual(['seated', 'ranked'])
+  })
+
+  it('charges the seated cost against the type budget', () => {
+    // The seat leaves one token less than the ranked row costs, so that row is
+    // dropped for budget rather than for score. Derived from LORE_COST, not
+    // written out: an expectation computed from the constant under test would
+    // pass at every overhead value including 0.
+    const spent = 100 - LORE_COST + 1
+    const r = rankPerType(
+      [candidate({ id: 'ranked', kind: 'lore', sims: [0.9, 0.9, 0.9] })],
+      'lore',
+      100,
+      { ...base, keywordInjected: [injection({ row: seatRow('seat'), tokensEstimated: spent })] },
+    )
+
+    expect(r.selected.map((c) => c.id)).toEqual(['seat'])
+    expect(r.traces[0].dropReason).toBe('over_budget')
+    expect(r.funnel.tokensUsed).toBe(spent)
+  })
+
+  it('drops a seated row from the pool so it is never seated or charged twice', () => {
+    const r = rankPerType([candidate({ id: 'dup', sims: [0.9, 0.9, 0.9] })], 'lore', 1000, {
+      ...base,
+      keywordInjected: [loreSeat('dup')],
+    })
+
+    expect(r.selected.map((c) => c.id)).toEqual(['dup'])
+    expect(r.traces).toHaveLength(0)
+    expect(r.funnel.poolSize).toBe(0)
+  })
+
+  it('leaves an overflow-cut row in the pool to compete on score', () => {
+    const r = rankPerType([candidate({ id: 'cut', sims: [0.9, 0.9, 0.9] })], 'lore', 1000, {
+      ...base,
+      keywordInjected: [loreSeat('cut', { seated: false })],
+    })
+
+    expect(r.selected.map((c) => c.id)).toEqual(['cut'])
+    expect(r.funnel.poolSize).toBe(1)
+    expect(r.traces[0].dropReason).toBe('not_dropped')
+  })
+})
+
+describe('rankAll — keyword injection routing', () => {
+  it('hands each type only its own seats', () => {
+    const out = rankAll({
+      pools: emptyPools(),
+      budgets: { entities: 1000, lore: 1000, happenings: 1000, threads: 1000, chapters: 1000 },
+      ...base,
+      keywordInjected: { lore: [loreSeat('l1')], entities: [] },
+    })
+
+    expect(out.lore.selected.map((c) => c.id)).toEqual(['l1'])
+    for (const type of ['entities', 'happenings', 'threads', 'chapters'] as const)
+      expect(out[type].selected).toEqual([])
   })
 })

--- a/lib/retrieval/ranker.test.ts
+++ b/lib/retrieval/ranker.test.ts
@@ -698,10 +698,8 @@ describe('rankPerType — keyword injection', () => {
   })
 
   it('charges the seated cost against the type budget', () => {
-    // The seat leaves one token less than the ranked row costs, so that row is
-    // dropped for budget rather than for score. Derived from LORE_COST, not
-    // written out: an expectation computed from the constant under test would
-    // pass at every overhead value including 0.
+    // Seat spend leaves the ranked row one token short, so it drops for budget, not
+    // score. Derived from LORE_COST: a hardcoded number would pass even at overhead 0.
     const spent = 100 - LORE_COST + 1
     const r = rankPerType(
       [candidate({ id: 'ranked', kind: 'lore', sims: [0.9, 0.9, 0.9] })],

--- a/lib/retrieval/ranker.ts
+++ b/lib/retrieval/ranker.ts
@@ -3,11 +3,13 @@ import type {
   Candidate,
   CandidateTrace,
   DropReason,
+  KeywordInjection,
   QueryWeights,
   RankAllInput,
   RankedType,
   RankerParams,
   RetrievalType,
+  SeatedRow,
 } from './types'
 
 export type RankTypeInput = {
@@ -24,6 +26,13 @@ export type RankTypeInput = {
    * from the map falls back to computing it.
    */
   capturedTokens?: ReadonlyMap<string, number>
+  /**
+   * This type's keyword matches (retrieval.md → Keyword injection budget).
+   * Empty under `keywordRetrieval.mode='boost'`, which is every pass until a
+   * story turns the mode on. Cut rows may be present and are ignored here —
+   * they stay in the pool and compete on score like any other candidate.
+   */
+  keywordInjected?: readonly KeywordInjection[]
 }
 
 type Scored = {
@@ -115,15 +124,24 @@ function score(
 
 type Costed = Scored & { tokensEstimated: number }
 
+/**
+ * retrieval.md → Token estimation. Exported so the keyword pre-pass prices a
+ * seat with the same formula: the same row seated down either path has to cost
+ * the same, or the budget the probe reports is not the budget that was spent.
+ */
+export function tokenCost(
+  text: string,
+  type: RetrievalType,
+  input: Pick<RankTypeInput, 'params' | 'countTokens'>,
+): number {
+  return input.countTokens(text) + input.params.typeOverhead[type]
+}
+
 // Deferred past the pre-filter: a pre-filtered row can never be seated, so its
 // count is never read (retrieval.md → Token estimation).
 function costTokens(s: Scored, type: RetrievalType, input: RankTypeInput): Costed {
   const captured = input.capturedTokens?.get(s.id)
-  return {
-    ...s,
-    tokensEstimated:
-      captured ?? input.countTokens(s.candidate.renderedText) + input.params.typeOverhead[type],
-  }
+  return { ...s, tokensEstimated: captured ?? tokenCost(s.candidate.renderedText, type, input) }
 }
 
 function trace(
@@ -172,11 +190,20 @@ function boostedEntryIdsFor(input: RankTypeInput): ReadonlySet<string> {
 }
 
 export function rankPerType(
-  pool: readonly Candidate[],
+  wholePool: readonly Candidate[],
   type: RetrievalType,
   budget: number,
   input: RankTypeInput,
 ): RankedType {
+  const seats = (input.keywordInjected ?? []).filter((i) => i.seated)
+  const seatedIds = new Set(seats.map((i) => i.row.id))
+  // A seated row is skipped when it later appears as a ranked candidate rather
+  // than seated or charged twice (retrieval.md → Keyword injection). Dropped
+  // from the pool rather than during the fill so the probe stays honest: these
+  // rows never reached the ranker, so they file as keyword injections and get no
+  // candidate record. A CUT row is deliberately left in to compete on score.
+  const pool = seatedIds.size === 0 ? wholePool : wholePool.filter((c) => !seatedIds.has(c.id))
+
   const boostedEntryIds = boostedEntryIdsFor(input)
   const scored = pool.map((c) => score(c, type, input, boostedEntryIds))
   scored.sort((a, b) => b.score - a.score)
@@ -184,9 +211,13 @@ export function rankPerType(
   const kept = scored.slice(0, input.params.preFilterTopN).map((s) => costTokens(s, type, input))
   const ranked = mmrRank(kept, input.params.lambdaDiv)
 
-  const selected: Candidate[] = []
+  const selected: SeatedRow[] = seats.map((i) => i.row)
   const traces: CandidateTrace[] = []
-  let remaining = budget
+  // Unclamped: budgetShare caps the seats at or below the budget, so a negative
+  // here means a caller supplied seats the cap could not have produced. Every
+  // ranked row is then correctly refused, and funnel.tokensUsed reports over
+  // budget rather than hiding it.
+  let remaining = budget - seats.reduce((sum, i) => sum + i.tokensEstimated, 0)
   let belowFloor = false
 
   for (let i = 0; i < ranked.length; i++) {
@@ -233,6 +264,16 @@ export function rankPerType(
 }
 
 /**
+ * Module-level rather than a closure so the `chapters` default parameter can
+ * reach it. Mirrors canon's `injected_by_type.get(type, ())`: chapters and
+ * happenings stay on `boost` unconditionally, so theirs is always empty.
+ */
+const forType = (input: RankAllInput, type: RetrievalType): RankTypeInput => ({
+  ...input,
+  keywordInjected: input.keywordInjected?.[type] ?? [],
+})
+
+/**
  * Chapters rank first, because only the chapters that win budget feed the
  * happenings boost. `runRetrieval` needs that set *before* it can build the
  * happenings pool — chapter membership decides admission, not just score — so
@@ -245,18 +286,28 @@ export function rankAll(
     input.pools.chapters,
     'chapters',
     input.budgets.chapters,
-    input,
+    forType(input, 'chapters'),
   ),
 ): Record<RetrievalType, RankedType> {
   const happenings = rankPerType(input.pools.happenings, 'happenings', input.budgets.happenings, {
-    ...input,
+    ...forType(input, 'happenings'),
     matchedChapterIds: new Set(chapters.selected.map((c) => c.id)),
   })
 
   return {
-    entities: rankPerType(input.pools.entities, 'entities', input.budgets.entities, input),
-    lore: rankPerType(input.pools.lore, 'lore', input.budgets.lore, input),
-    threads: rankPerType(input.pools.threads, 'threads', input.budgets.threads, input),
+    entities: rankPerType(
+      input.pools.entities,
+      'entities',
+      input.budgets.entities,
+      forType(input, 'entities'),
+    ),
+    lore: rankPerType(input.pools.lore, 'lore', input.budgets.lore, forType(input, 'lore')),
+    threads: rankPerType(
+      input.pools.threads,
+      'threads',
+      input.budgets.threads,
+      forType(input, 'threads'),
+    ),
     happenings,
     chapters,
   }

--- a/lib/retrieval/ranker.ts
+++ b/lib/retrieval/ranker.ts
@@ -27,10 +27,8 @@ export type RankTypeInput = {
    */
   capturedTokens?: ReadonlyMap<string, number>
   /**
-   * This type's keyword matches (retrieval.md → Keyword injection budget).
-   * Empty under `keywordRetrieval.mode='boost'`, which is every pass until a
-   * story turns the mode on. Cut rows may be present and are ignored here —
-   * they stay in the pool and compete on score like any other candidate.
+   * This type's keyword matches (retrieval.md → Keyword injection budget). Empty
+   * under `mode='boost'`; cut rows are ignored here and compete on score instead.
    */
   keywordInjected?: readonly KeywordInjection[]
 }
@@ -126,8 +124,7 @@ type Costed = Scored & { tokensEstimated: number }
 
 /**
  * retrieval.md → Token estimation. Exported so the keyword pre-pass prices a
- * seat with the same formula: the same row seated down either path has to cost
- * the same, or the budget the probe reports is not the budget that was spent.
+ * seat identically — else the probe's reported budget isn't the budget spent.
  */
 export function tokenCost(
   text: string,
@@ -197,11 +194,8 @@ export function rankPerType(
 ): RankedType {
   const seats = (input.keywordInjected ?? []).filter((i) => i.seated)
   const seatedIds = new Set(seats.map((i) => i.row.id))
-  // A seated row is skipped when it later appears as a ranked candidate rather
-  // than seated or charged twice (retrieval.md → Keyword injection). Dropped
-  // from the pool rather than during the fill so the probe stays honest: these
-  // rows never reached the ranker, so they file as keyword injections and get no
-  // candidate record. A CUT row is deliberately left in to compete on score.
+  // Seated rows leave the pool (retrieval.md → Keyword injection): never charged
+  // twice, and filed as injections with no candidate record. CUT rows stay in.
   const pool = seatedIds.size === 0 ? wholePool : wholePool.filter((c) => !seatedIds.has(c.id))
 
   const boostedEntryIds = boostedEntryIdsFor(input)
@@ -213,10 +207,8 @@ export function rankPerType(
 
   const selected: SeatedRow[] = seats.map((i) => i.row)
   const traces: CandidateTrace[] = []
-  // Unclamped: budgetShare caps the seats at or below the budget, so a negative
-  // here means a caller supplied seats the cap could not have produced. Every
-  // ranked row is then correctly refused, and funnel.tokensUsed reports over
-  // budget rather than hiding it.
+  // Unclamped: budgetShare caps seats at budget, so a negative means a caller
+  // broke the cap — rows are then refused and tokensUsed reports over budget.
   let remaining = budget - seats.reduce((sum, i) => sum + i.tokensEstimated, 0)
   let belowFloor = false
 
@@ -264,9 +256,8 @@ export function rankPerType(
 }
 
 /**
- * Module-level rather than a closure so the `chapters` default parameter can
- * reach it. Mirrors canon's `injected_by_type.get(type, ())`: chapters and
- * happenings stay on `boost` unconditionally, so theirs is always empty.
+ * Module-level so the `chapters` default parameter can reach it. Mirrors canon's
+ * `injected_by_type.get(type, ())` — chapters and happenings stay on `boost`.
  */
 const forType = (input: RankAllInput, type: RetrievalType): RankTypeInput => ({
   ...input,

--- a/lib/retrieval/rendered-text.ts
+++ b/lib/retrieval/rendered-text.ts
@@ -1,29 +1,24 @@
 import type { EntityRow, LoreRow } from './pools'
 
 /**
- * Canon frames two of the three sub-pools (retrieval.md → Three-sub-pool entity
- * model), so the model reads an active pool row as elsewhere rather than present
- * and a staged one as introducible rather than as cast. Retired has no framing,
- * hence Partial. The memory-blocks macro repeats these words for pinned rows,
- * which never reach the ranker; memory-blocks.test.ts pins the two together.
+ * retrieval.md → Three-sub-pool entity model. Retired has no framing, hence Partial.
+ * The memory-blocks macro repeats these words; memory-blocks.test.ts pins the two
+ * together.
  */
 export const ENTITY_FRAMING: Partial<Record<EntityRow['status'], string>> = {
   active: 'currently elsewhere',
   staged: 'available to introduce',
 }
 
-// A blank field must not leave its separator behind: a null description renders
-// "Mira: " to the model, which reads as a truncated line rather than an absent
-// one, and the ranker charges the budget for it either way.
+// A blank field must not leave its separator behind: "Mira: " reads to the model as
+// a truncated line, and the ranker charges the budget for it either way.
 export const lines = (...parts: (string | null)[]): string =>
   parts.filter((p) => p !== null && p !== '').join('\n')
 
 /**
  * The exact string the prompt carries for a retrieved entity, and the tokenizer's
- * input when its cost is computed. Shared rather than inlined at each call site
- * because keyword injection seats the same row down a different path
- * (retrieval.md → Keyword injection): two formulas would let one entity cost and
- * read differently depending on which path won, with nothing to fail.
+ * input when its cost is computed. Do not inline it at call sites: keyword injection
+ * seats the same row down a different path, and two formulas would diverge silently.
  */
 export function entityRenderedText(
   row: Pick<EntityRow, 'name' | 'description' | 'status'>,

--- a/lib/retrieval/rendered-text.ts
+++ b/lib/retrieval/rendered-text.ts
@@ -1,0 +1,39 @@
+import type { EntityRow, LoreRow } from './pools'
+
+/**
+ * Canon frames two of the three sub-pools (retrieval.md → Three-sub-pool entity
+ * model), so the model reads an active pool row as elsewhere rather than present
+ * and a staged one as introducible rather than as cast. Retired has no framing,
+ * hence Partial. The memory-blocks macro repeats these words for pinned rows,
+ * which never reach the ranker; memory-blocks.test.ts pins the two together.
+ */
+export const ENTITY_FRAMING: Partial<Record<EntityRow['status'], string>> = {
+  active: 'currently elsewhere',
+  staged: 'available to introduce',
+}
+
+// A blank field must not leave its separator behind: a null description renders
+// "Mira: " to the model, which reads as a truncated line rather than an absent
+// one, and the ranker charges the budget for it either way.
+export const lines = (...parts: (string | null)[]): string =>
+  parts.filter((p) => p !== null && p !== '').join('\n')
+
+/**
+ * The exact string the prompt carries for a retrieved entity, and the tokenizer's
+ * input when its cost is computed. Shared rather than inlined at each call site
+ * because keyword injection seats the same row down a different path
+ * (retrieval.md → Keyword injection): two formulas would let one entity cost and
+ * read differently depending on which path won, with nothing to fail.
+ */
+export function entityRenderedText(
+  row: Pick<EntityRow, 'name' | 'description' | 'status'>,
+): string {
+  const framing = ENTITY_FRAMING[row.status]
+  const head = framing === undefined ? row.name : `${row.name} (${framing})`
+  return row.description ? `${head}: ${row.description}` : head
+}
+
+/** Lore's counterpart to entityRenderedText, shared for the same reason. */
+export function loreRenderedText(row: Pick<LoreRow, 'title' | 'body'>): string {
+  return lines(row.title, row.body)
+}

--- a/lib/retrieval/run.test.ts
+++ b/lib/retrieval/run.test.ts
@@ -1235,7 +1235,9 @@ describe('runRetrieval — pools', () => {
         }),
         params(),
       )
-      return expectOk(out).bundles.happenings.selected.find((c) => c.id === 'hap_1')?.pinSignal
+      return expectOk(out)
+        .bundles.happenings.selected.filter(isHappeningCandidate)
+        .find((c) => c.id === 'hap_1')?.pinSignal
     }
 
     // Nothing in the schema stops a common-knowledge row from carrying awareness
@@ -1343,7 +1345,9 @@ describe('runRetrieval — pools', () => {
       { id: 'haw_a', retrievalCount: 0 },
       { id: 'haw_b', retrievalCount: 0 },
     ])
-    const selected = ok.bundles.happenings.selected.find((c) => c.id === 'hap_1')
+    const selected = ok.bundles.happenings.selected
+      .filter(isHappeningCandidate)
+      .find((c) => c.id === 'hap_1')
     // Max over the holders, not min or first-wins: the most pinned holder is
     // what keeps the row alive against decay.
     expect(selected?.pinSignal).toBe(0.7)

--- a/lib/retrieval/run.test.ts
+++ b/lib/retrieval/run.test.ts
@@ -1584,9 +1584,8 @@ describe('runRetrieval — keyword boost', () => {
     expect(boost('lore_miss')).toBe(0)
   })
 
-  // The digest is assembled from entity names, the location and thread titles —
-  // synthetic text, not something the prose said. Matching it manufactured a hit
-  // on every turn the named row was on stage.
+  // The digest is synthetic text (entity names, location, thread titles), not
+  // something the prose said — matching it manufactures a hit every turn.
   it('does not boost on a term reaching only the structural digest', async () => {
     const out = await runRetrieval(
       deps({ queryAll: twoLoreRows() }),
@@ -1597,8 +1596,7 @@ describe('runRetrieval — keyword boost', () => {
     expect(expectOk(out).bundles.lore.traces.find((t) => t.id === 'lore_hit')?.kwBoostValue).toBe(0)
   })
 
-  // Q3 selects top-K sentences, so a proper noun in a sentence the extract
-  // skipped could never fire while the haystack came from the query stack.
+  // Q3 selects top-K sentences: a proper noun in a sentence it skipped must still fire.
   it('boosts on prose Q3 left out of its extract', async () => {
     const out = await runRetrieval(
       deps({ queryAll: twoLoreRows() }),
@@ -1685,9 +1683,8 @@ describe('runRetrieval — keyword boost', () => {
     expect(await boostFor(['the innkeeper'])).toBe(0)
   })
 
-  // entities.priority orders keyword-inject overflow and nothing else. lore.priority
-  // feeding pin_signal is lore's own second effect — the branch two cases down in
-  // run.ts does exactly the thing this branch must not.
+  // entities.priority orders keyword-inject overflow and nothing else — feeding
+  // pin_signal is lore's own second effect, done by the next branch down in run.ts.
   it('leaves an entity pin_signal at zero however high its priority', async () => {
     const out = await runRetrieval(
       deps({
@@ -1745,9 +1742,8 @@ describe('runRetrieval — keyword injection', () => {
   })
 
   it('charges the seat against the type budget the ranked rows then compete for', async () => {
-    // Real prose, never a repeated character: tiktoken's byte-pair loop treats
-    // 'x'.repeat(n) as one word and costs ~620 ms (lessons-learned →
-    // Token-counting fixtures must be prose).
+    // Real prose, never 'x'.repeat(n): tiktoken's byte-pair loop treats it as one word
+    // and costs ~620 ms (lessons-learned → Token-counting fixtures must be prose).
     const seatBody = 'The engine drowned under the tide and has hummed there since.'
     const rankedBody = `${seatBody} Its keepers left no ledger, no name, and no way back up.`
     // Budget priced off the fixture rather than guessed: the seat must fit in

--- a/lib/retrieval/run.test.ts
+++ b/lib/retrieval/run.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import type { EmbeddedFieldRow } from '@/lib/db'
 import { EmbedderCallError, EmbedderCancelledError, EmbedderInitError } from '@/lib/embedder'
 
-import { KNN_K } from './constants'
+import { KNN_K, RANKER_DEFAULTS } from './constants'
 import {
   runRetrieval,
   type RetrievalDeps,
@@ -11,6 +11,7 @@ import {
   type RetrievalParams,
   type RetrievalSuccess,
 } from './run'
+import { countTokens } from './tokens'
 import { isHappeningCandidate, type QueryAll } from './types'
 
 const DIM = 2
@@ -214,6 +215,7 @@ const BASE: RetrievalParams = {
   currentLocationId: null,
   recentProse: '',
   scanText: 'I ask about the amulet.\nKara Vex drew the blade.',
+  keywordRetrieval: { mode: 'boost', budgetShare: 0.5, cascade: false, cascadeMaxDepth: 2 },
 }
 
 const params = (
@@ -349,7 +351,7 @@ describe('runRetrieval — sync ordering', () => {
   it('carries no partial state when the sync stage fails', async () => {
     const { partial } = await withSyncFailure()
 
-    expect(partial).toEqual({ queries: null, floor: null, bundles: {} })
+    expect(partial).toEqual({ queries: null, floor: null, bundles: {}, keywordInjections: [] })
   })
 
   it('reads the source rows AFTER the sync commits, not before', async () => {
@@ -1697,5 +1699,118 @@ describe('runRetrieval — keyword boost', () => {
       params({ sceneEntityIds: [], sceneCharacterIds: [] }),
     )
     expect(expectOk(out).bundles.entities.traces.find((t) => t.id === 'char_a')?.pinSignal).toBe(0)
+  })
+})
+
+describe('runRetrieval — keyword injection', () => {
+  const injecting = {
+    mode: 'inject' as const,
+    budgetShare: 0.5,
+    cascade: false,
+    cascadeMaxDepth: 2,
+  }
+
+  it('seats a lore row the KNN never returned', async () => {
+    const queryAll = makeQueryAll({
+      lore: [loreRow('lore_far', 'The Aetherium', { keywords: ['aetherium'] })],
+      knn: [],
+    })
+
+    const out = expectOk(
+      await runRetrieval(
+        deps({ queryAll }),
+        params({ keywordRetrieval: injecting, scanText: 'The aetherium hums below.' }),
+      ),
+    )
+
+    expect(out.bundles.lore.selected.map((c) => c.id)).toEqual(['lore_far'])
+    // It never reached the ranker, so it files as a keyword injection and NOT as
+    // a candidate — no invented sim_blend or final_score.
+    expect(out.bundles.lore.traces).toEqual([])
+    expect(out.keywordInjections.map((i) => i.row.id)).toEqual(['lore_far'])
+  })
+
+  it('seats nothing under the default boost mode', async () => {
+    const queryAll = makeQueryAll({
+      lore: [loreRow('lore_far', 'The Aetherium', { keywords: ['aetherium'] })],
+      knn: [],
+    })
+
+    const out = expectOk(
+      await runRetrieval(deps({ queryAll }), params({ scanText: 'The aetherium hums below.' })),
+    )
+
+    expect(out.bundles.lore.selected).toEqual([])
+    expect(out.keywordInjections).toEqual([])
+  })
+
+  it('charges the seat against the type budget the ranked rows then compete for', async () => {
+    // Real prose, never a repeated character: tiktoken's byte-pair loop treats
+    // 'x'.repeat(n) as one word and costs ~620 ms (lessons-learned →
+    // Token-counting fixtures must be prose).
+    const seatBody = 'The engine drowned under the tide and has hummed there since.'
+    const rankedBody = `${seatBody} Its keepers left no ledger, no name, and no way back up.`
+    // Budget priced off the fixture rather than guessed: the seat must fit in
+    // budgetShare (half), and the larger ranked row must not fit in what is left.
+    const loreBudget = 2 * (countTokens(`Seat\n${seatBody}`) + RANKER_DEFAULTS.typeOverhead.lore)
+    const queryAll = makeQueryAll({
+      lore: [
+        loreRow('lore_seat', 'Seat', { keywords: ['aetherium'], body: seatBody }),
+        loreRow('lore_ranked', 'Ranked', { body: rankedBody }),
+      ],
+      knn: [hit('lore_ranked')],
+    })
+
+    const out = expectOk(
+      await runRetrieval(
+        deps({ queryAll }),
+        params({
+          keywordRetrieval: injecting,
+          budgets: { ...BASE.budgets, lore: loreBudget },
+          scanText: 'The aetherium hums below.',
+        }),
+      ),
+    )
+
+    expect(out.bundles.lore.selected.map((c) => c.id)).toEqual(['lore_seat'])
+    expect(out.bundles.lore.traces[0].dropReason).toBe('over_budget')
+  })
+
+  it('does not seat an entity the structural floor already holds', async () => {
+    const queryAll = makeQueryAll({
+      entities: [entityRow('char_a', 'Kael', { keywords: ['the ferryman'] })],
+      knn: [],
+    })
+
+    const out = expectOk(
+      await runRetrieval(
+        deps({ queryAll }),
+        params({ keywordRetrieval: injecting, scanText: 'You pay the ferryman.' }),
+      ),
+    )
+
+    // char_a is BASE.sceneEntityIds, so the floor seated it before the pre-pass.
+    expect(out.keywordInjections).toEqual([])
+  })
+
+  it('reports an injected location through selectedLocationIds', async () => {
+    const queryAll = makeQueryAll({
+      entities: [entityRow('loc_1', 'The Hollow', { kind: 'location' })],
+      knn: [],
+    })
+
+    const out = expectOk(
+      await runRetrieval(
+        deps({ queryAll }),
+        params({
+          keywordRetrieval: injecting,
+          sceneEntityIds: [],
+          sceneCharacterIds: [],
+          scanText: 'Rain over The Hollow.',
+        }),
+      ),
+    )
+
+    expect(out.selectedLocationIds).toEqual(['loc_1'])
   })
 })

--- a/lib/retrieval/run.ts
+++ b/lib/retrieval/run.ts
@@ -23,7 +23,6 @@ import {
   filterLorePool,
   filterThreadPool,
   poolIdsFromKnn,
-  type EntityRow,
   type KnnHit,
   type StructuralFloor,
 } from './pools'
@@ -34,6 +33,7 @@ import {
   type QueryStackInput,
 } from './queries'
 import { rankAll, rankPerType } from './ranker'
+import { entityRenderedText, lines, loreRenderedText } from './rendered-text'
 import {
   countStaleHappenings,
   loadChapterRanges,
@@ -629,24 +629,6 @@ function decodeVector(blob: unknown): Float32Array {
 
 const fresh = <T extends Stale>(rows: readonly T[]): T[] => rows.filter((r) => !r.embeddingStale)
 
-/**
- * Canon frames two of the three sub-pools (retrieval.md → Three-sub-pool entity
- * model), so the model reads an active pool row as elsewhere rather than present
- * and a staged one as introducible rather than as cast. Retired has no framing,
- * hence Partial. The memory-blocks macro repeats these words for pinned rows,
- * which never reach the ranker; memory-blocks.test.ts pins the two together.
- */
-export const ENTITY_FRAMING: Partial<Record<EntityRow['status'], string>> = {
-  active: 'currently elsewhere',
-  staged: 'available to introduce',
-}
-
-// A blank field must not leave its separator behind: a null description renders
-// "Mira: " to the model, which reads as a truncated line rather than an absent
-// one, and the ranker charges the budget for it either way.
-const lines = (...parts: (string | null)[]): string =>
-  parts.filter((p) => p !== null && p !== '').join('\n')
-
 /** The one place KNN ids, vectors, source rows and pool predicates meet. */
 function assembleCandidates(
   ctx: PoolCtx,
@@ -703,14 +685,12 @@ function assembleCandidates(
       })
       return inPool(pool).map((r) => {
         const vector = vectorFor(r.id)
-        const framing = ENTITY_FRAMING[r.status]
-        const head = framing === undefined ? r.name : `${r.name} (${framing})`
         return {
           ...shared(),
           kind: 'entity' as const,
           id: r.id,
           displayName: r.name,
-          renderedText: r.description ? `${head}: ${r.description}` : head,
+          renderedText: entityRenderedText(r),
           sims: simsFor(vector),
           vector,
           pinSignal: 0,
@@ -728,7 +708,7 @@ function assembleCandidates(
           kind: 'lore' as const,
           id: r.id,
           displayName: r.title,
-          renderedText: lines(r.title, r.body),
+          renderedText: loreRenderedText(r),
           sims: simsFor(vector),
           vector,
           pinSignal: r.priority / 100,

--- a/lib/retrieval/run.ts
+++ b/lib/retrieval/run.ts
@@ -88,16 +88,13 @@ export type RetrievalParams = {
   /** Un-classified buffer prose, for Layer-A suppression. */
   recentProse: string
   /**
-   * The keyword haystack: this turn's action plus the trailing entries
-   * (retrieval.md → Keyword scan surface). Independent of `query` by design —
-   * see buildScanText.
+   * The keyword haystack (retrieval.md → Keyword scan surface). Independent of
+   * `query` by design — see buildScanText.
    */
   scanText: string
   /**
-   * The second axis beside `injection_mode` (retrieval.md → Keyword injection).
-   * The whole block rather than just `mode`: the cap, the cascade depth and the
-   * mode are read together in one pre-pass, and splitting them across params
-   * invites a caller passing a mode without its budget.
+   * retrieval.md → Keyword injection. The whole block, not just `mode`: cap,
+   * depth and mode are read together, so splitting invites a mode with no budget.
    */
   keywordRetrieval: KeywordRetrievalSettings
 }
@@ -122,12 +119,8 @@ export type RetrievalTimings = {
    */
   knnMs: number
   /**
-   * The keyword-injection pre-pass, then scoring and the sort over the whole
-   * pool, then MMR and the token estimate over the rows that survive the
-   * pre-filter — one span, because tokenization runs inside the same kept-row
-   * map that feeds MMR and splitting it would break the disjoint-sub-span
-   * contract above. The pre-pass tokenizes too, hence its place here rather than
-   * in the unattributed remainder.
+   * Keyword pre-pass, scoring, sort, MMR and token estimate — one span:
+   * tokenization runs inside MMR's kept-row map (disjoint sub-spans above).
    */
   rankMs: number
 }
@@ -161,9 +154,8 @@ export type RetrievalPartial = {
   floor: StructuralFloor | null
   bundles: Partial<Record<RetrievalType, RankedType>>
   /**
-   * Every keyword match this pass made, seated or cut — the probe's
-   * `keyword_injections` (probe.md → Keyword injections). Empty under
-   * `mode='boost'`, and on a pass that failed before ranking started.
+   * Every keyword match, seated or cut (probe.md → Keyword injections). Empty
+   * under `mode='boost'`, and on a pass that failed before ranking started.
    */
   keywordInjections: readonly KeywordInjection[]
 }
@@ -175,9 +167,8 @@ export type RetrievalOutcome =
       bundles: Record<RetrievalType, RankedType>
       queries: QueryStack
       /**
-       * Every keyword match this pass made, seated or cut — the probe's
-       * `keyword_injections` (probe.md → Keyword injections). Empty under
-       * `keywordRetrieval.mode='boost'`.
+       * Every keyword match, seated or cut (probe.md → Keyword injections).
+       * Empty under `keywordRetrieval.mode='boost'`.
        */
       keywordInjections: readonly KeywordInjection[]
       /**
@@ -381,10 +372,8 @@ async function runRetrievalPass(
   }
 
   let rankStartedAt = performance.now()
-  // Ahead of every rankPerType call and inside the rank span: it prices rows with
-  // the same tokenizer the ranker uses, so outside it that cost would vanish into
-  // the unattributed remainder. It needs no vectors, only source rows and the
-  // floor — which is why a keyword hit can seat a row the KNN never returned.
+  // Ahead of every rankPerType call, inside the rank span (see RetrievalTimings).
+  // Needs no vectors — which is why a keyword hit can seat a row the KNN missed.
   const injections = buildKeywordInjections({
     settings: params.keywordRetrieval,
     entities: sourceRows.entities,
@@ -697,10 +686,8 @@ function assembleCandidates(
     sim(vector, queryVectors[2]),
   ]
 
-  // kw = keyword_boost(c, scan_text) (retrieval.md → Pseudocode) runs the
-  // candidate's own keyword surface against the scan text, NOT `queries`. The
-  // other direction — a candidate against the name index — is degenerate, since
-  // every row's own terms are in that index by construction.
+  // kw = keyword_boost(c, scan_text) (retrieval.md → Pseudocode): candidate surface
+  // vs scan text, NOT `queries` — the reverse matches every row's own indexed terms.
   const kwHits = (surface: readonly string[]): string[] =>
     matchTerms(ctx.scanText, surface.map(normalizeTerm))
 

--- a/lib/retrieval/run.ts
+++ b/lib/retrieval/run.ts
@@ -11,6 +11,7 @@ import { EmbedderCancelledError, type EmbedderErrorKind } from '@/lib/embedder'
 
 import { loadAwarenessForScene, type AwarenessRow } from './awareness'
 import { KNN_K, RANKER_DEFAULTS } from './constants'
+import { buildKeywordInjections, type KeywordRetrievalSettings } from './injection'
 import {
   matchTerms,
   nameKeywordIndexFrom,
@@ -48,8 +49,10 @@ import { classifyEmbedderFailure, runSyncStage, type SyncStageDeps } from './syn
 import { countTokens } from './tokens'
 import {
   isHappeningCandidate,
+  RETRIEVAL_TYPES,
   TYPE_OF_KIND,
   type Candidate,
+  type KeywordInjection,
   type QueryAll,
   type RankedType,
   type RetrievalType,
@@ -90,6 +93,13 @@ export type RetrievalParams = {
    * see buildScanText.
    */
   scanText: string
+  /**
+   * The second axis beside `injection_mode` (retrieval.md → Keyword injection).
+   * The whole block rather than just `mode`: the cap, the cascade depth and the
+   * mode are read together in one pre-pass, and splitting them across params
+   * invites a caller passing a mode without its budget.
+   */
+  keywordRetrieval: KeywordRetrievalSettings
 }
 
 /**
@@ -112,10 +122,12 @@ export type RetrievalTimings = {
    */
   knnMs: number
   /**
-   * Scoring and the sort over the whole pool, then MMR and the token estimate
-   * over the rows that survive the pre-filter — one span, because tokenization
-   * runs inside the same kept-row map that feeds MMR and splitting it would
-   * break the disjoint-sub-span contract above.
+   * The keyword-injection pre-pass, then scoring and the sort over the whole
+   * pool, then MMR and the token estimate over the rows that survive the
+   * pre-filter — one span, because tokenization runs inside the same kept-row
+   * map that feeds MMR and splitting it would break the disjoint-sub-span
+   * contract above. The pre-pass tokenizes too, hence its place here rather than
+   * in the unattributed remainder.
    */
   rankMs: number
 }
@@ -148,6 +160,12 @@ export type RetrievalPartial = {
   queries: QueryStack | null
   floor: StructuralFloor | null
   bundles: Partial<Record<RetrievalType, RankedType>>
+  /**
+   * Every keyword match this pass made, seated or cut — the probe's
+   * `keyword_injections` (probe.md → Keyword injections). Empty under
+   * `mode='boost'`, and on a pass that failed before ranking started.
+   */
+  keywordInjections: readonly KeywordInjection[]
 }
 
 export type RetrievalOutcome =
@@ -156,6 +174,12 @@ export type RetrievalOutcome =
       floor: StructuralFloor
       bundles: Record<RetrievalType, RankedType>
       queries: QueryStack
+      /**
+       * Every keyword match this pass made, seated or cut — the probe's
+       * `keyword_injections` (probe.md → Keyword injections). Empty under
+       * `keywordRetrieval.mode='boost'`.
+       */
+      keywordInjections: readonly KeywordInjection[]
       /**
        * A tripwire, not a report. The sync stage is blocking and clears the flag
        * on every row it embeds, so each count here is structurally 0 — a
@@ -216,7 +240,12 @@ export async function runRetrieval(
 ): Promise<RetrievalOutcome> {
   // Threaded rather than returned: the catch below reports progress from a throw at
   // any depth of the pass, which no return value can reach.
-  const partial: RetrievalPartial = { queries: null, floor: null, bundles: {} }
+  const partial: RetrievalPartial = {
+    queries: null,
+    floor: null,
+    bundles: {},
+    keywordInjections: [],
+  }
   try {
     return await runRetrievalPass(deps, params, partial)
   } catch (error) {
@@ -352,7 +381,26 @@ async function runRetrievalPass(
   }
 
   let rankStartedAt = performance.now()
-  const chapters = rankPerType(pools.chapters, 'chapters', params.budgets.chapters, rankTypeInput)
+  // Ahead of every rankPerType call and inside the rank span: it prices rows with
+  // the same tokenizer the ranker uses, so outside it that cost would vanish into
+  // the unattributed remainder. It needs no vectors, only source rows and the
+  // floor — which is why a keyword hit can seat a row the KNN never returned.
+  const injections = buildKeywordInjections({
+    settings: params.keywordRetrieval,
+    entities: sourceRows.entities,
+    lore: sourceRows.lore,
+    floorIds: floor.seatedIds,
+    recentProse: params.recentProse,
+    scanText: params.scanText,
+    budgets: params.budgets,
+    params: RANKER_DEFAULTS,
+    countTokens,
+  })
+  partial.keywordInjections = RETRIEVAL_TYPES.flatMap((type) => injections[type])
+  const chapters = rankPerType(pools.chapters, 'chapters', params.budgets.chapters, {
+    ...rankTypeInput,
+    keywordInjected: injections.chapters,
+  })
   let rankMs = performance.now() - rankStartedAt
   partial.bundles.chapters = chapters
 
@@ -381,6 +429,7 @@ async function runRetrievalPass(
     {
       pools,
       budgets: params.budgets,
+      keywordInjected: injections,
       ...rankTypeInput,
     },
     chapters,
@@ -400,6 +449,7 @@ async function runRetrievalPass(
     floor,
     bundles,
     queries,
+    keywordInjections: partial.keywordInjections,
     staleCounts: staleCountsOf(sourceRows, happeningsStale),
     injectedAwareness: bundles.happenings.selected
       .filter(isHappeningCandidate)

--- a/lib/retrieval/scan-surface.test.ts
+++ b/lib/retrieval/scan-surface.test.ts
@@ -69,14 +69,12 @@ describe('buildScanText', () => {
     expect(buildScanText({ userAction: 'I wait', trailing: [] })).toBe('I wait')
   })
 
-  // An empty haystack matches nothing, which is the honest answer for a turn
-  // with no prose — not a surface that reads present and scores zero.
+  // An empty haystack matches nothing — the honest answer for a turn with no prose.
   it('is empty when there is no action and no trailing prose', () => {
     expect(buildScanText({ userAction: '   ', trailing: [row('')] })).toBe('')
   })
 
-  // promptProse, not raw content: a keyword has to match what the model read,
-  // and a tagged trailing block is not part of that.
+  // promptProse, not raw content: a keyword must match what the model actually read.
   it('strips the piggyback block from a narrative entry', () => {
     const text = buildScanText({
       userAction: '',
@@ -113,8 +111,7 @@ describe('readScanEntries', () => {
     expect(await readScanEntries(db, 'br_1', 3)).toEqual([])
   })
 
-  // A failure notice carries no narrative prose, and scanning it would let a
-  // system message decide what lore gets seated.
+  // Scanning a system notice would let a failure message decide what lore gets seated.
   it('excludes system entries', async () => {
     const db = await seed([entry(1), entry(2, 'system'), entry(3, 'user_action')])
     expect(ids(await readScanEntries(db, 'br_1', 2))).toEqual(['e1'])
@@ -135,9 +132,8 @@ describe('readScanEntries', () => {
     expect(ids(await readScanEntries(db, 'br_1', 5))).toEqual(['e1'])
   })
 
-  // storySettingsSchema declares .int().min(1), so these harden against a blob
-  // that never went through it rather than pinning reachable values — the same
-  // hardening readPromptBuffer's toCount carries.
+  // storySettingsSchema declares .int().min(1): these harden against a blob that
+  // skipped it, not reachable values — as readPromptBuffer's toCount does.
   it.each([0, -3, 1.7, Number.NaN, undefined])(
     'floors an unvalidated scanEntries of %s at one trailing entry',
     async (take) => {

--- a/lib/retrieval/scan-surface.ts
+++ b/lib/retrieval/scan-surface.ts
@@ -5,9 +5,8 @@ import { promptProse } from '@/lib/piggyback'
 
 import { warnOnDuplicatePositions } from './buffer'
 
-// Hardening against settings that never went through storySettingsSchema, the
-// same threat readPromptBuffer's toCount covers: a fractional or NaN limit
-// reaches SQLite raw. One trailing entry is the floor the surface is defined on.
+// Hardens against settings that skipped storySettingsSchema, as readPromptBuffer's
+// toCount does: a fractional or NaN limit reaches SQLite raw. Floor of one entry.
 function toTake(value: number): number {
   return Number.isFinite(value) ? Math.max(1, Math.floor(value)) : 1
 }
@@ -20,11 +19,9 @@ export type ScanSurfaceInput = {
 }
 
 /**
- * The haystack the keyword pathway matches against, deliberately independent of
- * the query stack so the lexical complement does not inherit the dense
- * pathway's inputs (docs/memory/retrieval.md → Keyword scan surface).
- *
+ * The keyword pathway's haystack — independent of the query stack, and built from
  * `promptProse` so a keyword matches what the model was actually shown.
+ * docs/memory/retrieval.md → Keyword scan surface.
  */
 export function buildScanText(input: ScanSurfaceInput): string {
   return [input.userAction.trim(), ...input.trailing.map((e) => promptProse(e))]
@@ -35,11 +32,8 @@ export function buildScanText(input: ScanSurfaceInput): string {
 /**
  * The last `take` entries standing before this turn's action, oldest first.
  *
- * Its own read rather than a slice of `readPromptBuffer`: the scan surface is
- * defined independently of the prompt window, whose depth `protectedBuffer` and
- * `partialChapterBuffer` govern — with `protectedBuffer` at 0 that window can be
- * shorter than `scanEntries`, which would scan less than configured and report
- * nothing.
+ * Its own read, not a slice of `readPromptBuffer`: with `protectedBuffer` at 0 the
+ * prompt window can be shorter than `scanEntries` and silently scan less than asked.
  */
 export async function readScanEntries(
   db: DbCtx['db'],

--- a/lib/retrieval/types.ts
+++ b/lib/retrieval/types.ts
@@ -70,7 +70,42 @@ export type SimpleCandidate = CandidateBase & { kind: Exclude<CandidateKind, 'ha
 /** One row that reached a type's ranker pool. */
 export type Candidate = HappeningCandidate | SimpleCandidate
 
-export const isHappeningCandidate = (c: Candidate): c is HappeningCandidate =>
+/**
+ * A row a keyword hit seated directly (retrieval.md → Keyword injection). It
+ * never reached the ranker, so it carries no vector, no sims and no score —
+ * hence a peer of Candidate in `selected` rather than a Candidate with holes.
+ * `kind` excludes the three types canon keeps on `boost` unconditionally, which
+ * is what keeps a `kind === 'happening'` narrow over the union provable.
+ */
+export type InjectedRow = {
+  kind: 'entity' | 'lore'
+  id: string
+  displayName: string
+  renderedText: string
+}
+
+/** Anything a type's budget paid for this turn, however it earned the seat. */
+export type SeatedRow = Candidate | InjectedRow
+
+/**
+ * One keyword match, seated or cut. camelCase here; lib/probe maps it to the
+ * snake_case CaptureKeywordInjection. Cut rows travel too — the probe records
+ * them so the overflow order stays inspectable, and the ranker reads `seated`
+ * rather than being handed a pre-filtered list, so one list serves both.
+ */
+export type KeywordInjection = {
+  row: InjectedRow
+  /** The normalized terms that fired, for the probe. */
+  terms: readonly string[]
+  /** Overflow ordering key: entities.priority / lore.priority. */
+  priority: number
+  /** Same formula the ranker costs a candidate with (retrieval.md → Token estimation). */
+  tokensEstimated: number
+  /** False when the row matched but the budget cap cut it. */
+  seated: boolean
+}
+
+export const isHappeningCandidate = (c: SeatedRow): c is HappeningCandidate =>
   c.kind === 'happening'
 
 export type { DropReason }
@@ -126,7 +161,14 @@ export type PoolFunnel = {
 }
 
 export type RankedType = {
-  selected: readonly Candidate[]
+  /**
+   * Injected rows first, then the ranked fill — canon's `selected =
+   * list(keyword_injected)` (retrieval.md → Budget-fill termination). Widened
+   * past Candidate because a keyword seat carries no vector; a second field
+   * would leave every consumer responsible for merging, and forgetting would
+   * drop a row that has already spent the budget.
+   */
+  selected: readonly SeatedRow[]
   traces: readonly CandidateTrace[]
   funnel: PoolFunnel
   /**
@@ -170,4 +212,11 @@ export type RankAllInput = {
   chapterRanges: ReadonlyMap<string, ReadonlySet<string>>
   /** Injected so the ranker stays pure — tokens.ts is the production impl. */
   countTokens: (text: string) => number
+  /**
+   * Per-type seat lists (retrieval.md → `rank_all`'s `injected_by_type`). Named
+   * identically to RankTypeInput's array on purpose: the two are mutually
+   * unassignable, so rankAll cannot pass `input` straight through to rankPerType
+   * and every call site has to name the type whose seats it means.
+   */
+  keywordInjected?: Partial<Record<RetrievalType, readonly KeywordInjection[]>>
 }

--- a/lib/retrieval/types.ts
+++ b/lib/retrieval/types.ts
@@ -71,11 +71,9 @@ export type SimpleCandidate = CandidateBase & { kind: Exclude<CandidateKind, 'ha
 export type Candidate = HappeningCandidate | SimpleCandidate
 
 /**
- * A row a keyword hit seated directly (retrieval.md → Keyword injection). It
- * never reached the ranker, so it carries no vector, no sims and no score —
- * hence a peer of Candidate in `selected` rather than a Candidate with holes.
- * `kind` excludes the three types canon keeps on `boost` unconditionally, which
- * is what keeps a `kind === 'happening'` narrow over the union provable.
+ * A row a keyword hit seated directly (retrieval.md → Keyword injection). No vector,
+ * sims or score — a peer of Candidate in `selected`, not a Candidate with holes.
+ * `kind` excludes the boost-only types, keeping a `kind === 'happening'` narrow provable.
  */
 export type InjectedRow = {
   kind: 'entity' | 'lore'
@@ -89,9 +87,8 @@ export type SeatedRow = Candidate | InjectedRow
 
 /**
  * One keyword match, seated or cut. camelCase here; lib/probe maps it to the
- * snake_case CaptureKeywordInjection. Cut rows travel too — the probe records
- * them so the overflow order stays inspectable, and the ranker reads `seated`
- * rather than being handed a pre-filtered list, so one list serves both.
+ * snake_case CaptureKeywordInjection. Cut rows travel too, so the probe can show the
+ * overflow order and the ranker filters on `seated` itself.
  */
 export type KeywordInjection = {
   row: InjectedRow
@@ -162,11 +159,9 @@ export type PoolFunnel = {
 
 export type RankedType = {
   /**
-   * Injected rows first, then the ranked fill — canon's `selected =
-   * list(keyword_injected)` (retrieval.md → Budget-fill termination). Widened
-   * past Candidate because a keyword seat carries no vector; a second field
-   * would leave every consumer responsible for merging, and forgetting would
-   * drop a row that has already spent the budget.
+   * Injected rows first, then the ranked fill (retrieval.md → Budget-fill
+   * termination). Widened past Candidate rather than split in two: a consumer that
+   * forgot to merge would drop a row that already spent the budget.
    */
   selected: readonly SeatedRow[]
   traces: readonly CandidateTrace[]
@@ -213,10 +208,9 @@ export type RankAllInput = {
   /** Injected so the ranker stays pure — tokens.ts is the production impl. */
   countTokens: (text: string) => number
   /**
-   * Per-type seat lists (retrieval.md → `rank_all`'s `injected_by_type`). Named
-   * identically to RankTypeInput's array on purpose: the two are mutually
-   * unassignable, so rankAll cannot pass `input` straight through to rankPerType
-   * and every call site has to name the type whose seats it means.
+   * Per-type seat lists (retrieval.md → `rank_all`'s `injected_by_type`). Shares
+   * RankTypeInput's field name on purpose: the two are mutually unassignable, so
+   * rankAll cannot pass `input` straight through to rankPerType.
    */
   keywordInjected?: Partial<Record<RetrievalType, readonly KeywordInjection[]>>
 }


### PR DESCRIPTION
Third and final PR of the stacked keyword-retrieval work (2026-09-06 design, `f3f1016d`).

| PR | Owns | Base |
| --- | --- | --- |
| [#485](https://github.com/AventurasTeam/Aventuras/pull/485) | Scan surface, `keywordRetrieval` settings, CJK match rule | `main` |
| [#486](https://github.com/AventurasTeam/Aventuras/pull/486) | `entities.keywords` + `entities.priority` and its readers | #485 |
| **this** | `mode: 'inject'` — seating, budget share, cascade, probe | #486 |

Based on #486, so the diff below is only this PR's own work.

## What changed

Under `keywordRetrieval.mode='inject'`, a keyword hit on lore or an entity seats that row directly ahead of the ranker instead of adding `kw_boost` to a ranked score. Default is still `boost`; on that path the pre-pass short-circuits before touching the tokenizer, and every pre-existing assertion in the suite holds unchanged.

- **`lib/retrieval/injection.ts`** (new) — matches the scan surface against lore and entity keyword sets, runs the same pool filters the ranker does, orders overflow by `priority`, caps each type at `budgetShare × type_budget`, and cascades to `cascadeMaxDepth`.
- **`lib/retrieval/ranker.ts`** — `rankPerType` drops seated ids from its pool, starts `selected` with them, and deducts their cost from `remaining`. That is canon's `selected = list(keyword_injected)` literally.
- **`lib/retrieval/rendered-text.ts`** (new) — the entity and lore rendered-text formulas, shared so a row seated down either path costs and reads identically.
- **Probe** — `keyword_injections` on the capture, `CAPTURE_VERSION` 4 → 5.

## Four decisions worth arguing with

**`RankedType.selected` widens to `(Candidate | InjectedRow)[]`.** A keyword seat never entered the KNN pool, so it has no vector and no sims and cannot be a `Candidate` without holes. The alternative — a second field consumers merge — fails silently: forget the merge and a row that already spent budget never reaches the prompt. `InjectedRow['kind']` excludes `'happening'`, so the existing `kind === 'happening'` narrows stay provable rather than assumed.

**`kw_boost` still applies in the ranked path under `inject`.** Canon's `rank_per_type` computes `kw` unconditionally and takes `keyword_injected` as a separate parameter; there is no mode branch in the scoring function. Since seated rows leave the pool, the boost lands exactly on the rows the cap cut — which is right independently: an overflow row is still lexically relevant.

**The pre-pass does not filter `embedding_stale`, though the ranked pools do.** `fresh()` gates vector validity and this path reads no vector; canon's wording is "the same **status** and **pool-exclusion** rules". Moot in practice — the blocking sync empties the set before the pre-pass runs.

**Overflow ties break on a normalized display name, then the id — not `localeCompare`.** The host locale would make *which rows seat* device-dependent, and `sensitivity: 'base'` is not a total order: two rows differing only in case would tie and fall through to SQLite's unordered read. There is a test with a mutant behind the id fallback specifically.

## Two things the gates did not catch

**A non-finite type budget uncapped injection entirely.** The cap is a `>` comparison, so `used + cost > NaN` is false for every row — the whole match set seats with no cap, which is the unbounded-lorebook failure `budgetShare` exists to prevent. Every other reader of a bad budget in this repo seats *nothing*; this one seated *everything*. Found by the adversarial pass with a scratch repro, fixed in `e8684455`, and now covered for `NaN`, `Infinity` and negatives.

**Canon's pseudocode contradicted canon's prose.** `rank_per_type` scored `for c in candidates` and appended without excluding seated rows, so the sketch would seat a keyword row twice — while the prose says a seated row "is skipped when it later appears as a ranked candidate rather than seated or charged twice". Repaired the sketch against the prose in `45de5a42`, the same move #485 made for the `rank_all` signature. No spec change.

## Verification

`typecheck`, `lint`, `lint:docs`, `prettier --check`, `db:check`, `db:check:format` all clean. Full suite **445 files / 4681 tests** green. No migration in this branch.

**Mutation record: 16 mutants, 16 killed.** One survived a first pass — the floor-exclusion test covered entities but not lore — and the gap is now closed. Mutants cover the cascade depth bound, the visited set over cut rows, the seated-only frontier, the `cascade` flag, the id tiebreak, the cap's `continue`, `budgetShare`, both keyword surfaces, Layer-A suppression, floor exclusion, the replay reservation, the payload mapping, the shape guard, and the budget guard.

**Smoke ran against real seeded data**, not the app: the desktop shell needs a configured provider, so instead the pre-pass ran over `pnpm db:seed` output through the real `loadSourceRows`. On the hero branch's own trailing prose —

- prose says *"Watchmen move in pairs tonight"* → **The City Watch** seats at depth 1 on its keyword `watchmen`. Its *name* never appears in the prose, so this is #486's `entities.keywords` doing the work it was added for.
- that row's own text — *"quietly at war with the Syndicate"* → the **Syndicate lore row** seats at depth 2 via cascade, cross-type. With `cascade: false` it does not seat.
- `mode: 'boost'` seats nothing.

The in-app smoke (Electron, a real turn, a deep capture viewed as JSON) was **not** run.

## Known limits

- `keywordRetrieval.mode` has no editor until M4.4; flipping it needs `json_set` on `stories.settings`. Already filed in `roadmap.md`.
- `CAPTURE_VERSION` 5 retires every stored capture into the `corrupt` lane. Correct per "there is one capture format", but existing dev captures are gone.
- The pre-pass tokenizes cut rows as well as seated ones. Not waste — `probe.md` requires `tokens_estimated` on a cut row so the overflow order is inspectable.
- Injection cost is unmeasured by `bench/`, which runs the default `boost` path and so short-circuits.

## Comment audit

The audit deferred from #485 and #486 ran here over `main...HEAD`, so **it also rewrites comments in those two PRs' files** — both will need a rebase, and their reviewers won't see this churn.

151 blocks across 39 files: **90 compressed** (6 of them pruned first), **61 kept**, **0 deleted**, 0 flagged. Touched comment volume went 289 lines → 162. Nothing was deleted because nothing needed to be — the blocks carried real *why*, inflated past the two-line ceiling, which is the failure mode the skill exists for. Hazards, magic-number provenance and "do not do X" directives were compressed in place.

Verified comment-only: the non-comment diff filter printed nothing across all 31 files, and `format:check`, `lint`, `typecheck` and the full suite all pass on the result.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyword-based retrieval injections for matching entities and lore.
  * Added configurable retrieval modes, budget sharing, cascade depth, and scan settings.
  * Matching results can be prioritized and seated while respecting retrieval budgets.
  * Capture and replay now preserve keyword injection details for consistent results.
* **Improvements**
  * Improved rendered text for entities and lore during retrieval.
  * Added clearer validation and handling for keyword retrieval data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->