### PR TITLE
Deal with frequent Android freezes

### DIFF
--- a/src/lib/components/layout/AppShell.svelte
+++ b/src/lib/components/layout/AppShell.svelte
@@ -185,16 +185,9 @@
    * The single owner of orphaned-scroll-lock recovery, for the whole app. Two triggers, one
    * release: see `$lib/utils/scrollLock`.
    *
-   * The observer alone cannot be enough. It fires on writes to `body.style`, and an orphaned
-   * lock is precisely the case where nothing writes there again — it gets one look, at the
-   * moment the overlay is still legitimately open, and is never called back.
-   *
-   * Input is the trigger that cannot miss: a real event reaching the document while the body
-   * is locked and no owner is present means the lock is orphaned, whatever left it behind. A
-   * locked page still delivers these — `pointer-events: none` on `<body>` takes `<body>` and
-   * its subtree out of hit testing, but `<html>` keeps `auto`, so the event targets
-   * `documentElement` and still reaches a capture listener here. Hence document level, and
-   * hence not delegated from anywhere inside the app tree.
+   * The observer fires on writes to `body.style`, which an orphaned lock stops producing, so
+   * input is the trigger that cannot miss. Document level because a locked `<body>` leaves hit
+   * testing while `<html>` keeps `pointer-events: auto` and still receives the event.
    */
   $effect(() => {
     if (typeof document === 'undefined') return
@@ -217,17 +210,14 @@
 
     observer.observe(document.body, { attributes: true, attributeFilter: ['style'] })
 
-    // No settle delay: input arrives from a person, long after any close transition, and an
-    // overlay still exiting is still present and so still counts as an owner.
+    // No settle delay: input arrives long after any close transition, and an exiting overlay
+    // is still present and so still counts as an owner.
     function handleInput() {
       if (!isBodyLockPresent()) return
       release()
     }
 
-    // All three, because any one of them can be the first thing a person tries on a page that
-    // has stopped responding — and `overflow: hidden` makes a scroll the most likely of them.
-    // A wheel is not a pointerdown: without it, someone scrolling at a frozen page keeps
-    // scrolling and never recovers.
+    // `wheel` too: `overflow: hidden` makes scrolling the first thing tried on a frozen page.
     document.addEventListener('pointerdown', handleInput, true)
     document.addEventListener('keydown', handleInput, true)
     document.addEventListener('wheel', handleInput, { capture: true, passive: true })

--- a/src/lib/components/layout/AppShell.svelte
+++ b/src/lib/components/layout/AppShell.svelte
@@ -20,7 +20,7 @@
   import STChatImportModal from '$lib/components/modals/STChatImportModal.svelte'
   import UpdateDialog from '$lib/components/updater/UpdateDialog.svelte'
   import { swipe } from '$lib/utils/swipe'
-  import { releaseOrphanScrollLock } from '$lib/utils/scrollLock'
+  import { releaseOrphanScrollLock, isBodyLockPresent } from '$lib/utils/scrollLock'
   import { createLogger } from '$lib/log'
   import { Bug } from '@lucide/svelte'
   import {
@@ -182,31 +182,62 @@
   })
 
   /**
-   * The single owner of orphaned-scroll-lock recovery, for the whole app: watches
-   * `document.body` for a lock and, once the close transition has had time to run, releases
-   * it if nothing on screen should be holding it. See `$lib/utils/scrollLock`.
+   * The single owner of orphaned-scroll-lock recovery, for the whole app. Two triggers, one
+   * release: see `$lib/utils/scrollLock`.
+   *
+   * The observer alone cannot be enough. It fires on writes to `body.style`, and an orphaned
+   * lock is precisely the case where nothing writes there again — it gets one look, at the
+   * moment the overlay is still legitimately open, and is never called back.
+   *
+   * Input is the trigger that cannot miss: a real event reaching the document while the body
+   * is locked and no owner is present means the lock is orphaned, whatever left it behind. A
+   * locked page still delivers these — `pointer-events: none` on `<body>` takes `<body>` and
+   * its subtree out of hit testing, but `<html>` keeps `auto`, so the event targets
+   * `documentElement` and still reaches a capture listener here. Hence document level, and
+   * hence not delegated from anywhere inside the app tree.
    */
   $effect(() => {
     if (typeof document === 'undefined') return
 
     let settleTimer: ReturnType<typeof setTimeout> | null = null
 
+    function release() {
+      if (releaseOrphanScrollLock()) log('Released an orphaned body scroll lock')
+    }
+
     const observer = new MutationObserver(() => {
-      const { pointerEvents, overflow } = document.body.style
-      if (pointerEvents !== 'none' && overflow !== 'hidden') return
+      if (!isBodyLockPresent()) return
 
       if (settleTimer) clearTimeout(settleTimer)
       settleTimer = setTimeout(() => {
         settleTimer = null
-        if (releaseOrphanScrollLock()) log('Released an orphaned body scroll lock')
+        release()
       }, MODAL_CLOSE_TRANSITION_MS)
     })
 
     observer.observe(document.body, { attributes: true, attributeFilter: ['style'] })
 
+    // No settle delay: input arrives from a person, long after any close transition, and an
+    // overlay still exiting is still present and so still counts as an owner.
+    function handleInput() {
+      if (!isBodyLockPresent()) return
+      release()
+    }
+
+    // All three, because any one of them can be the first thing a person tries on a page that
+    // has stopped responding — and `overflow: hidden` makes a scroll the most likely of them.
+    // A wheel is not a pointerdown: without it, someone scrolling at a frozen page keeps
+    // scrolling and never recovers.
+    document.addEventListener('pointerdown', handleInput, true)
+    document.addEventListener('keydown', handleInput, true)
+    document.addEventListener('wheel', handleInput, { capture: true, passive: true })
+
     return () => {
       if (settleTimer) clearTimeout(settleTimer)
       observer.disconnect()
+      document.removeEventListener('pointerdown', handleInput, true)
+      document.removeEventListener('keydown', handleInput, true)
+      document.removeEventListener('wheel', handleInput, true)
     }
   })
 </script>

--- a/src/lib/components/ui/dropdown-menu/dropdown-menu-content.svelte
+++ b/src/lib/components/ui/dropdown-menu/dropdown-menu-content.svelte
@@ -1,12 +1,20 @@
 <script lang="ts">
   import { cn } from '$lib/utils/cn.js'
   import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui'
+  import { NO_SCROLL_LOCK_ATTR } from '$lib/utils/scrollLock'
 
   let {
     ref = $bindable(null),
     sideOffset = 4,
     portalProps,
     class: className,
+    // `bits-ui` resolves `preventScroll ?? true`, so a dropdown locks the body by default —
+    // its own sub-menus, popovers, selects and tooltips all opt out, and a dropdown has no
+    // more need of it than they do. `strategy` is derived from `preventScroll` upstream
+    // (`strategy ?? (preventScroll ? 'fixed' : 'absolute')`), so it is pinned here to keep
+    // positioning unchanged inside a scrolling container.
+    preventScroll = false,
+    strategy = 'fixed',
     ...restProps
   }: DropdownMenuPrimitive.ContentProps & {
     portalProps?: DropdownMenuPrimitive.PortalProps
@@ -17,6 +25,9 @@
   <DropdownMenuPrimitive.Content
     bind:ref
     {sideOffset}
+    {preventScroll}
+    {strategy}
+    {...preventScroll ? {} : { [NO_SCROLL_LOCK_ATTR]: '' }}
     class={cn(
       'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-md outline-none',
       className,

--- a/src/lib/components/ui/dropdown-menu/dropdown-menu-content.svelte
+++ b/src/lib/components/ui/dropdown-menu/dropdown-menu-content.svelte
@@ -8,11 +8,9 @@
     sideOffset = 4,
     portalProps,
     class: className,
-    // `bits-ui` resolves `preventScroll ?? true`, so a dropdown locks the body by default —
-    // its own sub-menus, popovers, selects and tooltips all opt out, and a dropdown has no
-    // more need of it than they do. `strategy` is derived from `preventScroll` upstream
-    // (`strategy ?? (preventScroll ? 'fixed' : 'absolute')`), so it is pinned here to keep
-    // positioning unchanged inside a scrolling container.
+    // `bits-ui` resolves `preventScroll ?? true`, so a dropdown locks the body unless told not
+    // to. `strategy` is derived from it upstream, and is pinned so opting out leaves position
+    // unchanged.
     preventScroll = false,
     strategy = 'fixed',
     ...restProps

--- a/src/lib/components/ui/dropdown-menu/dropdown-menu-sub-content.svelte
+++ b/src/lib/components/ui/dropdown-menu/dropdown-menu-sub-content.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui'
   import { cn } from '$lib/utils/cn.js'
+  import { NO_SCROLL_LOCK_ATTR } from '$lib/utils/scrollLock'
 
   let {
     ref = $bindable(null),
@@ -9,8 +10,11 @@
   }: DropdownMenuPrimitive.SubContentProps = $props()
 </script>
 
+<!-- A sub-menu never locks the body upstream, but renders the same `role="menu"` as one that
+     does, so it has to say so or it would veto orphan recovery while holding nothing. -->
 <DropdownMenuPrimitive.SubContent
   bind:ref
+  {...{ [NO_SCROLL_LOCK_ATTR]: '' }}
   class={cn(
     'bg-popover text-popover-foreground z-50 min-w-[8rem] rounded-md border p-1 shadow-lg focus:outline-none',
     className,

--- a/src/lib/utils/scrollLock.test.ts
+++ b/src/lib/utils/scrollLock.test.ts
@@ -1,11 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { isBodyLocked } from './scrollLock'
 
-/**
- * The half-locked states are the point. `bits-ui` sets `overflow` synchronously and
- * `pointer-events` an `afterTick` later, so a snapshot taken between the two sees only one of
- * them -- and a lock the recovery net does not recognise is a session that never recovers.
- */
+/** The half-locked states are the point: they are what the library's deferred apply produces. */
 describe('isBodyLocked', () => {
   it('reports a lock from pointer-events alone', () => {
     expect(isBodyLocked('none', '')).toBe(true)

--- a/src/lib/utils/scrollLock.test.ts
+++ b/src/lib/utils/scrollLock.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { isBodyLocked } from './scrollLock'
+import { isBodyLocked, isWithinCloseGrace } from './scrollLock'
+import { MODAL_CLOSE_TRANSITION_MS } from '$lib/constants/layout'
 
 /** The half-locked states are the point: they are what the library's deferred apply produces. */
 describe('isBodyLocked', () => {
@@ -22,5 +23,21 @@ describe('isBodyLocked', () => {
   it('ignores values that are not the locked ones', () => {
     expect(isBodyLocked('auto', 'visible')).toBe(false)
     expect(isBodyLocked('all', 'auto')).toBe(false)
+  })
+})
+
+/** The grace has to expire: a stalled exit animation would otherwise veto recovery forever. */
+describe('isWithinCloseGrace', () => {
+  it('keeps a just-closed overlay entitled', () => {
+    expect(isWithinCloseGrace(1000, 1000)).toBe(true)
+    expect(isWithinCloseGrace(1000, 1000 + MODAL_CLOSE_TRANSITION_MS - 1)).toBe(true)
+  })
+
+  it('drops entitlement once the exit has had time to finish', () => {
+    expect(isWithinCloseGrace(1000, 1000 + MODAL_CLOSE_TRANSITION_MS)).toBe(false)
+  })
+
+  it('drops entitlement for an overlay stalled at closed', () => {
+    expect(isWithinCloseGrace(1000, 1000 + 60_000)).toBe(false)
   })
 })

--- a/src/lib/utils/scrollLock.test.ts
+++ b/src/lib/utils/scrollLock.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { isBodyLocked } from './scrollLock'
+
+/**
+ * The half-locked states are the point. `bits-ui` sets `overflow` synchronously and
+ * `pointer-events` an `afterTick` later, so a snapshot taken between the two sees only one of
+ * them -- and a lock the recovery net does not recognise is a session that never recovers.
+ */
+describe('isBodyLocked', () => {
+  it('reports a lock from pointer-events alone', () => {
+    expect(isBodyLocked('none', '')).toBe(true)
+  })
+
+  it('reports a lock from overflow alone', () => {
+    expect(isBodyLocked('', 'hidden')).toBe(true)
+  })
+
+  it('reports a lock when both are set', () => {
+    expect(isBodyLocked('none', 'hidden')).toBe(true)
+  })
+
+  it('reports no lock when neither is set', () => {
+    expect(isBodyLocked('', '')).toBe(false)
+  })
+
+  it('ignores values that are not the locked ones', () => {
+    expect(isBodyLocked('auto', 'visible')).toBe(false)
+    expect(isBodyLocked('all', 'auto')).toBe(false)
+  })
+})

--- a/src/lib/utils/scrollLock.ts
+++ b/src/lib/utils/scrollLock.ts
@@ -13,6 +13,8 @@
  * Nothing here is a substitute for closing a modal properly. It is the net under it.
  */
 
+import { MODAL_CLOSE_TRANSITION_MS } from '$lib/constants/layout'
+
 /** Marks menu content that has opted out of the body lock, so it is never mistaken for an owner. */
 export const NO_SCROLL_LOCK_ATTR = 'data-no-scroll-lock'
 
@@ -20,22 +22,52 @@ export const NO_SCROLL_LOCK_ATTR = 'data-no-scroll-lock'
  * Everything in this stack that legitimately holds a body lock, as it appears in the DOM.
  *
  * `bits-ui` resolves `preventScroll ?? true`, so dialog, alert-dialog, context-menu and
- * dropdown/menu lock; popover, select, tooltip and sub-menus opt out. `vaul` locks its own way.
+ * dropdown/menu lock. Popover, select and tooltip opt out upstream; a sub-menu shares
+ * `MenuContentState` and so looks identical here, and is excluded by the same marker the
+ * app's own dropdowns carry. `vaul` locks its own way.
  *
- * Matched on presence, not `[data-state="open"]`: an owner is mounted with its element and
- * still holds the lock while animating closed. `[data-state]` itself separates a library-owned
- * overlay from a hand-rolled one with the same role, which holds no lock and must not veto.
+ * `[data-state]` is what separates a library-owned overlay from a hand-rolled one with the
+ * same ARIA role, which holds no lock and must not be able to veto recovery.
  */
-const OPEN_OVERLAY_SELECTOR = [
-  '[role="dialog"][data-state]',
-  '[role="alertdialog"][data-state]',
-  `[role="menu"][data-state]:not([${NO_SCROLL_LOCK_ATTR}])`,
-  '[data-vaul-drawer][data-state]',
-].join(', ')
+const OVERLAY_CLAUSES = [
+  '[role="dialog"]',
+  '[role="alertdialog"]',
+  `[role="menu"]:not([${NO_SCROLL_LOCK_ATTR}])`,
+  '[data-vaul-drawer]',
+]
 
-/** Is anything on screen entitled to be holding the body lock right now? */
+const OPEN_OVERLAY_SELECTOR = OVERLAY_CLAUSES.map((c) => `${c}[data-state="open"]`).join(', ')
+const CLOSING_OVERLAY_SELECTOR = OVERLAY_CLAUSES.map((c) => `${c}[data-state="closed"]`).join(', ')
+
+/** When each closing overlay was first seen, so the grace below is measured from somewhere. */
+const closingSince = new WeakMap<Element, number>()
+
+/** Is a closing overlay still within the window where it may hold its lock? */
+export function isWithinCloseGrace(since: number, now: number): boolean {
+  return now - since < MODAL_CLOSE_TRANSITION_MS
+}
+
+/**
+ * Is anything on screen entitled to be holding the body lock right now?
+ *
+ * A closing overlay still owns its lock — the owner unmounts with the element, not with the
+ * state flip — so it counts, but only until its exit has had time to finish. `bits-ui` drops
+ * the element from an animation callback, and a WebView that never delivers one would
+ * otherwise leave a node at `data-state="closed"` vetoing recovery for the rest of the session.
+ */
 function hasOpenOverlay(): boolean {
-  return document.querySelector(OPEN_OVERLAY_SELECTOR) !== null
+  if (document.querySelector(OPEN_OVERLAY_SELECTOR) !== null) return true
+
+  const now = Date.now()
+  for (const el of document.querySelectorAll(CLOSING_OVERLAY_SELECTOR)) {
+    const since = closingSince.get(el)
+    if (since === undefined) {
+      closingSince.set(el, now)
+      return true
+    }
+    if (isWithinCloseGrace(since, now)) return true
+  }
+  return false
 }
 
 /**

--- a/src/lib/utils/scrollLock.ts
+++ b/src/lib/utils/scrollLock.ts
@@ -13,18 +13,31 @@
  * Nothing here is a substitute for closing a modal properly. It is the net under it.
  */
 
+/** Marks menu content that has opted out of the body lock, so it is never mistaken for an owner. */
+export const NO_SCROLL_LOCK_ATTR = 'data-no-scroll-lock'
+
 /**
  * Everything in this stack that legitimately holds a body lock, as it appears in the DOM.
  *
- * Only `preventScroll` defaults to true in `bits-ui` — dialog, alert-dialog and
- * context-menu; select, popover and dropdown-menu never lock. A missing selector here
- * would unlock the page under an open modal.
+ * `preventScroll` resolves to `preventScroll ?? true` in `bits-ui`, so dialog, alert-dialog,
+ * context-menu AND dropdown/menu all lock; popover, select, tooltip, link-preview and
+ * sub-menus pass `false`. `vaul` drawers lock through their own mechanism.
+ *
+ * Two rules decide what belongs here, and both matter:
+ *
+ * - Presence, not open state. A lock owner is mounted and unmounted with its element, so it
+ *   still holds the lock while animating closed. Matching `[data-state="open"]` would release
+ *   the lock under a modal opening behind one that is still exiting.
+ * - `[data-state]` is what separates a library-managed owner from a hand-rolled overlay
+ *   carrying the same ARIA role. Both libraries set it for the element's whole life; the
+ *   app's own overlays (the expanded portrait, the wizard discard prompt) never do, and must
+ *   not be able to veto recovery — a veto strands the user, since they hold no lock to release.
  */
 const OPEN_OVERLAY_SELECTOR = [
-  '[role="dialog"][data-state="open"]',
-  '[role="alertdialog"][data-state="open"]',
-  '[role="menu"][data-state="open"]',
-  '[data-vaul-drawer][data-state="open"]',
+  '[role="dialog"][data-state]',
+  '[role="alertdialog"][data-state]',
+  `[role="menu"][data-state]:not([${NO_SCROLL_LOCK_ATTR}])`,
+  '[data-vaul-drawer][data-state]',
 ].join(', ')
 
 /** Is anything on screen entitled to be holding the body lock right now? */
@@ -33,7 +46,24 @@ function hasOpenOverlay(): boolean {
 }
 
 /**
- * Drop the body lock, but only if nothing open should be holding it.
+ * Is the body locked? Pure so the decision can be tested without a DOM.
+ *
+ * Either property alone is a lock: `bits-ui` applies `overflow` synchronously and
+ * `pointer-events` an `afterTick` later, so both half-states are reachable.
+ */
+export function isBodyLocked(pointerEvents: string, overflow: string): boolean {
+  return pointerEvents === 'none' || overflow === 'hidden'
+}
+
+/** Is `document.body` locked right now? */
+export function isBodyLockPresent(): boolean {
+  if (typeof document === 'undefined') return false
+  const { pointerEvents, overflow } = document.body.style
+  return isBodyLocked(pointerEvents, overflow)
+}
+
+/**
+ * Drop the body lock, but only if nothing present should be holding it.
  *
  * Returns whether it released anything, which is what makes it safe to call from a modal's
  * own teardown: a modal closing on top of another finds the one underneath and leaves the
@@ -44,6 +74,7 @@ function hasOpenOverlay(): boolean {
  */
 export function releaseOrphanScrollLock(): boolean {
   if (typeof document === 'undefined') return false
+  if (!isBodyLockPresent()) return false
   if (hasOpenOverlay()) return false
 
   document.body.style.pointerEvents = ''

--- a/src/lib/utils/scrollLock.ts
+++ b/src/lib/utils/scrollLock.ts
@@ -19,19 +19,12 @@ export const NO_SCROLL_LOCK_ATTR = 'data-no-scroll-lock'
 /**
  * Everything in this stack that legitimately holds a body lock, as it appears in the DOM.
  *
- * `preventScroll` resolves to `preventScroll ?? true` in `bits-ui`, so dialog, alert-dialog,
- * context-menu AND dropdown/menu all lock; popover, select, tooltip, link-preview and
- * sub-menus pass `false`. `vaul` drawers lock through their own mechanism.
+ * `bits-ui` resolves `preventScroll ?? true`, so dialog, alert-dialog, context-menu and
+ * dropdown/menu lock; popover, select, tooltip and sub-menus opt out. `vaul` locks its own way.
  *
- * Two rules decide what belongs here, and both matter:
- *
- * - Presence, not open state. A lock owner is mounted and unmounted with its element, so it
- *   still holds the lock while animating closed. Matching `[data-state="open"]` would release
- *   the lock under a modal opening behind one that is still exiting.
- * - `[data-state]` is what separates a library-managed owner from a hand-rolled overlay
- *   carrying the same ARIA role. Both libraries set it for the element's whole life; the
- *   app's own overlays (the expanded portrait, the wizard discard prompt) never do, and must
- *   not be able to veto recovery — a veto strands the user, since they hold no lock to release.
+ * Matched on presence, not `[data-state="open"]`: an owner is mounted with its element and
+ * still holds the lock while animating closed. `[data-state]` itself separates a library-owned
+ * overlay from a hand-rolled one with the same role, which holds no lock and must not veto.
  */
 const OPEN_OVERLAY_SELECTOR = [
   '[role="dialog"][data-state]',
@@ -48,7 +41,7 @@ function hasOpenOverlay(): boolean {
 /**
  * Is the body locked? Pure so the decision can be tested without a DOM.
  *
- * Either property alone is a lock: `bits-ui` applies `overflow` synchronously and
+ * Either property alone counts: `bits-ui` applies `overflow` synchronously and
  * `pointer-events` an `afterTick` later, so both half-states are reachable.
  */
 export function isBodyLocked(pointerEvents: string, overflow: string): boolean {


### PR DESCRIPTION
## The bug

On Android the app regularly reached a state where it rendered correctly but ignored every touch — taps, scrolling and the action input all dead, while generation kept running and entries kept streaming in. Only the floating scroll buttons responded, and the state survived navigating away from the story view, persisting for the rest of the session.

That one surviving control is the whole diagnosis. `StoryView.svelte:583` is the only element in the story view that sets `pointer-events: auto`, and `pointer-events` is inherited — so `pointer-events: none` on `<body>` kills the entire tree *except* anything that re-declares it. Not an overlay covering the app; the input was severed at the root.

Both modal libraries write `pointer-events: none; overflow: hidden` to `document.body` while an overlay is open and restore it on the teardown paths they control. An overlay unmounted while still open never runs that restore, and the lock is permanent.

## Why the existing net didn't catch it

`releaseOrphanScrollLock` and the `AppShell` watcher already existed for exactly this. The watcher is triggered by a `MutationObserver` on `body.style` — and an orphaned lock is by definition the case where nothing writes to `body.style` again. It gets one look, at the moment the overlay is still legitimately open, and is never called back.

This is also why it was Android-only: the only other code that writes `body.style` is the desktop pane-resize handler, so on desktop the next splitter drag silently rescued the session.

## What changed

**Recovery is driven by real input** (`AppShell.svelte`). Capture-phase `pointerdown`, `keydown` and `wheel` listeners on `document`, sharing one release with the existing watcher, which is kept. The correctness argument mentions no library: if a real input event reaches the document while the body is locked and no owner is present, the lock is orphaned. A locked page still delivers those events — `<body>` leaves hit testing but `<html>` keeps `pointer-events: auto`, so the event targets `documentElement`. `wheel` is included because `overflow: hidden` makes scrolling the first thing a user tries, and a wheel is not a `pointerdown`.

**Ownership detection corrected** (`scrollLock.ts`). Two defects found in review, both of which would have survived a fix to the trigger alone:

- Entitlement tested `data-state="open"`, but a lock owner is mounted with its *element* and still holds the lock while animating closed. Releasing in that window could leave a modal opened behind a still-exiting one displayed with no lock at all. Now matches presence.
- Presence alone is too broad: `[data-state]` is what separates a library-managed owner from a hand-rolled overlay carrying the same ARIA role. The app has two non-owners (`CharacterPanel` expanded portrait, `WizardExitConfirm`); letting either veto recovery would strand the user, since neither holds a lock to release and the portrait sets no `pointer-events: auto` of its own.

**Dropdown menus stop taking the lock** (`dropdown-menu-content.svelte`). `bits-ui` resolves `preventScroll ?? true`, so dropdowns locked by default despite needing it no more than its own sub-menus, popovers and selects, which all opt out. The story entry `⋯` menu is `sm:hidden` — mobile-only — and the most frequent trigger. `strategy` is pinned to `fixed` because it is otherwise derived from `preventScroll`, so opting out would silently change positioning inside the scrolling story container too.

The comment in `scrollLock.ts` claiming dropdown menus never lock was wrong for the pinned `bits-ui`, and was the stated justification for the selector — corrected, since the next person to edit that list would have reasoned from it.

## For the reviewer

**Verification is incomplete, deliberately so.** The suite is `environment: 'node'` with no DOM, so only the style predicate has unit tests (5 of them, weighted toward the half-locked states the `afterTick` gap produces).

| Claim | Status |
|---|---|
| `isBodyLocked` predicate | ✅ unit tested |
| `<html>` stays hit-testable under the lock | 🟡 Chromium desktop, real input events — **not** Android WebView |
| `wheel` reaches document under the lock | 🟡 same |
| Listener-driven recovery in the app | ❌ unverified |
| Closing / stacked overlay behavior | ❌ unverified |
| Dropdown positioning after `strategy="fixed"` | ❌ unverified |

The middle rows are engine-level evidence for a CSS premise, gathered on a synthetic page. They say the approach is viable; they say nothing about whether this app's wiring is right.

**The load-bearing risk**: if `<html>` is *not* hit-testable under the lock in Android WebView, this approach fails entirely rather than partially. Worth settling on-device before this lands.

Behaviour change to expect: content behind an open dropdown menu now scrolls. Dialogs, alert dialogs and drawers keep locking, so no full-screen modal is affected.

Planning artifacts (proposal, spec, design, tasks, and two rounds of review with responses) live in the `aventuras-specs` store under `recover-orphaned-scroll-lock`; they are not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery from stuck page scroll locks, including recovery after user interaction.
  - Updated overlay handling to more reliably identify and release abandoned scroll locks.
  - Dropdown menus and submenus no longer interfere with page scrolling by default and maintain stable positioning.
  - Improved handling of overlays while they are closing to prevent premature scroll-lock recovery.

- **Internal Improvements**
  - Improved scroll-lock detection and coordination across menus and overlays.
  - Added automated coverage for scroll-lock state detection and closing-overlay behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->