### PR TITLE
Prompt packs: export and import as a directory of Markdown files

### DIFF
--- a/docs/architecture/prompts.md
+++ b/docs/architecture/prompts.md
@@ -134,6 +134,56 @@ self.
 Importing a file always creates a *new* pack. A name collision offers a copy or a cancel, never an
 overwrite: replacing a pack is reached from that pack, not from a name that happens to match.
 
+### Exporting a Pack as a Directory
+
+A pack is also readable and writable as a directory of Markdown files — one per stored row, `pack.yaml` at
+the root for metadata and custom variables, generated reference material under `_reference/`. Desktop only:
+`tauri-plugin-dialog`'s folder picker is `FolderPickerNotImplemented` on mobile. On desktop the picked
+folder reaches `fs_scope.allow_directory`, so the capability's `$APPDATA`/`$TEMP` scope is not a constraint
+and the whole thing is plain `plugin-fs` from TypeScript.
+
+**The filename is the identity; the folder is presentation.** `<group>/<id>.md`, where the group comes from
+`TEMPLATE_GROUP_MAP` — which is code, and changes between releases. Were the path the identity, a template
+the app regroups would read as a delete plus an add of a file the user may also have edited. As a stem it is
+a rename, which git detects. Import ignores the folder entirely, so two files sharing a name anywhere in the
+tree are refused rather than resolved.
+
+Import reads `pack.yaml` and `.md` files inside folders. Root `.md` files and `_`-prefixed folders are
+ignored silently, which is what lets a user's `README.md`, their notes, and the generated reference share
+one tree with no manifest saying which is which. Export writes into that tree, and prunes template files and
+reference material it did not write — but only in a directory already carrying a `pack.yaml`, and never a
+root file it does not own.
+
+Two exports of unchanged content must be byte-identical or git cannot merge them, which is the whole point.
+Hence LF endings, one trailing newline, fixed key order in `pack.yaml`, variables sorted by `sortOrder` then
+name, and **no timestamp** — a value that moves between two exports of the same pack conflicts on every
+merge and says nothing the commit does not.
+
+`_reference/template-status.md` names the templates carrying an edit, and speaks a different language per
+source. For `default-pack` it uses `classifyTemplate`'s three states, because there the baseline *is* the
+shipped text; those rows are what would otherwise ride silently into a merge base. For a custom pack it uses
+`isUntouched` alone — a shipped comparison there would flag every row of a pack whose baseline was never the
+shipped text — and names what the next replace destroys.
+
+### Why the Baseline Lives in Git
+
+`baseline_hash` is a single-slot approximation of a three-way merge for one pack. The workflow the directory
+format exists for does the merge properly: export the shipped baseline on each release onto an upstream
+branch, merge it into the branch carrying your own edits, review the result as a diff, import that into a
+custom pack. `base` is the previous shipped-baseline export, `theirs` the new one, `ours` the edited tree.
+
+The app therefore contributes two things and models none of the rest: a `theirs` no edit can reach, and an
+import that does not lie about what it wrote. **The shipped-baseline export is a separate action** — it
+reads `PROMPT_TEMPLATES`, not a pack's rows, so one in-app edit to `default-pack` cannot poison the merge
+base. It lives beside `refreshTemplates` in the built-in pack's Pack Settings, whose subject is already the
+text the app ships rather than the pack it renders under.
+
+A directory import writes rows with `isBaseline: true`, as `updatePackFromFile` does, and for the same
+reason: the file *is* the pack's baseline, the user's edits live in git. The alternative reads every row as
+edited, so `summarizeUpdate` would warn that ~80 edits are about to be discarded on every single import —
+and a warning that always fires stops being read. The built-in pack stays excluded as an import target for
+the reason it already is.
+
 ## Prompt Ordering and Prefix Caching
 
 Inference servers reuse the KV cache for the longest prefix a request shares with the previous one, and

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "marked": "^18.0.7",
     "svelte-codemirror-editor": "^2.1.0",
     "tailwind-merge": "^3.6.0",
+    "yaml": "^2.9.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
@@ -92,8 +93,7 @@
     "typescript-eslint": "^8.65.0",
     "vaul-svelte": "^1.0.0-next.7",
     "vite": "^8.2.0",
-    "vitest": "^4.1.10",
-    "yaml": "^2.9.0"
+    "vitest": "^4.1.10"
   },
   "aube": {
     "allowBuilds": {

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -18,6 +18,7 @@
     "fs:default",
     "fs:allow-read-file",
     "fs:allow-read-text-file",
+    "fs:allow-read-dir",
     "fs:allow-write-file",
     "fs:allow-write-text-file",
     "fs:allow-exists",

--- a/src/lib/components/vault/VaultPanel.svelte
+++ b/src/lib/components/vault/VaultPanel.svelte
@@ -18,6 +18,7 @@
     Bot,
     FileCode,
     Download,
+    FolderDown,
   } from '@lucide/svelte'
   import UniversalVaultCard from './UniversalVaultCard.svelte'
   import InteractiveVaultAssistant from './InteractiveVaultAssistant.svelte'
@@ -35,6 +36,7 @@
   import PromptPackEditor from './prompts/PromptPackEditor.svelte'
   import ImportPreviewDialog from './prompts/ImportPreviewDialog.svelte'
   import VaultExportModal from './VaultExportModal.svelte'
+  import { supportsDirectoryTransfer } from '$lib/services/packs/directory/support'
   import {
     importExportService,
     type ImportValidationResult,
@@ -81,6 +83,8 @@
   let importDialogOpen = $state(false)
   let importValidation = $state<ImportValidationResult | null>(null)
   let importConflictPack = $state<PresetPack | null>(null)
+  let importSource = $state<'file' | 'folder'>('file')
+  const canUseDirectories = supportsDirectoryTransfer()
   // Prompts tab view state
   type PromptsViewState = { mode: 'browsing' } | { mode: 'editing'; packId: string }
   let promptsViewState = $state<PromptsViewState>({ mode: 'browsing' })
@@ -373,10 +377,24 @@
   }
 
   // Import pack handlers
+  async function handleImportPackDirectory() {
+    const candidate = await importExportService.pickAndValidateDirectory()
+    if (!candidate) return
+
+    importSource = 'folder'
+    importValidation = candidate.validation
+    importConflictPack =
+      candidate.validation.valid && candidate.validation.pack
+        ? await importExportService.checkNameConflict(candidate.validation.pack.name)
+        : null
+    importDialogOpen = true
+  }
+
   async function handleImportPack() {
     const content = await importExportService.pickAndReadImportFile()
     if (!content) return
     const result = importExportService.validateImport(content)
+    importSource = 'file'
     importValidation = result
     if (result.valid && result.pack) {
       importConflictPack = await importExportService.checkNameConflict(result.pack.name)
@@ -458,6 +476,17 @@
             class="h-9"
             onclick={handleImportPack}
           />
+
+          {#if canUseDirectories}
+            <Button
+              icon={FolderDown}
+              label="Import Folder"
+              variant="outline"
+              size="sm"
+              class="h-9"
+              onclick={handleImportPackDirectory}
+            />
+          {/if}
 
           <Button
             icon={Plus}
@@ -769,6 +798,7 @@
   open={importDialogOpen}
   validationResult={importValidation}
   conflictPack={importConflictPack}
+  source={importSource}
   onConfirm={handleImportConfirm}
   onCancel={() => {
     importDialogOpen = false

--- a/src/lib/components/vault/VaultPanel.svelte
+++ b/src/lib/components/vault/VaultPanel.svelte
@@ -3,6 +3,7 @@
   import { lorebookVault } from '$lib/stores/lorebookVault.svelte'
   import { scenarioVault } from '$lib/stores/scenarioVault.svelte'
   import { ui } from '$lib/stores/ui.svelte'
+  import { errMessage } from '$lib/utils/error'
   import type { VaultCharacter, VaultLorebook, VaultScenario } from '$lib/types'
   import {
     Plus,
@@ -378,16 +379,22 @@
 
   // Import pack handlers
   async function handleImportPackDirectory() {
-    const candidate = await importExportService.pickAndValidateDirectory()
-    if (!candidate) return
+    try {
+      const candidate = await importExportService.pickAndValidateDirectory()
+      if (!candidate) return
 
-    importSource = 'folder'
-    importValidation = candidate.validation
-    importConflictPack =
-      candidate.validation.valid && candidate.validation.pack
-        ? await importExportService.checkNameConflict(candidate.validation.pack.name)
-        : null
-    importDialogOpen = true
+      importSource = 'folder'
+      importValidation = candidate.validation
+      importConflictPack =
+        candidate.validation.valid && candidate.validation.pack
+          ? await importExportService.checkNameConflict(candidate.validation.pack.name)
+          : null
+      importDialogOpen = true
+    } catch (e) {
+      // The folder picker itself can reject; only the read past it is handled in the service.
+      console.error('Folder import failed:', e)
+      ui.showToast(`Import failed: ${errMessage(e)}`, 'error')
+    }
   }
 
   async function handleImportPack() {

--- a/src/lib/components/vault/prompts/ExportIntoFolderDialog.svelte
+++ b/src/lib/components/vault/prompts/ExportIntoFolderDialog.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+  import type { DirectoryExportPlan } from '$lib/services/packs/import-export'
+  import * as ResponsiveModal from '$lib/components/ui/responsive-modal'
+  import { ScrollArea } from '$lib/components/ui/scroll-area'
+  import { Button } from '$lib/components/ui/button'
+
+  interface Props {
+    /** The planned export awaiting an answer, or null when nothing is pending. */
+    plan: DirectoryExportPlan | null
+    onConfirm: () => void
+    onCancel: () => void
+  }
+
+  let { plan, onConfirm, onCancel }: Props = $props()
+
+  let removals = $derived(plan?.prunePaths ?? [])
+</script>
+
+<ResponsiveModal.Root
+  open={!!plan}
+  onOpenChange={(v) => {
+    if (!v) onCancel()
+  }}
+>
+  <ResponsiveModal.Content class="p-0 sm:max-w-md">
+    <ResponsiveModal.Header class="border-b px-6 py-4">
+      <ResponsiveModal.Title>
+        {removals.length > 0 ? 'Delete files no longer in this pack?' : 'Export into this folder?'}
+      </ResponsiveModal.Title>
+      <ResponsiveModal.Description>
+        {#if plan && !plan.isKnownExport}
+          This folder already holds files and was not written by a previous export. Nothing in it
+          will be deleted, but any file sharing a name with one of the exported files — including
+          ABOUT.md, .gitattributes and any prompt of the same name — will be overwritten.
+        {:else}
+          Exporting keeps the folder matching the pack, so files it no longer contains are removed.
+          A Markdown file you kept beside the prompts looks the same as a prompt this pack has
+          dropped, so check the list before continuing.
+        {/if}
+      </ResponsiveModal.Description>
+    </ResponsiveModal.Header>
+
+    {#if removals.length > 0}
+      <div class="flex flex-col gap-1 px-6 py-4">
+        <p class="text-sm font-medium">
+          {removals.length === 1
+            ? '1 file will be deleted:'
+            : `${removals.length} files will be deleted:`}
+        </p>
+        <ScrollArea class="max-h-48">
+          <ul class="text-destructive list-disc pl-5 text-sm">
+            {#each removals as path (path)}
+              <li class="font-mono text-xs">{path}</li>
+            {/each}
+          </ul>
+        </ScrollArea>
+      </div>
+    {/if}
+
+    <ResponsiveModal.Footer class="border-t px-6 py-4">
+      <Button variant="outline" onclick={onCancel}>Cancel</Button>
+      <Button variant={removals.length > 0 ? 'destructive' : 'default'} onclick={onConfirm}>
+        {removals.length > 0 ? 'Delete and export' : 'Export here'}
+      </Button>
+    </ResponsiveModal.Footer>
+  </ResponsiveModal.Content>
+</ResponsiveModal.Root>

--- a/src/lib/components/vault/prompts/ImportPreviewDialog.svelte
+++ b/src/lib/components/vault/prompts/ImportPreviewDialog.svelte
@@ -13,11 +13,20 @@
     open: boolean
     validationResult: ImportValidationResult | null
     conflictPack: PresetPack | null
+    /** What the user picked, so an error names the thing they chose. */
+    source?: 'file' | 'folder'
     onConfirm: (strategy: ConflictStrategy) => void
     onCancel: () => void
   }
 
-  let { open, validationResult, conflictPack, onConfirm, onCancel }: Props = $props()
+  let {
+    open,
+    validationResult,
+    conflictPack,
+    source = 'file',
+    onConfirm,
+    onCancel,
+  }: Props = $props()
 
   let isValid = $derived(validationResult?.valid ?? false)
   let pack = $derived(validationResult?.pack)
@@ -46,7 +55,7 @@
         {#if isValid}
           Review the pack details before importing.
         {:else}
-          The selected file contains errors and cannot be imported.
+          The selected {source} contains errors and cannot be imported.
         {/if}
       </ResponsiveModal.Description>
     </ResponsiveModal.Header>
@@ -72,7 +81,9 @@
               <ul class="text-destructive list-disc pl-5 text-sm">
                 {#each validationResult.templateErrors as templateError (templateError.templateId)}
                   <li>
-                    <span class="font-mono text-xs">{templateError.templateId}</span>:
+                    <span class="font-mono text-xs">
+                      {templateError.path ?? templateError.templateId}
+                    </span>:
                     {templateError.error}
                   </li>
                 {/each}
@@ -111,8 +122,8 @@
             <Alert.Title>Name conflict</Alert.Title>
             <Alert.Description>
               A pack named "{conflictPack.name}" already exists. Importing creates a separate copy.
-              To replace that pack's contents with this file, use its "Update from file" action
-              instead.
+              To replace that pack's contents instead, use "Replace this pack from" in its
+              import/export menu.
             </Alert.Description>
           </Alert.Root>
         {/if}

--- a/src/lib/components/vault/prompts/PromptPackCard.svelte
+++ b/src/lib/components/vault/prompts/PromptPackCard.svelte
@@ -41,15 +41,24 @@
   const canReplace = $derived(!pack.isDefault && !!onUpdateFromFile)
 </script>
 
-<button type="button" class="w-full text-left" {onclick}>
+<div class="relative">
   <Card
     class="group hover:border-primary/50 h-full cursor-pointer transition-colors {pack.isDefault
       ? 'border-dashed'
       : ''}"
   >
     <CardContent class="flex h-full flex-col p-4">
+      <!-- Covers the card so the whole surface opens the pack, while the action menu stays a
+           sibling: a menu trigger nested in a <button> breaks focus and activation. -->
+      <button
+        type="button"
+        class="absolute inset-0 z-0 h-full w-full cursor-pointer rounded-xl text-left"
+        aria-label="Open {pack.name}"
+        {onclick}
+      ></button>
+
       <div class="flex items-start justify-between">
-        <div class="min-w-0 flex-1">
+        <div class="pointer-events-none relative z-10 min-w-0 flex-1">
           <div class="flex flex-wrap items-center gap-2">
             <h3 class="truncate font-semibold">{pack.name}</h3>
             {#if usageCount > 0}
@@ -60,7 +69,7 @@
             {#if pack.description}{stripToPlainText(pack.description)}{:else}&nbsp;{/if}
           </p>
         </div>
-        <div class="flex shrink-0 items-center gap-0.5">
+        <div class="relative z-10 flex shrink-0 items-center gap-0.5">
           <DropdownMenu.Root bind:open={transferMenuOpen}>
             <DropdownMenu.Trigger>
               {#snippet child({ props })}
@@ -138,4 +147,4 @@
       </div>
     </CardContent>
   </Card>
-</button>
+</div>

--- a/src/lib/components/vault/prompts/PromptPackCard.svelte
+++ b/src/lib/components/vault/prompts/PromptPackCard.svelte
@@ -3,8 +3,10 @@
   import { Card, CardContent } from '$lib/components/ui/card'
   import { Badge } from '$lib/components/ui/badge'
   import { Button } from '$lib/components/ui/button'
-  import { Upload, Trash2, Lock, RefreshCw } from '@lucide/svelte'
+  import * as DropdownMenu from '$lib/components/ui/dropdown-menu'
+  import { Trash2, Lock, ArrowUpDown, ChevronDown, FileJson, FolderOpen } from '@lucide/svelte'
   import { stripToPlainText } from '$lib/utils/markdown'
+  import { supportsDirectoryTransfer } from '$lib/services/packs/directory/support'
 
   interface Props {
     pack: PresetPack
@@ -12,12 +14,31 @@
     usageCount: number
     onclick: () => void
     onExport?: () => void
+    onExportDirectory?: () => void
     onUpdateFromFile?: () => void
+    onUpdateFromDirectory?: () => void
     onDelete?: () => void
   }
 
-  let { pack, modifiedCount, usageCount, onclick, onExport, onUpdateFromFile, onDelete }: Props =
-    $props()
+  let {
+    pack,
+    modifiedCount,
+    usageCount,
+    onclick,
+    onExport,
+    onExportDirectory,
+    onUpdateFromFile,
+    onUpdateFromDirectory,
+    onDelete,
+  }: Props = $props()
+
+  const canUseDirectories = supportsDirectoryTransfer()
+
+  let transferMenuOpen = $state(false)
+
+  // The built-in pack is rewritten from the app's own templates on every launch, so it is
+  // never a replacement target.
+  const canReplace = $derived(!pack.isDefault && !!onUpdateFromFile)
 </script>
 
 <button type="button" class="w-full text-left" {onclick}>
@@ -40,34 +61,56 @@
           </p>
         </div>
         <div class="flex shrink-0 items-center gap-0.5">
-          {#if onExport}
-            <Button
-              variant="ghost"
-              size="icon"
-              class="h-8 w-8 transition-opacity sm:opacity-0 sm:group-hover:opacity-100"
-              onclick={(e: MouseEvent) => {
-                e.stopPropagation()
-                onExport?.()
-              }}
-              title="Export pack"
-            >
-              <Upload class="h-4 w-4" />
-            </Button>
-          {/if}
-          {#if !pack.isDefault && onUpdateFromFile}
-            <Button
-              variant="ghost"
-              size="icon"
-              class="h-8 w-8 transition-opacity sm:opacity-0 sm:group-hover:opacity-100"
-              onclick={(e: MouseEvent) => {
-                e.stopPropagation()
-                onUpdateFromFile?.()
-              }}
-              title="Update from file"
-            >
-              <RefreshCw class="h-4 w-4" />
-            </Button>
-          {/if}
+          <DropdownMenu.Root bind:open={transferMenuOpen}>
+            <DropdownMenu.Trigger>
+              {#snippet child({ props })}
+                <Button
+                  {...props}
+                  variant="ghost"
+                  size="icon"
+                  class="h-8 w-auto gap-0.5 px-1.5 transition-opacity sm:opacity-0 sm:group-hover:opacity-100 {transferMenuOpen
+                    ? 'sm:opacity-100'
+                    : ''}"
+                  onclick={(e: MouseEvent) => {
+                    e.stopPropagation()
+                    transferMenuOpen = !transferMenuOpen
+                  }}
+                  title="Import / Export pack"
+                >
+                  <ArrowUpDown class="h-4 w-4" />
+                  <ChevronDown class="h-3 w-3" />
+                </Button>
+              {/snippet}
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Content align="end" onclick={(e: MouseEvent) => e.stopPropagation()}>
+              <DropdownMenu.Label>Export</DropdownMenu.Label>
+              <DropdownMenu.Item onclick={() => onExport?.()}>
+                <FileJson class="text-accent-400 h-4 w-4" />
+                Pack file (.prompt.json)
+              </DropdownMenu.Item>
+              {#if canUseDirectories}
+                <DropdownMenu.Item onclick={() => onExportDirectory?.()}>
+                  <FolderOpen class="h-4 w-4 text-blue-400" />
+                  Folder of Markdown
+                </DropdownMenu.Item>
+              {/if}
+
+              {#if canReplace}
+                <DropdownMenu.Separator />
+                <DropdownMenu.Label>Replace this pack from</DropdownMenu.Label>
+                <DropdownMenu.Item onclick={() => onUpdateFromFile?.()}>
+                  <FileJson class="text-accent-400 h-4 w-4" />
+                  Pack file (.prompt.json)
+                </DropdownMenu.Item>
+                {#if canUseDirectories && onUpdateFromDirectory}
+                  <DropdownMenu.Item onclick={() => onUpdateFromDirectory?.()}>
+                    <FolderOpen class="h-4 w-4 text-blue-400" />
+                    Folder of Markdown
+                  </DropdownMenu.Item>
+                {/if}
+              {/if}
+            </DropdownMenu.Content>
+          </DropdownMenu.Root>
           {#if !pack.isDefault && onDelete}
             <Button
               variant="ghost"

--- a/src/lib/components/vault/prompts/PromptPackCard.svelte
+++ b/src/lib/components/vault/prompts/PromptPackCard.svelte
@@ -70,6 +70,8 @@
           </p>
         </div>
         <div class="relative z-10 flex shrink-0 items-center gap-0.5">
+          <!-- No onclick on the trigger: its own handlers arrive through the spread props, and
+               a second toggle on click opens then immediately closes it on touch. -->
           <DropdownMenu.Root bind:open={transferMenuOpen}>
             <DropdownMenu.Trigger>
               {#snippet child({ props })}
@@ -80,10 +82,6 @@
                   class="h-8 w-auto gap-0.5 px-1.5 transition-opacity sm:opacity-0 sm:group-hover:opacity-100 {transferMenuOpen
                     ? 'sm:opacity-100'
                     : ''}"
-                  onclick={(e: MouseEvent) => {
-                    e.stopPropagation()
-                    transferMenuOpen = !transferMenuOpen
-                  }}
                   title="Import / Export pack"
                 >
                   <ArrowUpDown class="h-4 w-4" />
@@ -91,7 +89,7 @@
                 </Button>
               {/snippet}
             </DropdownMenu.Trigger>
-            <DropdownMenu.Content align="end" onclick={(e: MouseEvent) => e.stopPropagation()}>
+            <DropdownMenu.Content align="end">
               <DropdownMenu.Label>Export</DropdownMenu.Label>
               <DropdownMenu.Item onclick={() => onExport?.()}>
                 <FileJson class="text-accent-400 h-4 w-4" />

--- a/src/lib/components/vault/prompts/PromptPackCard.svelte
+++ b/src/lib/components/vault/prompts/PromptPackCard.svelte
@@ -4,7 +4,7 @@
   import { Badge } from '$lib/components/ui/badge'
   import { Button } from '$lib/components/ui/button'
   import * as DropdownMenu from '$lib/components/ui/dropdown-menu'
-  import { Trash2, Lock, ArrowUpDown, ChevronDown, FileJson, FolderOpen } from '@lucide/svelte'
+  import { Upload, RefreshCw, Trash2, Lock, FileJson, FolderOpen } from '@lucide/svelte'
   import { stripToPlainText } from '$lib/utils/markdown'
   import { supportsDirectoryTransfer } from '$lib/services/packs/directory/support'
 
@@ -34,7 +34,12 @@
 
   const canUseDirectories = supportsDirectoryTransfer()
 
-  let transferMenuOpen = $state(false)
+  let exportMenuOpen = $state(false)
+  let replaceMenuOpen = $state(false)
+
+  // The card reveals its actions on hover, so an open menu has to hold its trigger visible.
+  const triggerClass = (open: boolean) =>
+    `h-8 w-8 transition-opacity sm:opacity-0 sm:group-hover:opacity-100 ${open ? 'sm:opacity-100' : ''}`
 
   // The built-in pack is rewritten from the app's own templates on every launch, so it is
   // never a replacement target.
@@ -70,54 +75,94 @@
           </p>
         </div>
         <div class="relative z-10 flex shrink-0 items-center gap-0.5">
-          <!-- No onclick on the trigger: its own handlers arrive through the spread props, and
-               a second toggle on click opens then immediately closes it on touch. -->
-          <DropdownMenu.Root bind:open={transferMenuOpen}>
-            <DropdownMenu.Trigger>
-              {#snippet child({ props })}
-                <Button
-                  {...props}
-                  variant="ghost"
-                  size="icon"
-                  class="h-8 w-auto gap-0.5 px-1.5 transition-opacity sm:opacity-0 sm:group-hover:opacity-100 {transferMenuOpen
-                    ? 'sm:opacity-100'
-                    : ''}"
-                  title="Import / Export pack"
-                >
-                  <ArrowUpDown class="h-4 w-4" />
-                  <ChevronDown class="h-3 w-3" />
-                </Button>
-              {/snippet}
-            </DropdownMenu.Trigger>
-            <DropdownMenu.Content align="end">
-              <DropdownMenu.Label>Export</DropdownMenu.Label>
-              <DropdownMenu.Item onclick={() => onExport?.()}>
-                <FileJson class="text-accent-400 h-4 w-4" />
-                Pack file (.prompt.json)
-              </DropdownMenu.Item>
-              {#if canUseDirectories}
+          <!--
+            One button per direction, as before. Where a folder is possible the button opens a
+            menu to choose the format; on Android there is only the file, so it is the action
+            itself rather than a menu of one.
+
+            No onclick on a trigger: its handlers arrive through the spread props, and a second
+            toggle on click opens then immediately closes the menu on touch.
+          -->
+          {#if canUseDirectories}
+            <DropdownMenu.Root bind:open={exportMenuOpen}>
+              <DropdownMenu.Trigger>
+                {#snippet child({ props })}
+                  <Button
+                    {...props}
+                    variant="ghost"
+                    size="icon"
+                    class={triggerClass(exportMenuOpen)}
+                    title="Export pack"
+                  >
+                    <Upload class="h-4 w-4" />
+                  </Button>
+                {/snippet}
+              </DropdownMenu.Trigger>
+              <DropdownMenu.Content align="end">
+                <DropdownMenu.Label>Export as</DropdownMenu.Label>
+                <DropdownMenu.Item onclick={() => onExport?.()}>
+                  <FileJson class="text-accent-400 h-4 w-4" />
+                  Pack file (.prompt.json)
+                </DropdownMenu.Item>
                 <DropdownMenu.Item onclick={() => onExportDirectory?.()}>
                   <FolderOpen class="h-4 w-4 text-blue-400" />
                   Folder of Markdown
                 </DropdownMenu.Item>
-              {/if}
+              </DropdownMenu.Content>
+            </DropdownMenu.Root>
+          {:else if onExport}
+            <Button
+              variant="ghost"
+              size="icon"
+              class={triggerClass(false)}
+              onclick={() => onExport?.()}
+              title="Export pack"
+            >
+              <Upload class="h-4 w-4" />
+            </Button>
+          {/if}
 
-              {#if canReplace}
-                <DropdownMenu.Separator />
+          {#if canReplace && canUseDirectories}
+            <DropdownMenu.Root bind:open={replaceMenuOpen}>
+              <DropdownMenu.Trigger>
+                {#snippet child({ props })}
+                  <Button
+                    {...props}
+                    variant="ghost"
+                    size="icon"
+                    class={triggerClass(replaceMenuOpen)}
+                    title="Replace this pack"
+                  >
+                    <RefreshCw class="h-4 w-4" />
+                  </Button>
+                {/snippet}
+              </DropdownMenu.Trigger>
+              <DropdownMenu.Content align="end">
                 <DropdownMenu.Label>Replace this pack from</DropdownMenu.Label>
                 <DropdownMenu.Item onclick={() => onUpdateFromFile?.()}>
                   <FileJson class="text-accent-400 h-4 w-4" />
                   Pack file (.prompt.json)
                 </DropdownMenu.Item>
-                {#if canUseDirectories && onUpdateFromDirectory}
+                {#if onUpdateFromDirectory}
                   <DropdownMenu.Item onclick={() => onUpdateFromDirectory?.()}>
                     <FolderOpen class="h-4 w-4 text-blue-400" />
                     Folder of Markdown
                   </DropdownMenu.Item>
                 {/if}
-              {/if}
-            </DropdownMenu.Content>
-          </DropdownMenu.Root>
+              </DropdownMenu.Content>
+            </DropdownMenu.Root>
+          {:else if canReplace}
+            <Button
+              variant="ghost"
+              size="icon"
+              class={triggerClass(false)}
+              onclick={() => onUpdateFromFile?.()}
+              title="Update from file"
+            >
+              <RefreshCw class="h-4 w-4" />
+            </Button>
+          {/if}
+
           {#if !pack.isDefault && onDelete}
             <Button
               variant="ghost"

--- a/src/lib/components/vault/prompts/PromptPackEditor.svelte
+++ b/src/lib/components/vault/prompts/PromptPackEditor.svelte
@@ -152,7 +152,9 @@
   }
 
   async function handleExportShippedBaseline() {
+    if (exportingBaseline) return
     exportingBaseline = true
+    let awaitingConfirmation = false
     try {
       const plan = await importExportService.planShippedBaselineExport()
       if (!plan) return
@@ -161,9 +163,26 @@
       // is still overwritten, so the folder is confirmed before anything is written.
       if (plan.needsConfirmation) {
         pendingExport = plan
+        awaitingConfirmation = true
         return
       }
 
+      await importExportService.applyDirectoryExport(plan)
+      ui.showToast('Shipped prompts exported to folder', 'info')
+    } catch (e) {
+      console.error('Shipped baseline export failed:', e)
+      ui.showToast(`Export failed: ${errMessage(e)}`, 'error')
+    } finally {
+      // Held until the confirmation is answered, so the guard spans the write itself.
+      if (!awaitingConfirmation) exportingBaseline = false
+    }
+  }
+
+  async function confirmExportIntoUsedFolder() {
+    if (!pendingExport) return
+    const plan = pendingExport
+    pendingExport = null
+    try {
       await importExportService.applyDirectoryExport(plan)
       ui.showToast('Shipped prompts exported to folder', 'info')
     } catch (e) {
@@ -174,20 +193,9 @@
     }
   }
 
-  async function confirmExportIntoUsedFolder() {
-    if (!pendingExport) return
-    const plan = pendingExport
+  function cancelExportIntoUsedFolder() {
     pendingExport = null
-    exportingBaseline = true
-    try {
-      await importExportService.applyDirectoryExport(plan)
-      ui.showToast('Shipped prompts exported to folder', 'info')
-    } catch (e) {
-      console.error('Shipped baseline export failed:', e)
-      ui.showToast(`Export failed: ${errMessage(e)}`, 'error')
-    } finally {
-      exportingBaseline = false
-    }
+    exportingBaseline = false
   }
 
   async function handleRefresh(scope: RefreshScope) {
@@ -819,5 +827,5 @@
 <ExportIntoFolderDialog
   plan={pendingExport}
   onConfirm={confirmExportIntoUsedFolder}
-  onCancel={() => (pendingExport = null)}
+  onCancel={cancelExportIntoUsedFolder}
 />

--- a/src/lib/components/vault/prompts/PromptPackEditor.svelte
+++ b/src/lib/components/vault/prompts/PromptPackEditor.svelte
@@ -24,12 +24,16 @@
   import { renderDescription } from '$lib/utils/markdown'
   import TestVariablesModal from './TestVariablesModal.svelte'
   import RefreshTemplatesDialog from './RefreshTemplatesDialog.svelte'
+  import { importExportService, type DirectoryExportPlan } from '$lib/services/packs/import-export'
+  import * as ResponsiveModal from '$lib/components/ui/responsive-modal'
+  import { supportsDirectoryTransfer } from '$lib/services/packs/directory/support'
   import {
     ChevronLeft,
     Menu,
     Save,
     Undo2,
     RotateCcw,
+    FolderUp,
     Pencil,
     Eye,
     Check,
@@ -121,6 +125,13 @@
   let classified = $state<ClassifiedTemplates | null>(null)
   let refreshDialogOpen = $state(false)
   let refreshing = $state(false)
+  let exportingBaseline = $state(false)
+
+  // A folder that already holds files and was not written by a previous export. Nothing is
+  // pruned there, but a file of the same name is still overwritten.
+  let pendingExport = $state<DirectoryExportPlan | null>(null)
+
+  const canUseDirectories = supportsDirectoryTransfer()
 
   let editedCount = $derived(
     (classified?.behind.length ?? 0) + (classified?.customised.length ?? 0),
@@ -137,6 +148,45 @@
     } catch (error) {
       console.error('[PromptPackEditor] Failed to classify templates:', error)
       classified = null
+    }
+  }
+
+  async function handleExportShippedBaseline() {
+    exportingBaseline = true
+    try {
+      const plan = await importExportService.planShippedBaselineExport()
+      if (!plan) return
+
+      // Nothing is pruned from a folder this export does not own, but a file of the same name
+      // is still overwritten, so the folder is confirmed before anything is written.
+      if (plan.needsConfirmation) {
+        pendingExport = plan
+        return
+      }
+
+      await importExportService.applyDirectoryExport(plan)
+      ui.showToast('Shipped prompts exported to folder', 'info')
+    } catch (e) {
+      console.error('Shipped baseline export failed:', e)
+      ui.showToast(`Export failed: ${errMessage(e)}`, 'error')
+    } finally {
+      exportingBaseline = false
+    }
+  }
+
+  async function confirmExportIntoUsedFolder() {
+    if (!pendingExport) return
+    const plan = pendingExport
+    pendingExport = null
+    exportingBaseline = true
+    try {
+      await importExportService.applyDirectoryExport(plan)
+      ui.showToast('Shipped prompts exported to folder', 'info')
+    } catch (e) {
+      console.error('Shipped baseline export failed:', e)
+      ui.showToast(`Export failed: ${errMessage(e)}`, 'error')
+    } finally {
+      exportingBaseline = false
     }
   }
 
@@ -602,7 +652,7 @@
                       </p>
                     {/if}
                   </div>
-                  <div>
+                  <div class="flex flex-wrap gap-2">
                     <Button
                       variant="outline"
                       size="sm"
@@ -613,7 +663,25 @@
                       <RotateCcw class="h-3.5 w-3.5" />
                       Refresh from shipped prompts
                     </Button>
+                    {#if canUseDirectories}
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        class="h-7 gap-1.5 text-xs"
+                        disabled={exportingBaseline}
+                        onclick={handleExportShippedBaseline}
+                      >
+                        <FolderUp class="h-3.5 w-3.5" />
+                        {exportingBaseline ? 'Exporting…' : 'Export shipped prompts to folder'}
+                      </Button>
+                    {/if}
                   </div>
+                  {#if canUseDirectories}
+                    <p class="text-muted-foreground text-xs">
+                      Writes the prompts this version ships, not this pack, so no edit above can
+                      reach it — the merge base to carry your own edits onto after an update.
+                    </p>
+                  {/if}
                 </div>
               {/if}
 
@@ -747,3 +815,32 @@
     </Dialog.Footer>
   </Dialog.Content>
 </Dialog.Root>
+
+<!-- Exporting into a folder that holds files but is not a previous export. Nothing is removed
+     there, but a file of the same name is overwritten. -->
+<ResponsiveModal.Root
+  open={!!pendingExport}
+  onOpenChange={(v) => {
+    if (!v) pendingExport = null
+  }}
+>
+  <ResponsiveModal.Content class="p-0 sm:max-w-md">
+    <ResponsiveModal.Header class="border-b px-6 py-4">
+      <ResponsiveModal.Title>Export into this folder?</ResponsiveModal.Title>
+      <ResponsiveModal.Description>
+        This folder already holds files and was not written by a previous export. Nothing in it will
+        be deleted, but any file sharing a name with one of the exported files — including ABOUT.md,
+        .gitattributes and any prompt of the same name — will be overwritten.
+      </ResponsiveModal.Description>
+    </ResponsiveModal.Header>
+    <ResponsiveModal.Footer class="border-t px-6 py-4">
+      <Button
+        variant="outline"
+        onclick={() => {
+          pendingExport = null
+        }}>Cancel</Button
+      >
+      <Button onclick={confirmExportIntoUsedFolder}>Export here</Button>
+    </ResponsiveModal.Footer>
+  </ResponsiveModal.Content>
+</ResponsiveModal.Root>

--- a/src/lib/components/vault/prompts/PromptPackEditor.svelte
+++ b/src/lib/components/vault/prompts/PromptPackEditor.svelte
@@ -24,8 +24,8 @@
   import { renderDescription } from '$lib/utils/markdown'
   import TestVariablesModal from './TestVariablesModal.svelte'
   import RefreshTemplatesDialog from './RefreshTemplatesDialog.svelte'
+  import ExportIntoFolderDialog from './ExportIntoFolderDialog.svelte'
   import { importExportService, type DirectoryExportPlan } from '$lib/services/packs/import-export'
-  import * as ResponsiveModal from '$lib/components/ui/responsive-modal'
   import { supportsDirectoryTransfer } from '$lib/services/packs/directory/support'
   import {
     ChevronLeft,
@@ -816,31 +816,8 @@
   </Dialog.Content>
 </Dialog.Root>
 
-<!-- Exporting into a folder that holds files but is not a previous export. Nothing is removed
-     there, but a file of the same name is overwritten. -->
-<ResponsiveModal.Root
-  open={!!pendingExport}
-  onOpenChange={(v) => {
-    if (!v) pendingExport = null
-  }}
->
-  <ResponsiveModal.Content class="p-0 sm:max-w-md">
-    <ResponsiveModal.Header class="border-b px-6 py-4">
-      <ResponsiveModal.Title>Export into this folder?</ResponsiveModal.Title>
-      <ResponsiveModal.Description>
-        This folder already holds files and was not written by a previous export. Nothing in it will
-        be deleted, but any file sharing a name with one of the exported files — including ABOUT.md,
-        .gitattributes and any prompt of the same name — will be overwritten.
-      </ResponsiveModal.Description>
-    </ResponsiveModal.Header>
-    <ResponsiveModal.Footer class="border-t px-6 py-4">
-      <Button
-        variant="outline"
-        onclick={() => {
-          pendingExport = null
-        }}>Cancel</Button
-      >
-      <Button onclick={confirmExportIntoUsedFolder}>Export here</Button>
-    </ResponsiveModal.Footer>
-  </ResponsiveModal.Content>
-</ResponsiveModal.Root>
+<ExportIntoFolderDialog
+  plan={pendingExport}
+  onConfirm={confirmExportIntoUsedFolder}
+  onCancel={() => (pendingExport = null)}
+/>

--- a/src/lib/components/vault/prompts/PromptPackList.svelte
+++ b/src/lib/components/vault/prompts/PromptPackList.svelte
@@ -19,6 +19,7 @@
   import CreatePackDialog from './CreatePackDialog.svelte'
   import ImportPreviewDialog from './ImportPreviewDialog.svelte'
   import UpdatePackDialog from './UpdatePackDialog.svelte'
+  import ExportIntoFolderDialog from './ExportIntoFolderDialog.svelte'
 
   interface Props {
     onOpenPack: (packId: string) => void
@@ -48,6 +49,10 @@
   // A folder that already holds files but is not a previous export: nothing is pruned, but
   // the user is asked before anything lands in it.
   let pendingExport = $state<DirectoryExportPlan | null>(null)
+
+  // Two folder pickers open at once would run two exports, and the second could prune what
+  // the first had just written.
+  let directoryBusy = $state(false)
 
   const canUseDirectories = supportsDirectoryTransfer()
 
@@ -104,6 +109,8 @@
   }
 
   async function handleExportPackDirectory(packId: string) {
+    if (directoryBusy) return
+    directoryBusy = true
     try {
       const plan = await importExportService.planPackDirectoryExport(packId)
       if (!plan) return
@@ -118,6 +125,10 @@
     } catch (e) {
       console.error('Folder export failed:', e)
       ui.showToast(`Export failed: ${errMessage(e)}`, 'error')
+    } finally {
+      // A pending confirmation keeps its own plan; the guard lifts either way, since the
+      // dialog is modal.
+      directoryBusy = false
     }
   }
 
@@ -135,16 +146,22 @@
   }
 
   async function handleUpdateFromDirectory(pack: PresetPack) {
-    const candidate = await importExportService.pickAndValidateDirectory()
-    if (!candidate) return
+    if (directoryBusy) return
+    directoryBusy = true
+    try {
+      const candidate = await importExportService.pickAndValidateDirectory()
+      if (!candidate) return
 
-    if (!candidate.validation.valid || !candidate.validation.pack) {
-      updateErrorSource = 'folder'
-      updateErrors = candidate.validation
-      return
+      if (!candidate.validation.valid || !candidate.validation.pack) {
+        updateErrorSource = 'folder'
+        updateErrors = candidate.validation
+        return
+      }
+
+      await openUpdateConfirmation(pack, candidate.validation)
+    } finally {
+      directoryBusy = false
     }
-
-    await openUpdateConfirmation(pack, candidate.validation)
   }
 
   async function handleUpdateFromFile(pack: PresetPack) {
@@ -301,34 +318,11 @@
   }}
 />
 
-<!-- Exporting into a folder that holds files but is not a previous export. Nothing is removed
-     in that case, so the only question is whether the user meant this folder. -->
-<ResponsiveModal.Root
-  open={!!pendingExport}
-  onOpenChange={(v) => {
-    if (!v) pendingExport = null
-  }}
->
-  <ResponsiveModal.Content class="p-0 sm:max-w-md">
-    <ResponsiveModal.Header class="border-b px-6 py-4">
-      <ResponsiveModal.Title>Export into this folder?</ResponsiveModal.Title>
-      <ResponsiveModal.Description>
-        This folder already holds files and was not written by a previous export. Nothing in it will
-        be deleted, but any file sharing a name with one of the exported files — including ABOUT.md,
-        .gitattributes and any prompt of the same name — will be overwritten.
-      </ResponsiveModal.Description>
-    </ResponsiveModal.Header>
-    <ResponsiveModal.Footer class="border-t px-6 py-4">
-      <Button
-        variant="outline"
-        onclick={() => {
-          pendingExport = null
-        }}>Cancel</Button
-      >
-      <Button onclick={confirmExportIntoUsedFolder}>Export here</Button>
-    </ResponsiveModal.Footer>
-  </ResponsiveModal.Content>
-</ResponsiveModal.Root>
+<ExportIntoFolderDialog
+  plan={pendingExport}
+  onConfirm={confirmExportIntoUsedFolder}
+  onCancel={() => (pendingExport = null)}
+/>
 
 <!-- Delete confirmation -->
 <ResponsiveModal.Root

--- a/src/lib/components/vault/prompts/PromptPackList.svelte
+++ b/src/lib/components/vault/prompts/PromptPackList.svelte
@@ -111,12 +111,14 @@
   async function handleExportPackDirectory(packId: string) {
     if (directoryBusy) return
     directoryBusy = true
+    let awaitingConfirmation = false
     try {
       const plan = await importExportService.planPackDirectoryExport(packId)
       if (!plan) return
 
       if (plan.needsConfirmation) {
         pendingExport = plan
+        awaitingConfirmation = true
         return
       }
 
@@ -126,9 +128,10 @@
       console.error('Folder export failed:', e)
       ui.showToast(`Export failed: ${errMessage(e)}`, 'error')
     } finally {
-      // A pending confirmation keeps its own plan; the guard lifts either way, since the
-      // dialog is modal.
-      directoryBusy = false
+      // The guard has to span the write, not just the planning: once the dialog closes the UI
+      // is live again, and a second export interleaving with this one reads a half-written
+      // tree or prunes what it has just put there. The confirmation keeps it until answered.
+      if (!awaitingConfirmation) directoryBusy = false
     }
   }
 
@@ -142,7 +145,14 @@
     } catch (e) {
       console.error('Folder export failed:', e)
       ui.showToast(`Export failed: ${errMessage(e)}`, 'error')
+    } finally {
+      directoryBusy = false
     }
+  }
+
+  function cancelExportIntoUsedFolder() {
+    pendingExport = null
+    directoryBusy = false
   }
 
   async function handleUpdateFromDirectory(pack: PresetPack) {
@@ -325,7 +335,7 @@
 <ExportIntoFolderDialog
   plan={pendingExport}
   onConfirm={confirmExportIntoUsedFolder}
-  onCancel={() => (pendingExport = null)}
+  onCancel={cancelExportIntoUsedFolder}
 />
 
 <!-- Delete confirmation -->

--- a/src/lib/components/vault/prompts/PromptPackList.svelte
+++ b/src/lib/components/vault/prompts/PromptPackList.svelte
@@ -4,8 +4,10 @@
   import { database } from '$lib/services/database'
   import {
     importExportService,
+    type DirectoryExportPlan,
     type ImportValidationResult,
   } from '$lib/services/packs/import-export'
+  import { supportsDirectoryTransfer } from '$lib/services/packs/directory/support'
   import type { PackUpdateSummary } from '$lib/services/packs/update-summary'
   import { ui } from '$lib/stores/ui.svelte'
   import { errMessage } from '$lib/utils/error'
@@ -39,8 +41,15 @@
   let updateValidation = $state<ImportValidationResult | null>(null)
   let updateSummary = $state<PackUpdateSummary | null>(null)
   let updateErrors = $state<ImportValidationResult | null>(null)
+  let updateErrorSource = $state<'file' | 'folder'>('file')
   let updating = $state(false)
   let exportingBeforeUpdate = $state(false)
+
+  // A folder that already holds files but is not a previous export: nothing is pruned, but
+  // the user is asked before anything lands in it.
+  let pendingExport = $state<DirectoryExportPlan | null>(null)
+
+  const canUseDirectories = supportsDirectoryTransfer()
 
   async function loadPacks() {
     loading = true
@@ -94,16 +103,67 @@
     }
   }
 
+  async function handleExportPackDirectory(packId: string) {
+    try {
+      const plan = await importExportService.planPackDirectoryExport(packId)
+      if (!plan) return
+
+      if (plan.needsConfirmation) {
+        pendingExport = plan
+        return
+      }
+
+      await importExportService.applyDirectoryExport(plan)
+      ui.showToast('Pack exported to folder', 'info')
+    } catch (e) {
+      console.error('Folder export failed:', e)
+      ui.showToast(`Export failed: ${errMessage(e)}`, 'error')
+    }
+  }
+
+  async function confirmExportIntoUsedFolder() {
+    if (!pendingExport) return
+    const plan = pendingExport
+    pendingExport = null
+    try {
+      await importExportService.applyDirectoryExport(plan)
+      ui.showToast('Pack exported to folder', 'info')
+    } catch (e) {
+      console.error('Folder export failed:', e)
+      ui.showToast(`Export failed: ${errMessage(e)}`, 'error')
+    }
+  }
+
+  async function handleUpdateFromDirectory(pack: PresetPack) {
+    const candidate = await importExportService.pickAndValidateDirectory()
+    if (!candidate) return
+
+    if (!candidate.validation.valid || !candidate.validation.pack) {
+      updateErrorSource = 'folder'
+      updateErrors = candidate.validation
+      return
+    }
+
+    await openUpdateConfirmation(pack, candidate.validation)
+  }
+
   async function handleUpdateFromFile(pack: PresetPack) {
     const content = await importExportService.pickAndReadImportFile()
     if (!content) return
 
     const result = importExportService.validateImport(content)
     if (!result.valid || !result.pack) {
+      updateErrorSource = 'file'
       updateErrors = result
       return
     }
 
+    await openUpdateConfirmation(pack, result)
+  }
+
+  /** The confirmation is the same whichever source the replacement came from. */
+  async function openUpdateConfirmation(pack: PresetPack, result: ImportValidationResult) {
+    if (!result.pack) return
     try {
       updateSummary = await importExportService.summarizeUpdate(pack.id, result.pack)
       updateValidation = result
@@ -193,7 +253,11 @@
         usageCount={usageCounts.get(pack.id) ?? 0}
         onclick={() => onOpenPack(pack.id)}
         onExport={() => handleExportPack(pack.id)}
+        onExportDirectory={() => handleExportPackDirectory(pack.id)}
         onUpdateFromFile={pack.isDefault ? undefined : () => handleUpdateFromFile(pack)}
+        onUpdateFromDirectory={pack.isDefault || !canUseDirectories
+          ? undefined
+          : () => handleUpdateFromDirectory(pack)}
         onDelete={pack.isDefault
           ? undefined
           : () => {
@@ -228,6 +292,7 @@
   open={!!updateErrors}
   validationResult={updateErrors}
   conflictPack={null}
+  source={updateErrorSource}
   onConfirm={() => {
     updateErrors = null
   }}
@@ -235,6 +300,35 @@
     updateErrors = null
   }}
 />
+
+<!-- Exporting into a folder that holds files but is not a previous export. Nothing is removed
+     in that case, so the only question is whether the user meant this folder. -->
+<ResponsiveModal.Root
+  open={!!pendingExport}
+  onOpenChange={(v) => {
+    if (!v) pendingExport = null
+  }}
+>
+  <ResponsiveModal.Content class="p-0 sm:max-w-md">
+    <ResponsiveModal.Header class="border-b px-6 py-4">
+      <ResponsiveModal.Title>Export into this folder?</ResponsiveModal.Title>
+      <ResponsiveModal.Description>
+        This folder already holds files and was not written by a previous export. Nothing in it will
+        be deleted, but any file sharing a name with one of the exported files — including ABOUT.md,
+        .gitattributes and any prompt of the same name — will be overwritten.
+      </ResponsiveModal.Description>
+    </ResponsiveModal.Header>
+    <ResponsiveModal.Footer class="border-t px-6 py-4">
+      <Button
+        variant="outline"
+        onclick={() => {
+          pendingExport = null
+        }}>Cancel</Button
+      >
+      <Button onclick={confirmExportIntoUsedFolder}>Export here</Button>
+    </ResponsiveModal.Footer>
+  </ResponsiveModal.Content>
+</ResponsiveModal.Root>
 
 <!-- Delete confirmation -->
 <ResponsiveModal.Root

--- a/src/lib/components/vault/prompts/PromptPackList.svelte
+++ b/src/lib/components/vault/prompts/PromptPackList.svelte
@@ -159,6 +159,10 @@
       }
 
       await openUpdateConfirmation(pack, candidate.validation)
+    } catch (e) {
+      // The folder picker itself can reject; only the read past it is handled in the service.
+      console.error('Folder update failed:', e)
+      ui.showToast(`Update failed: ${errMessage(e)}`, 'error')
     } finally {
       directoryBusy = false
     }

--- a/src/lib/services/packs/directory/io.ts
+++ b/src/lib/services/packs/directory/io.ts
@@ -1,0 +1,77 @@
+/**
+ * Reading and writing an exported tree on disk.
+ *
+ * The only part of the directory format that touches Tauri. `recursive: true` on the folder
+ * picker is what puts the chosen directory in the fs scope for the session; without it every
+ * write below is refused.
+ */
+
+import { open } from '@tauri-apps/plugin-dialog'
+import { mkdir, readDir, readTextFile, remove, writeTextFile } from '@tauri-apps/plugin-fs'
+import { classifyPath } from './layout'
+import type { Tree } from './tree'
+
+/** Ask for a directory, adding it to the fs scope. `null` if the user cancelled. */
+export async function pickDirectory(title: string): Promise<string | null> {
+  const chosen = await open({ directory: true, multiple: false, recursive: true, title })
+  return typeof chosen === 'string' ? chosen : null
+}
+
+function joinPath(root: string, relative: string): string {
+  return `${root}/${relative}`
+}
+
+/** Every file below `root`, as paths relative to it. */
+export async function listFiles(root: string, relativeDir = ''): Promise<string[]> {
+  const entries = await readDir(relativeDir ? joinPath(root, relativeDir) : root)
+  const files: string[] = []
+
+  for (const entry of entries) {
+    const relative = relativeDir ? `${relativeDir}/${entry.name}` : entry.name
+    if (entry.isDirectory) files.push(...(await listFiles(root, relative)))
+    else if (entry.isFile) files.push(relative)
+  }
+
+  return files
+}
+
+export interface ReadTree {
+  /** Every file found, whether or not the import reads it. Needed to plan a prune. */
+  allPaths: string[]
+  /** Only the files an import reads, by relative path. */
+  contents: Map<string, string>
+}
+
+/** Read a tree, loading only the files an import actually reads. */
+export async function readTree(root: string): Promise<ReadTree> {
+  const allPaths = await listFiles(root)
+  const contents = new Map<string, string>()
+
+  for (const path of allPaths) {
+    if (classifyPath(path) === 'ignored') continue
+    contents.set(path, await readTextFile(joinPath(root, path)))
+  }
+
+  return { allPaths, contents }
+}
+
+/** Write every file of `tree`, creating folders as needed, then remove `prunePaths`. */
+export async function writeTree(root: string, tree: Tree, prunePaths: string[]): Promise<void> {
+  const directories = new Set<string>()
+  for (const path of tree.keys()) {
+    const lastSlash = path.lastIndexOf('/')
+    if (lastSlash > 0) directories.add(path.slice(0, lastSlash))
+  }
+
+  for (const directory of [...directories].sort()) {
+    await mkdir(joinPath(root, directory), { recursive: true })
+  }
+
+  for (const [path, content] of tree) {
+    await writeTextFile(joinPath(root, path), content)
+  }
+
+  for (const path of prunePaths) {
+    await remove(joinPath(root, path))
+  }
+}

--- a/src/lib/services/packs/directory/io.ts
+++ b/src/lib/services/packs/directory/io.ts
@@ -21,6 +21,17 @@ function joinPath(root: string, relative: string): string {
   return `${root}/${relative}`
 }
 
+/**
+ * Directories never worth walking into.
+ *
+ * A tree lives in a git repository -- that is the point of the format -- so `.git` alone is
+ * thousands of loose-object files reached one `readDir` round-trip at a time. Nothing under a
+ * dot-directory can be a template or a file this export owns, so descending is pure cost.
+ */
+function isSkippedDirectory(name: string): boolean {
+  return name.startsWith('.') || name === 'node_modules'
+}
+
 /** Every file below `root`, as paths relative to it. */
 export async function listFiles(root: string, relativeDir = ''): Promise<string[]> {
   const entries = await readDir(relativeDir ? joinPath(root, relativeDir) : root)
@@ -28,8 +39,10 @@ export async function listFiles(root: string, relativeDir = ''): Promise<string[
 
   for (const entry of entries) {
     const relative = relativeDir ? `${relativeDir}/${entry.name}` : entry.name
-    if (entry.isDirectory) files.push(...(await listFiles(root, relative)))
-    else if (entry.isFile) files.push(relative)
+    if (entry.isDirectory) {
+      if (isSkippedDirectory(entry.name)) continue
+      files.push(...(await listFiles(root, relative)))
+    } else if (entry.isFile) files.push(relative)
   }
 
   return files

--- a/src/lib/services/packs/directory/layout.test.ts
+++ b/src/lib/services/packs/directory/layout.test.ts
@@ -10,7 +10,7 @@ import {
   classifyPath,
   collectTemplateFiles,
   groupFolderFor,
-  isRoundTrippableId,
+  isWritableTemplateId,
   templateIdFromPath,
   templatePath,
 } from './layout'
@@ -116,18 +116,47 @@ describe('collectTemplateFiles', () => {
   })
 })
 
-describe('isRoundTrippableId', () => {
+describe('isWritableTemplateId', () => {
   it('accepts every shipped row id', () => {
-    for (const id of storedRowIds()) expect(isRoundTrippableId(id)).toBe(true)
+    for (const id of storedRowIds()) expect(isWritableTemplateId(id)).toBe(true)
   })
 
   it('rejects an id that would gain a folder and come back as its last segment', () => {
-    expect(isRoundTrippableId('custom/example')).toBe(false)
-    expect(isRoundTrippableId('custom\\example')).toBe(false)
+    expect(isWritableTemplateId('custom/example')).toBe(false)
+    expect(isWritableTemplateId('custom\\example')).toBe(false)
   })
 
   it('accepts an underscore-prefixed id', () => {
-    expect(isRoundTrippableId('_scratch')).toBe(true)
+    expect(isWritableTemplateId('_scratch')).toBe(true)
+  })
+
+  // These reach buildTree through a hand-written .prompt.json, and plugin-fs fails on them.
+  it.each(['a:b', 'why?', 'a<b', 'a>b', 'a|b', 'a"b', 'a*b'])(
+    'rejects %s, which Windows forbids in a filename',
+    (id) => {
+      expect(isWritableTemplateId(id)).toBe(false)
+    },
+  )
+
+  it.each(['con', 'PRN', 'aux', 'nul', 'com1', 'LPT9'])(
+    'rejects the reserved device name %s',
+    (id) => {
+      expect(isWritableTemplateId(id)).toBe(false)
+    },
+  )
+
+  it('rejects a trailing dot or space, which Windows strips', () => {
+    expect(isWritableTemplateId('trailing.')).toBe(false)
+    expect(isWritableTemplateId('trailing ')).toBe(false)
+  })
+
+  it('rejects an empty id', () => {
+    expect(isWritableTemplateId('')).toBe(false)
+  })
+
+  it('still accepts ordinary hyphenated ids', () => {
+    expect(isWritableTemplateId('chapter-analysis')).toBe(true)
+    expect(isWritableTemplateId('image-style-soft-anime')).toBe(true)
   })
 })
 

--- a/src/lib/services/packs/directory/layout.test.ts
+++ b/src/lib/services/packs/directory/layout.test.ts
@@ -102,6 +102,16 @@ describe('collectTemplateFiles', () => {
     expect([...collected.templates.keys()].sort()).toEqual(['classifier', 'classifier-user'])
   })
 
+  // buildTree refuses these on export, so accepting them here would import a pack whose
+  // directory export can never succeed, with no way to rename a stored id.
+  it('refuses two files whose stems differ only in capitalisation', () => {
+    const collected = collectTemplateFiles(['Analysis/adventure.md', 'Memory/Adventure.md'])
+
+    expect(collected.templates.size).toBe(0)
+    expect(collected.duplicates).toHaveLength(1)
+    expect(collected.duplicates[0].paths).toEqual(['Analysis/adventure.md', 'Memory/Adventure.md'])
+  })
+
   it('reports every conflicting path and yields no templates', () => {
     const collected = collectTemplateFiles([
       'Analysis/classifier.md',

--- a/src/lib/services/packs/directory/layout.test.ts
+++ b/src/lib/services/packs/directory/layout.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest'
+import { PROMPT_TEMPLATES } from '$lib/services/prompts/templates'
+import {
+  ABOUT_FILE,
+  GITATTRIBUTES_FILE,
+  PACK_FILE,
+  REFERENCE_DIR,
+  UNGROUPED_DIR,
+  USER_HALF_SUFFIX,
+  classifyPath,
+  collectTemplateFiles,
+  groupFolderFor,
+  isRoundTrippableId,
+  templateIdFromPath,
+  templatePath,
+} from './layout'
+
+/** Every row a full pack holds: each template's system half, and its user half where one ships. */
+function storedRowIds(): string[] {
+  const ids: string[] = []
+  for (const template of PROMPT_TEMPLATES) {
+    ids.push(template.id)
+    if (template.userContent !== undefined) ids.push(`${template.id}${USER_HALF_SUFFIX}`)
+  }
+  return ids
+}
+
+describe('templatePath', () => {
+  it('round-trips every shipped row id, both halves', () => {
+    for (const id of storedRowIds()) {
+      expect(templateIdFromPath(templatePath(id))).toBe(id)
+    }
+  })
+
+  it('files a user half beside its system half', () => {
+    const withUserHalf = PROMPT_TEMPLATES.find((t) => t.userContent !== undefined)!
+    expect(groupFolderFor(`${withUserHalf.id}${USER_HALF_SUFFIX}`)).toBe(
+      groupFolderFor(withUserHalf.id),
+    )
+  })
+
+  it('files an id the app no longer ships under the reserved folder', () => {
+    expect(templatePath('retired-prompt')).toBe(`${UNGROUPED_DIR}/retired-prompt.md`)
+    expect(templateIdFromPath(templatePath('retired-prompt'))).toBe('retired-prompt')
+  })
+})
+
+describe('templateIdFromPath', () => {
+  it('ignores the containing folder', () => {
+    expect(templateIdFromPath('Analysis/classifier.md')).toBe('classifier')
+    expect(templateIdFromPath('Memory/classifier.md')).toBe('classifier')
+    expect(templateIdFromPath('somewhere/nested/deep/classifier.md')).toBe('classifier')
+  })
+
+  it('accepts backslash separators', () => {
+    expect(templateIdFromPath('Analysis\\classifier.md')).toBe('classifier')
+  })
+})
+
+describe('classifyPath', () => {
+  it('reads pack.yaml and templates below the root', () => {
+    expect(classifyPath(PACK_FILE)).toBe('pack-file')
+    expect(classifyPath('Story Generation/adventure.md')).toBe('template')
+  })
+
+  it('ignores the user’s own root files and the generated ones', () => {
+    expect(classifyPath('README.md')).toBe('ignored')
+    expect(classifyPath(ABOUT_FILE)).toBe('ignored')
+    expect(classifyPath(GITATTRIBUTES_FILE)).toBe('ignored')
+  })
+
+  it('ignores underscore-prefixed folders at any depth', () => {
+    expect(classifyPath(`${REFERENCE_DIR}/system-variables.md`)).toBe('ignored')
+    expect(classifyPath(`Analysis/${REFERENCE_DIR}/notes.md`)).toBe('ignored')
+  })
+
+  // The rule is about folders. A template whose own id starts with `_` would otherwise export
+  // and then never come back.
+  it('reads a template whose own name starts with an underscore', () => {
+    expect(classifyPath('Other/_scratch.md')).toBe('template')
+    expect(templateIdFromPath('Other/_scratch.md')).toBe('_scratch')
+  })
+
+  it('ignores files that are not markdown', () => {
+    expect(classifyPath('Analysis/classifier.txt')).toBe('ignored')
+    expect(classifyPath('Analysis/notes.yaml')).toBe('ignored')
+  })
+})
+
+describe('collectTemplateFiles', () => {
+  it('resolves a tree to stored ids', () => {
+    const collected = collectTemplateFiles([
+      PACK_FILE,
+      ABOUT_FILE,
+      'README.md',
+      `${REFERENCE_DIR}/system-variables.md`,
+      'Analysis/classifier.md',
+      'Analysis/classifier-user.md',
+    ])
+
+    expect(collected.duplicates).toEqual([])
+    expect([...collected.templates.keys()].sort()).toEqual(['classifier', 'classifier-user'])
+  })
+
+  it('reports every conflicting path and yields no templates', () => {
+    const collected = collectTemplateFiles([
+      'Analysis/classifier.md',
+      'Memory/classifier.md',
+      'Story Generation/adventure.md',
+    ])
+
+    expect(collected.templates.size).toBe(0)
+    expect(collected.duplicates).toEqual([
+      { templateId: 'classifier', paths: ['Analysis/classifier.md', 'Memory/classifier.md'] },
+    ])
+  })
+})
+
+describe('isRoundTrippableId', () => {
+  it('accepts every shipped row id', () => {
+    for (const id of storedRowIds()) expect(isRoundTrippableId(id)).toBe(true)
+  })
+
+  it('rejects an id that would gain a folder and come back as its last segment', () => {
+    expect(isRoundTrippableId('custom/example')).toBe(false)
+    expect(isRoundTrippableId('custom\\example')).toBe(false)
+  })
+
+  it('accepts an underscore-prefixed id', () => {
+    expect(isRoundTrippableId('_scratch')).toBe(true)
+  })
+})
+
+describe('shipped template ids', () => {
+  // A shipped id ending in `-user` would be indistinguishable from another prompt's user half,
+  // both in storage and in the tree.
+  it('never end in the user-half suffix', () => {
+    const colliding = PROMPT_TEMPLATES.filter((t) => t.id.endsWith(USER_HALF_SUFFIX))
+    expect(colliding.map((t) => t.id)).toEqual([])
+  })
+})

--- a/src/lib/services/packs/directory/layout.ts
+++ b/src/lib/services/packs/directory/layout.ts
@@ -1,0 +1,130 @@
+/**
+ * Where each part of a pack lives inside an exported directory, and which files an import
+ * reads back.
+ *
+ * Export and import both resolve paths through here. A disagreement between them is silent
+ * data loss, so neither derives a path of its own.
+ */
+
+import { describeTemplate } from '$lib/components/vault/prompts/templateGroups'
+
+/** Pack metadata and custom variables. */
+export const PACK_FILE = 'pack.yaml'
+
+/** Generated description of the tree, overwritten on every export. */
+export const ABOUT_FILE = 'ABOUT.md'
+
+/** Generated line-ending configuration, overwritten on every export. */
+export const GITATTRIBUTES_FILE = '.gitattributes'
+
+/** Generated reference material; never read back. */
+export const REFERENCE_DIR = '_reference'
+
+/** Holds templates whose id the app no longer ships. */
+export const UNGROUPED_DIR = 'Other'
+
+/** Suffix marking a prompt's user-message half, as stored. */
+export const USER_HALF_SUFFIX = '-user'
+
+/** Files the export writes and overwrites; everything else at the root belongs to the user. */
+export const RESERVED_ROOT_FILES = [PACK_FILE, ABOUT_FILE, GITATTRIBUTES_FILE]
+
+/** How a path in an exported tree is treated on import. */
+export type PathRole = 'template' | 'pack-file' | 'ignored'
+
+const MARKDOWN_EXTENSION = '.md'
+
+function segmentsOf(path: string): string[] {
+  return path.split(/[\\/]+/).filter((segment) => segment.length > 0)
+}
+
+/** The folder a template's file sits in: its display group, or `Other` for an id the app no longer ships. */
+export function groupFolderFor(templateId: string): string {
+  return describeTemplate(templateId)?.group ?? UNGROUPED_DIR
+}
+
+/** Where a stored template's file belongs, relative to the tree's root. */
+export function templatePath(templateId: string): string {
+  return `${groupFolderFor(templateId)}/${templateId}${MARKDOWN_EXTENSION}`
+}
+
+/**
+ * How an import treats a path.
+ *
+ * A template is any Markdown file below the root whose path contains no `_`-prefixed segment.
+ * The folder is presentation, so reorganising one does not change what a file is.
+ */
+export function classifyPath(path: string): PathRole {
+  const segments = segmentsOf(path)
+  if (segments.length === 0) return 'ignored'
+  if (segments.length === 1) return segments[0] === PACK_FILE ? 'pack-file' : 'ignored'
+  // Folders only. A template whose own id starts with `_` is still a template.
+  if (segments.slice(0, -1).some((segment) => segment.startsWith('_'))) return 'ignored'
+  return segments[segments.length - 1].endsWith(MARKDOWN_EXTENSION) ? 'template' : 'ignored'
+}
+
+/**
+ * The stored id a template file carries.
+ *
+ * The filename alone, so a file moved between folders is still the same template and an
+ * upstream regrouping is a rename rather than a delete and an add.
+ */
+export function templateIdFromPath(path: string): string | null {
+  if (classifyPath(path) !== 'template') return null
+  const segments = segmentsOf(path)
+  return segments[segments.length - 1].slice(0, -MARKDOWN_EXTENSION.length)
+}
+
+/**
+ * Whether this id survives being written as a filename and read back.
+ *
+ * `PackTemplateSchema` accepts any non-empty string, so a hand-written `.prompt.json` can
+ * carry an id holding a path separator. Written out it would gain a folder and come back as
+ * only its last segment — a different template, silently. Rather than encode ids and make
+ * every filename harder to read, an export refuses the ones that would not survive.
+ */
+export function isRoundTrippableId(templateId: string): boolean {
+  return templateIdFromPath(templatePath(templateId)) === templateId
+}
+
+/** Two files resolving to one stored id. */
+export interface DuplicateTemplate {
+  templateId: string
+  paths: string[]
+}
+
+export interface CollectedTemplates {
+  /** Stored id to the path it was found at. Empty when any duplicate was found. */
+  templates: Map<string, string>
+  duplicates: DuplicateTemplate[]
+}
+
+/**
+ * Resolve a tree's paths to stored ids.
+ *
+ * The folder no longer disambiguates two files sharing a name, so a collision is refused
+ * rather than resolved: returning no templates keeps a partial import impossible.
+ */
+export function collectTemplateFiles(paths: string[]): CollectedTemplates {
+  const byId = new Map<string, string[]>()
+
+  for (const path of paths) {
+    const templateId = templateIdFromPath(path)
+    if (templateId === null) continue
+    const existing = byId.get(templateId)
+    if (existing) existing.push(path)
+    else byId.set(templateId, [path])
+  }
+
+  const duplicates: DuplicateTemplate[] = []
+  const templates = new Map<string, string>()
+
+  for (const [templateId, found] of byId) {
+    if (found.length > 1) duplicates.push({ templateId, paths: [...found].sort() })
+    else templates.set(templateId, found[0])
+  }
+
+  duplicates.sort((a, b) => a.templateId.localeCompare(b.templateId))
+  if (duplicates.length > 0) return { templates: new Map(), duplicates }
+  return { templates, duplicates }
+}

--- a/src/lib/services/packs/directory/layout.ts
+++ b/src/lib/services/packs/directory/layout.ts
@@ -75,15 +75,37 @@ export function templateIdFromPath(path: string): string | null {
   return segments[segments.length - 1].slice(0, -MARKDOWN_EXTENSION.length)
 }
 
+/** Characters Win32 forbids outright in a filename. */
+const FILESYSTEM_UNSAFE = /[<>:"|?*]/
+
+/** MS-DOS device names, still refused by Win32 with or without an extension. */
+const RESERVED_DEVICE_NAMES = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])$/i
+
+function hasControlCharacter(value: string): boolean {
+  for (let i = 0; i < value.length; i++) {
+    if (value.charCodeAt(i) < 32) return true
+  }
+  return false
+}
+
 /**
  * Whether this id survives being written as a filename and read back.
  *
  * `PackTemplateSchema` accepts any non-empty string, so a hand-written `.prompt.json` can
- * carry an id holding a path separator. Written out it would gain a folder and come back as
- * only its last segment — a different template, silently. Rather than encode ids and make
- * every filename harder to read, an export refuses the ones that would not survive.
+ * carry an id that is not a usable filename: a path separator, which would gain a folder and
+ * come back as only its last segment, or a character Windows forbids, which fails at the
+ * write. Rather than encode ids and make every filename harder to read, an export refuses
+ * the ones that would not survive.
  */
-export function isRoundTrippableId(templateId: string): boolean {
+export function isWritableTemplateId(templateId: string): boolean {
+  if (templateId.length === 0) return false
+  if (FILESYSTEM_UNSAFE.test(templateId)) return false
+  if (hasControlCharacter(templateId)) return false
+  if (RESERVED_DEVICE_NAMES.test(templateId)) return false
+  // Windows silently strips a trailing dot or space, so the file would not be found again
+  // under its own id.
+  if (/[. ]$/.test(templateId)) return false
+  // Catches the path separators, which would gain a folder and come back truncated.
   return templateIdFromPath(templatePath(templateId)) === templateId
 }
 

--- a/src/lib/services/packs/directory/layout.ts
+++ b/src/lib/services/packs/directory/layout.ts
@@ -128,20 +128,24 @@ export interface CollectedTemplates {
  * rather than resolved: returning no templates keeps a partial import impossible.
  */
 export function collectTemplateFiles(paths: string[]): CollectedTemplates {
-  const byId = new Map<string, string[]>()
+  // Keyed without case, so two files that are one file on Windows and macOS are refused here
+  // rather than importing as two rows on Linux -- rows `buildTree` would then refuse to export,
+  // leaving a pack whose directory export can never succeed and no way to rename a stored id.
+  const byId = new Map<string, { templateId: string; paths: string[] }>()
 
   for (const path of paths) {
     const templateId = templateIdFromPath(path)
     if (templateId === null) continue
-    const existing = byId.get(templateId)
-    if (existing) existing.push(path)
-    else byId.set(templateId, [path])
+    const key = templateId.toLowerCase()
+    const existing = byId.get(key)
+    if (existing) existing.paths.push(path)
+    else byId.set(key, { templateId, paths: [path] })
   }
 
   const duplicates: DuplicateTemplate[] = []
   const templates = new Map<string, string>()
 
-  for (const [templateId, found] of byId) {
+  for (const { templateId, paths: found } of byId.values()) {
     if (found.length > 1) duplicates.push({ templateId, paths: [...found].sort() })
     else templates.set(templateId, found[0])
   }

--- a/src/lib/services/packs/directory/parse.test.ts
+++ b/src/lib/services/packs/directory/parse.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest'
+import { ABOUT_FILE, GITATTRIBUTES_FILE, PACK_FILE, REFERENCE_DIR } from './layout'
+import { DIRECTORY_FORMAT_VERSION, serializePackFile } from './serialize'
+import { validateTree } from './parse'
+
+const packYaml = serializePackFile({
+  formatVersion: DIRECTORY_FORMAT_VERSION,
+  appVersion: '0.7.9',
+  source: 'pack',
+  name: 'My Pack',
+  variables: [
+    {
+      variableName: 'writing_style',
+      displayName: 'Writing Style',
+      variableType: 'text',
+      isRequired: false,
+      sortOrder: 0,
+    },
+  ],
+})
+
+function tree(extra: Record<string, string> = {}): Map<string, string> {
+  return new Map(
+    Object.entries({
+      [PACK_FILE]: packYaml,
+      'Story Generation/adventure.md': 'Narrate for {{ protagonistName }}.\n',
+      'Story Generation/adventure-user.md': 'The player did: {{ userAction }}\n',
+      ...extra,
+    }),
+  )
+}
+
+describe('validateTree', () => {
+  it('accepts a well-formed tree', () => {
+    const result = validateTree(tree())
+
+    expect(result.valid).toBe(true)
+    expect(result.source).toBe('pack')
+    expect(result.pack!.name).toBe('My Pack')
+    expect(result.pack!.templates.map((t) => t.templateId)).toEqual(['adventure', 'adventure-user'])
+    expect(result.pack!.variables).toHaveLength(1)
+  })
+
+  it('strips the trailing newline a file carries', () => {
+    const result = validateTree(tree())
+    expect(result.pack!.templates[0].content).toBe('Narrate for {{ protagonistName }}.')
+  })
+
+  it('reads only template files, ignoring the rest', () => {
+    // The reader drops ignored paths, but a hand-assembled tree may still carry them.
+    const result = validateTree(
+      tree({
+        'README.md': 'my notes',
+        [ABOUT_FILE]: 'generated',
+        [GITATTRIBUTES_FILE]: '* text eol=lf\n',
+        [`${REFERENCE_DIR}/template-status.md`]: 'generated',
+      }),
+    )
+
+    expect(result.valid).toBe(true)
+    expect(result.pack!.templates.map((t) => t.templateId)).toEqual(['adventure', 'adventure-user'])
+  })
+
+  it('refuses a duplicate stem, naming both files', () => {
+    const result = validateTree(tree({ 'Analysis/adventure.md': 'a second one' }))
+
+    expect(result.valid).toBe(false)
+    expect(result.pack).toBeUndefined()
+    expect(result.structuralErrors[0]).toContain('Analysis/adventure.md')
+    expect(result.structuralErrors[0]).toContain('Story Generation/adventure.md')
+  })
+
+  it('refuses a template that is not valid Liquid, naming the file', () => {
+    const result = validateTree(tree({ 'Analysis/classifier.md': '{% if unclosed %}' }))
+
+    expect(result.valid).toBe(false)
+    expect(result.pack).toBeUndefined()
+    expect(result.templateErrors).toHaveLength(1)
+    expect(result.templateErrors[0].path).toBe('Analysis/classifier.md')
+    expect(result.templateErrors[0].templateId).toBe('classifier')
+  })
+
+  it.each([
+    ['an unclosed tag', '{% if unclosed %}'],
+    ['a mismatched end tag', '{% if a %}x{% endfor %}'],
+    ['an unclosed output', '{{ genre '],
+    ['a filter the app does not have', '{{ genre | nosuchfilter }}'],
+  ])('refuses %s, leaving nothing applied', (_label, content) => {
+    const result = validateTree(tree({ 'Analysis/classifier.md': content }))
+
+    expect(result.valid).toBe(false)
+    expect(result.pack).toBeUndefined()
+    expect(result.templateErrors[0].path).toBe('Analysis/classifier.md')
+  })
+
+  // Liquid renders an unknown name as an empty string, so nothing here can catch a typo.
+  // ABOUT.md documents this because it is the one failure the import cannot warn about.
+  it('accepts a variable name the app does not know', () => {
+    const result = validateTree(tree({ 'Analysis/classifier.md': '{{ protagonistNmae }} acts.' }))
+
+    expect(result.valid).toBe(true)
+    expect(result.pack!.templates.find((t) => t.templateId === 'classifier')!.content).toBe(
+      '{{ protagonistNmae }} acts.',
+    )
+  })
+
+  it('refuses a folder with no pack.yaml', () => {
+    const withoutPackFile = tree()
+    withoutPackFile.delete(PACK_FILE)
+
+    const result = validateTree(withoutPackFile)
+    expect(result.valid).toBe(false)
+    expect(result.structuralErrors[0]).toContain(PACK_FILE)
+  })
+
+  it('refuses a format version it cannot read', () => {
+    const future = serializePackFile({
+      formatVersion: DIRECTORY_FORMAT_VERSION + 1,
+      appVersion: '9.9.9',
+      source: 'pack',
+      name: 'From the future',
+      variables: [],
+    })
+
+    const result = validateTree(tree({ [PACK_FILE]: future }))
+    expect(result.valid).toBe(false)
+    expect(result.structuralErrors[0]).toContain('format version')
+  })
+
+  it('carries the shipped-baseline marker through', () => {
+    const baseline = serializePackFile({
+      formatVersion: DIRECTORY_FORMAT_VERSION,
+      appVersion: '0.7.9',
+      source: 'shipped-baseline',
+      name: 'Aventuras 0.7.9 shipped prompts',
+      variables: [],
+    })
+
+    const result = validateTree(tree({ [PACK_FILE]: baseline }))
+    expect(result.valid).toBe(true)
+    expect(result.source).toBe('shipped-baseline')
+    expect(result.pack!.variables).toEqual([])
+  })
+})

--- a/src/lib/services/packs/directory/parse.ts
+++ b/src/lib/services/packs/directory/parse.ts
@@ -1,0 +1,101 @@
+/**
+ * Turning a read tree into the pack shape the existing import paths already take.
+ *
+ * A directory is a second source for `applyImport` and `updatePackFromFile`, not a second
+ * import: everything past this point is the code that already handles `.prompt.json`.
+ */
+
+import { templateEngine } from '$lib/services/templates/engine'
+import { validatePackImport, type PackExport } from '../validation'
+import { PACK_FILE, collectTemplateFiles } from './layout'
+import { parsePackFile, parseTemplateFile, type TreeSource } from './serialize'
+
+export interface TemplateFileError {
+  templateId: string
+  path: string
+  error: string
+}
+
+export interface DirectoryValidationResult {
+  valid: boolean
+  structuralErrors: string[]
+  templateErrors: TemplateFileError[]
+  pack?: PackExport
+  source?: TreeSource
+}
+
+/**
+ * Validate a tree in full before any of it is written.
+ *
+ * Every failure is collected rather than thrown at the first one: a user fixing a merge wants
+ * the whole list, and a partially applied tree is worse than a refused one.
+ */
+export function validateTree(contents: Map<string, string>): DirectoryValidationResult {
+  const { templates: files, duplicates } = collectTemplateFiles([...contents.keys()])
+
+  if (duplicates.length > 0) {
+    return {
+      valid: false,
+      structuralErrors: duplicates.map(
+        (d) => `Two files are both the template "${d.templateId}": ${d.paths.join(' and ')}`,
+      ),
+      templateErrors: [],
+    }
+  }
+
+  const packFileText = contents.get(PACK_FILE)
+  if (packFileText === undefined) {
+    return {
+      valid: false,
+      structuralErrors: [`This folder has no ${PACK_FILE}, so it is not an exported prompt pack.`],
+      templateErrors: [],
+    }
+  }
+
+  const packFile = parsePackFile(packFileText)
+  if (!packFile.ok) {
+    return { valid: false, structuralErrors: [packFile.error], templateErrors: [] }
+  }
+
+  const templateIds = [...files.keys()].sort()
+  const candidate = {
+    version: 1,
+    name: packFile.value.name,
+    description: packFile.value.description,
+    author: packFile.value.author,
+    templates: templateIds.map((templateId) => ({
+      templateId,
+      content: parseTemplateFile(contents.get(files.get(templateId)!)!),
+    })),
+    variables: packFile.value.variables,
+  }
+
+  const structural = validatePackImport(candidate)
+  if (!structural.valid) {
+    return { valid: false, structuralErrors: structural.errors ?? [], templateErrors: [] }
+  }
+
+  const templateErrors: TemplateFileError[] = []
+  for (const template of structural.pack!.templates) {
+    const parsed = templateEngine.parseTemplate(template.content)
+    if (!parsed.success) {
+      templateErrors.push({
+        templateId: template.templateId,
+        path: files.get(template.templateId)!,
+        error: parsed.error ?? 'Unknown parse error',
+      })
+    }
+  }
+
+  if (templateErrors.length > 0) {
+    return { valid: false, structuralErrors: [], templateErrors }
+  }
+
+  return {
+    valid: true,
+    structuralErrors: [],
+    templateErrors: [],
+    pack: structural.pack,
+    source: packFile.value.source,
+  }
+}

--- a/src/lib/services/packs/directory/reference.test.ts
+++ b/src/lib/services/packs/directory/reference.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest'
+import { SYSTEM_VARIABLES, RUNTIME_VARIABLES } from '$lib/services/templates/variables'
+import {
+  aboutDoc,
+  gitattributesDoc,
+  templateStatusDoc,
+  templateVariablesDoc,
+  variablesDoc,
+} from './reference'
+
+describe('variablesDoc', () => {
+  it('lists every registered system variable', () => {
+    const doc = variablesDoc('system')
+    for (const variable of SYSTEM_VARIABLES) {
+      expect(doc).toContain(`\`${variable.name}\``)
+      expect(doc).toContain(variable.description)
+    }
+  })
+
+  it('lists every registered runtime variable', () => {
+    const doc = variablesDoc('runtime')
+    for (const variable of RUNTIME_VARIABLES) {
+      expect(doc).toContain(`\`${variable.name}\``)
+    }
+  })
+
+  it('spells out an enum variable’s options', () => {
+    expect(variablesDoc('system')).toContain('enum (adventure, creative-writing)')
+  })
+
+  it('is deterministic', () => {
+    expect(variablesDoc('runtime')).toBe(variablesDoc('runtime'))
+  })
+})
+
+describe('templateVariablesDoc', () => {
+  const templates = new Map([
+    ['adventure', 'You are narrating for {{ protagonistName }} in {{ genre }}.'],
+    ['classifier', 'Classify what {{ protagonistName }} did.'],
+    ['static-one', 'No variables here.'],
+  ])
+
+  it('lists the variables a template references', () => {
+    const doc = templateVariablesDoc(templates)
+    const byTemplate = doc.slice(doc.indexOf('## By template'), doc.indexOf('## By variable'))
+    expect(byTemplate).toContain('`adventure` | `genre`, `protagonistName`')
+    expect(byTemplate).toContain('`static-one` | —')
+  })
+
+  it('lists the templates that reference a variable', () => {
+    const doc = templateVariablesDoc(templates)
+    const byVariable = doc.slice(doc.indexOf('## By variable'))
+    expect(byVariable).toContain('`protagonistName` | yes | `adventure`, `classifier`')
+    expect(byVariable).toContain('`genre` | yes | `adventure`')
+  })
+
+  it('is deterministic whatever order the templates arrive in', () => {
+    const reversed = new Map([...templates.entries()].reverse())
+    expect(templateVariablesDoc(reversed)).toBe(templateVariablesDoc(templates))
+  })
+})
+
+describe('templateStatusDoc', () => {
+  const shippedHashes = new Map([
+    ['current-one', 'hash-a'],
+    ['customised-one', 'hash-b'],
+    ['behind-one', 'hash-new'],
+  ])
+
+  const rows = [
+    { templateId: 'current-one', contentHash: 'hash-a', baselineHash: 'hash-a' },
+    { templateId: 'customised-one', contentHash: 'edited', baselineHash: 'hash-b' },
+    { templateId: 'behind-one', contentHash: 'edited', baselineHash: 'hash-old' },
+    { templateId: 'retired-one', contentHash: 'edited', baselineHash: 'hash-c' },
+  ]
+
+  it('separates behind from customised for the built-in pack, and names retired ids', () => {
+    const doc = templateStatusDoc({ kind: 'default-pack', rows, shippedHashes })
+
+    const behind = doc.slice(doc.indexOf('## Edited, and newer'), doc.indexOf('## Edited\n'))
+    expect(behind).toContain('`behind-one`')
+    expect(behind).not.toContain('`customised-one`')
+
+    expect(doc).toContain('## No longer shipped')
+    expect(doc).toContain('`retired-one`')
+    expect(doc).not.toContain('`current-one`')
+  })
+
+  it('reports a custom pack on edited-or-not alone', () => {
+    const doc = templateStatusDoc({ kind: 'custom-pack', rows })
+
+    expect(doc).not.toContain('## Edited, and newer')
+    expect(doc).not.toContain('No longer shipped')
+    expect(doc).toContain('`customised-one`')
+    expect(doc).toContain('`behind-one`')
+    expect(doc).toContain('`retired-one`')
+    expect(doc).not.toContain('`current-one`')
+  })
+
+  it('reports nothing edited for a shipped baseline', () => {
+    const doc = templateStatusDoc({ kind: 'shipped-baseline' })
+    expect(doc).toContain('No template in this export carries an edit made in the app.')
+    expect(doc).toContain('merge base you can trust')
+  })
+
+  it('reports nothing edited for an untouched pack', () => {
+    const untouched = [{ templateId: 'a', contentHash: 'h', baselineHash: 'h' }]
+    expect(templateStatusDoc({ kind: 'custom-pack', rows: untouched })).toContain(
+      'No template in this export carries an edit made in the app.',
+    )
+  })
+})
+
+describe('generated root files', () => {
+  it('pins line endings and nothing else', () => {
+    expect(gitattributesDoc()).toBe('* text eol=lf\n')
+  })
+
+  it('explains the identity rule, what import ignores, and that replacement deletes', () => {
+    const doc = aboutDoc()
+    expect(doc).toContain("A file's name is its identity.")
+    expect(doc).toContain('README.md')
+    expect(doc).toContain('_reference/')
+    expect(doc).toContain('Import replaces')
+    expect(doc).toContain('Runtime variables are not part of this format.')
+  })
+
+  it('explains that the files are Liquid and what happens when one is broken', () => {
+    const doc = aboutDoc()
+    expect(doc).toContain('Liquid templates, not Markdown')
+    expect(doc).toContain('{{ variableName }}')
+    expect(doc).toContain('The whole import is refused')
+    expect(doc).toContain('renders an unknown name as an empty string')
+  })
+})

--- a/src/lib/services/packs/directory/reference.test.ts
+++ b/src/lib/services/packs/directory/reference.test.ts
@@ -125,6 +125,12 @@ describe('generated root files', () => {
     expect(doc).toContain('Runtime variables are not part of this format.')
   })
 
+  it('warns that a file kept beside the prompts is treated as a prompt', () => {
+    const doc = aboutDoc()
+    expect(doc).toContain('Do not keep your own notes inside a group folder')
+    expect(doc).toContain('removed on the next export')
+  })
+
   it('explains that the files are Liquid and what happens when one is broken', () => {
     const doc = aboutDoc()
     expect(doc).toContain('Liquid templates, not Markdown')

--- a/src/lib/services/packs/directory/reference.ts
+++ b/src/lib/services/packs/directory/reference.ts
@@ -328,7 +328,13 @@ Only \`${PACK_FILE}\` and the \`.md\` files inside folders. Ignored, silently:
 - Anything that is not a \`.md\` file
 
 Two files anywhere in the tree with the same name are refused, since the folder does not
-disambiguate them.
+disambiguate them. Names are compared without case, because two spellings are one file on
+Windows and macOS.
+
+**Do not keep your own notes inside a group folder.** Any \`.md\` there is a prompt as far as
+this format is concerned: it imports as one, and if the pack has no such prompt it is
+removed on the next export. The root is the safe place for your own files — the export
+never reads or deletes anything there apart from the generated files named above.
 
 ## Import replaces
 

--- a/src/lib/services/packs/directory/reference.ts
+++ b/src/lib/services/packs/directory/reference.ts
@@ -1,0 +1,348 @@
+/**
+ * The generated files of an exported tree: what a template may reference, what references
+ * it, what carries an edit, and what the directory itself is.
+ *
+ * All of it is written from the app's own definitions on every export and never read back,
+ * so it follows a new release without anyone maintaining it.
+ */
+
+import { variableRegistry } from '$lib/services/templates/variables'
+import { templateEngine } from '$lib/services/templates/engine'
+import type { VariableCategory, VariableDefinition } from '$lib/services/templates/types'
+import { classifyTemplate, isUntouched } from '../staleness'
+import type { PackTemplate } from '../types'
+import {
+  ABOUT_FILE,
+  GITATTRIBUTES_FILE,
+  PACK_FILE,
+  REFERENCE_DIR,
+  UNGROUPED_DIR,
+  USER_HALF_SUFFIX,
+} from './layout'
+
+/** Cells are pipe-separated, so a description containing one would split the row. */
+function cell(text: string): string {
+  return text.replace(/\|/g, '\\|')
+}
+
+function table(headers: string[], rows: string[][]): string {
+  const lines = [`| ${headers.join(' | ')} |`, `| ${headers.map(() => '---').join(' | ')} |`]
+  for (const row of rows) lines.push(`| ${row.join(' | ')} |`)
+  return lines.join('\n')
+}
+
+function describeType(definition: VariableDefinition): string {
+  if (definition.type === 'enum' && definition.enumValues) {
+    return `enum (${definition.enumValues.join(', ')})`
+  }
+  return definition.type
+}
+
+const CATEGORY_INTRO: Record<'system' | 'runtime', string> = {
+  system:
+    'Filled from the story a prompt is being rendered for. Available in every template, though a value may be empty outside a story.',
+  runtime:
+    'Injected by the service that renders the prompt. A variable is only filled in the templates its own service renders — referencing it elsewhere leaves it empty.',
+}
+
+/** One file per variable category, listing what a template may reference. */
+export function variablesDoc(category: 'system' | 'runtime'): string {
+  const definitions = [...variableRegistry.getByCategory(category as VariableCategory)].sort(
+    (a, b) => a.name.localeCompare(b.name),
+  )
+
+  const rows = definitions.map((definition) => [
+    `\`${definition.name}\``,
+    cell(describeType(definition)),
+    definition.required ? 'yes' : 'no',
+    cell(definition.description),
+  ])
+
+  return [
+    `# ${category === 'system' ? 'System' : 'Runtime'} variables`,
+    '',
+    CATEGORY_INTRO[category],
+    '',
+    'Generated on export. Editing this file changes nothing.',
+    '',
+    table(['Variable', 'Type', 'Required', 'Description'], rows),
+    '',
+  ].join('\n')
+}
+
+/** Which variables each exported template references, and which templates reference each variable. */
+export function templateVariablesDoc(templates: Map<string, string>): string {
+  const byTemplate = [...templates.keys()].sort().map((templateId) => {
+    const names = [
+      ...new Set(templateEngine.extractVariableNames(templates.get(templateId)!)),
+    ].sort()
+    return { templateId, names }
+  })
+
+  const byVariable = new Map<string, string[]>()
+  for (const { templateId, names } of byTemplate) {
+    for (const name of names) {
+      const existing = byVariable.get(name)
+      if (existing) existing.push(templateId)
+      else byVariable.set(name, [templateId])
+    }
+  }
+
+  const knownFirst = [...byVariable.keys()].sort()
+
+  return [
+    '# Templates and variables',
+    '',
+    'Which variables each template in this export references, and which templates reference each',
+    'variable. Generated on export. Editing this file changes nothing.',
+    '',
+    '## By template',
+    '',
+    table(
+      ['Template', 'References'],
+      byTemplate.map(({ templateId, names }) => [
+        `\`${templateId}\``,
+        names.length > 0 ? names.map((n) => `\`${n}\``).join(', ') : '—',
+      ]),
+    ),
+    '',
+    '## By variable',
+    '',
+    table(
+      ['Variable', 'Known', 'Referenced by'],
+      knownFirst.map((name) => [
+        `\`${name}\``,
+        variableRegistry.has(name) ? 'yes' : 'no',
+        byVariable
+          .get(name)!
+          .map((id) => `\`${id}\``)
+          .join(', '),
+      ]),
+    ),
+    '',
+  ].join('\n')
+}
+
+type StatusRow = Pick<PackTemplate, 'templateId' | 'contentHash' | 'baselineHash'>
+
+/**
+ * What the status report is being written for.
+ *
+ * The three-state vocabulary only means something when a row's baseline *is* the shipped
+ * text, so it is offered for the built-in pack alone. A custom pack's baseline is the file
+ * its author wrote, and comparing that against what Aventuras ships answers no question
+ * anyone asked.
+ */
+export type StatusSource =
+  | { kind: 'default-pack'; rows: StatusRow[]; shippedHashes: Map<string, string> }
+  | { kind: 'custom-pack'; rows: StatusRow[] }
+  | { kind: 'shipped-baseline' }
+
+const NOTHING_EDITED = 'No template in this export carries an edit made in the app.'
+
+function defaultPackStatus(rows: StatusRow[], shippedHashes: Map<string, string>): string[] {
+  const customised: string[] = []
+  const behind: string[] = []
+  const unknown: string[] = []
+
+  for (const row of [...rows].sort((a, b) => a.templateId.localeCompare(b.templateId))) {
+    const state = classifyTemplate(row, shippedHashes.get(row.templateId))
+    if (state === null) unknown.push(row.templateId)
+    else if (state === 'behind') behind.push(row.templateId)
+    else if (state === 'customised') customised.push(row.templateId)
+  }
+
+  const sections: string[] = [
+    'This export came from the built-in pack as it is currently stored, so it carries any edit made',
+    'in the app. Those edits become part of whatever you commit — if you meant to capture the prompts',
+    'this release ships, export the shipped baseline instead.',
+    '',
+  ]
+
+  if (customised.length === 0 && behind.length === 0 && unknown.length === 0) {
+    sections.push(NOTHING_EDITED, '')
+    return sections
+  }
+
+  if (behind.length > 0) {
+    sections.push(
+      '## Edited, and newer text has shipped since',
+      '',
+      'These carry your edit *and* the app has changed its own text for them since you made it.',
+      '',
+      ...behind.map((id) => `- \`${id}\``),
+      '',
+    )
+  }
+  if (customised.length > 0) {
+    sections.push(
+      '## Edited',
+      '',
+      'These carry your edit; the app ships nothing newer for them.',
+      '',
+      ...customised.map((id) => `- \`${id}\``),
+      '',
+    )
+  }
+  if (unknown.length > 0) {
+    sections.push(
+      '## No longer shipped',
+      '',
+      `The app no longer ships these ids. They export to \`${UNGROUPED_DIR}/\`.`,
+      '',
+      ...unknown.map((id) => `- \`${id}\``),
+      '',
+    )
+  }
+  return sections
+}
+
+function customPackStatus(rows: StatusRow[]): string[] {
+  const edited = rows
+    .filter((row) => !isUntouched(row))
+    .map((row) => row.templateId)
+    .sort()
+
+  const sections: string[] = [
+    'This export came from a custom pack. A custom pack’s baseline is whatever it last received,',
+    'not the text Aventuras ships, so the only question worth asking is whether a template has been',
+    'edited in the app since then — those edits are what replacing this pack from a directory discards.',
+    '',
+  ]
+
+  if (edited.length === 0) {
+    sections.push(NOTHING_EDITED, '')
+    return sections
+  }
+
+  sections.push(
+    '## Edited in the app since this pack last received its contents',
+    '',
+    ...edited.map((id) => `- \`${id}\``),
+    '',
+  )
+  return sections
+}
+
+/** Names the templates carrying an edit, in the vocabulary that fits where the export came from. */
+export function templateStatusDoc(source: StatusSource): string {
+  const body =
+    source.kind === 'shipped-baseline'
+      ? [
+          'This export came from the text this version of the app ships, not from any pack, so nothing',
+          'in it can carry an edit. It is a merge base you can trust.',
+          '',
+          NOTHING_EDITED,
+          '',
+        ]
+      : source.kind === 'default-pack'
+        ? defaultPackStatus(source.rows, source.shippedHashes)
+        : customPackStatus(source.rows)
+
+  return [
+    '# Template status',
+    '',
+    'Generated on export. Editing this file changes nothing.',
+    '',
+    ...body,
+  ].join('\n')
+}
+
+/** Pins line endings so an editor on Windows cannot turn a merge into a whole-file conflict. */
+export function gitattributesDoc(): string {
+  return '* text eol=lf\n'
+}
+
+/** What the directory is, for a reader who has only the tree. */
+export function aboutDoc(): string {
+  return `# About this directory
+
+This is a prompt pack exported from Aventuras as Markdown, so it can be searched, diffed and
+merged with ordinary tools. It is regenerated on every export — including this file.
+
+## What is here
+
+- **Group folders** (\`Story Generation/\`, \`Analysis/\`, …) hold one \`.md\` file per stored
+  template. The folder is presentation only: it names the group the app lists that template
+  under, and it changes when the app regroups a template. It is **not** part of the
+  template's identity, so moving a file between folders changes nothing.
+- **A file's name is its identity.** \`adventure.md\` is the template \`adventure\`. A file
+  ending \`${USER_HALF_SUFFIX}.md\` is that prompt's user-message half, stored separately from its
+  system half.
+- **\`${UNGROUPED_DIR}/\`** holds templates whose id this version of the app no longer ships.
+- **\`${PACK_FILE}\`** carries the pack's name, description, author and custom variables, plus the
+  format and app versions this tree was written by.
+- **\`${REFERENCE_DIR}/\`** is generated reference material: the variables a template may
+  reference, which templates reference which, and which templates carry an edit. It is never
+  read back.
+- **\`${ABOUT_FILE}\`** and **\`${GITATTRIBUTES_FILE}\`** are generated and overwritten on every export.
+
+## What these files actually are
+
+**Liquid templates, not Markdown.** The \`.md\` extension is for your tooling's benefit — it
+makes the files open, diff and search as text everywhere — but nothing renders them as
+Markdown. The app parses each one with Liquid and sends the result to the model. Markdown
+holding Liquid is how Jekyll works too, so the pairing is ordinary; it just means the
+extension describes the prose, not the syntax.
+
+Two constructs appear:
+
+- \`{{ variableName }}\` is replaced by that variable's value.
+- \`{% if ... %}\` … \`{% endif %}\` (and \`elsif\`, \`else\`, \`unless\`, \`for\`, \`comment\`) decide
+  whether a passage appears at all. Most prompts here use them to drop a heading or a bullet
+  when the story has nothing to put in it.
+
+\`${REFERENCE_DIR}/\` lists every variable the app can fill, what it means, and which prompts
+already reference it. That listing is generated from this exact version of the app, so it is
+the authority on what a name has to be.
+
+Your editor will most likely highlight these as Markdown, which is wrong but harmless — the
+Liquid tags show as plain text. Editor extensions for Liquid exist if you want real
+highlighting; nothing here depends on having one.
+
+## When a template is broken
+
+Two kinds of mistake, and they are treated very differently.
+
+**Liquid that does not parse** — a tag left unclosed, an \`{% endif %}\` that does not match its
+opening, an unclosed \`{{\`, or a filter the app does not have. The whole import is refused
+before anything is written. Every failing file is named with the line and column of the
+fault, and the pack is left exactly as it was. Nothing is partially applied, so fixing the
+file and importing again is always safe.
+
+**A variable name that does not exist** — this is *not* an error, and nothing will tell you
+about it. Liquid renders an unknown name as an empty string, so \`{{ protagonistNmae }}\`
+imports cleanly, generates cleanly, and quietly contributes nothing to the prompt forever.
+A misspelling costs you the whole line it was on.
+
+That asymmetry is worth remembering when merging: a conflict that mangles a tag stops you at
+the door, while one that mangles a variable name passes silently. Check names against
+\`${REFERENCE_DIR}/\` rather than assuming a clean import means a correct prompt.
+
+## What import reads
+
+Only \`${PACK_FILE}\` and the \`.md\` files inside folders. Ignored, silently:
+
+- Markdown files at the root — so your own \`README.md\` and notes are safe
+- Any folder whose name starts with \`_\`, including \`${REFERENCE_DIR}/\`
+- Anything that is not a \`.md\` file
+
+Two files anywhere in the tree with the same name are refused, since the folder does not
+disambiguate them.
+
+## Import replaces
+
+Importing this directory over a pack replaces that pack's templates and custom variables
+with what is here. A template this tree does not contain is removed from the pack. Deleting
+a file is therefore a real deletion — which is why it should be a commit you can see.
+
+Runtime variables are not part of this format. An import leaves a pack's runtime variable
+definitions, and every value stored against them, exactly as they were.
+
+## Line endings
+
+\`${GITATTRIBUTES_FILE}\` pins this tree to line-feed endings. Without it an editor on Windows can
+rewrite every file, turning the next merge into a conflict in all of them. If you use git,
+keep that file.
+`
+}

--- a/src/lib/services/packs/directory/roundTrip.test.ts
+++ b/src/lib/services/packs/directory/roundTrip.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Export and import agreeing with each other.
+ *
+ * The unit tests either side pin half of it each. What they cannot show is that what the
+ * exporter wrote is exactly what the importer reads back — including through an editor that
+ * rewrites every line ending, which is the ordinary case on Windows.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { hashContent } from '../hash'
+import { isUntouched } from '../staleness'
+import { classifyPath } from './layout'
+import { validateTree } from './parse'
+import { buildTree, type Tree } from './tree'
+
+const stored = [
+  { templateId: 'adventure', content: 'Narrate for {{ protagonistName }}.\n\nStay in scene.' },
+  { templateId: 'adventure-user', content: 'The player did: {{ userAction }}' },
+  { templateId: 'classifier', content: 'Classify.\n\n{% if mode %}Adventure.{% endif %}' },
+]
+
+/** What `readTree` hands the importer: the tree, minus everything the import ignores. */
+function asReadContents(tree: Tree, rewriteLineEndings = false): Map<string, string> {
+  const contents = new Map<string, string>()
+  for (const [path, content] of tree) {
+    if (classifyPath(path) === 'ignored') continue
+    contents.set(path, rewriteLineEndings ? content.replace(/\n/g, '\r\n') : content)
+  }
+  return contents
+}
+
+async function exportThenImport(rewriteLineEndings: boolean) {
+  const rows = await Promise.all(
+    stored.map(async (row) => ({ ...row, contentHash: await hashContent(row.content) })),
+  )
+
+  const tree = buildTree({
+    source: 'pack',
+    appVersion: '0.7.9',
+    name: 'My Pack',
+    templates: stored,
+    variables: [],
+    status: { kind: 'custom-pack', rows: [] },
+  })
+
+  const result = validateTree(asReadContents(tree, rewriteLineEndings))
+  expect(result.valid).toBe(true)
+
+  return { rows, imported: result.pack!.templates }
+}
+
+describe.each([
+  ['written as exported', false],
+  ['rewritten with CRLF endings', true],
+])('a tree %s', (_label, rewriteLineEndings) => {
+  it('brings every stored row back', async () => {
+    const { rows, imported } = await exportThenImport(rewriteLineEndings)
+    expect(imported.map((t) => t.templateId).sort()).toEqual(rows.map((r) => r.templateId).sort())
+  })
+
+  it('leaves every content hash unchanged', async () => {
+    const { rows, imported } = await exportThenImport(rewriteLineEndings)
+
+    for (const row of rows) {
+      const back = imported.find((t) => t.templateId === row.templateId)!
+      expect(await hashContent(back.content)).toBe(row.contentHash)
+    }
+  })
+
+  it('reports no template as edited once written as the pack’s baseline', async () => {
+    const { imported } = await exportThenImport(rewriteLineEndings)
+
+    // An import writes each row as its own baseline, which is what `isBaseline: true` means
+    // at the database boundary.
+    for (const template of imported) {
+      const hash = await hashContent(template.content)
+      expect(isUntouched({ contentHash: hash, baselineHash: hash })).toBe(true)
+    }
+  })
+
+  it('renders the same prompt text as before the round trip', async () => {
+    const { imported } = await exportThenImport(rewriteLineEndings)
+
+    for (const row of stored) {
+      const back = imported.find((t) => t.templateId === row.templateId)!
+      expect(back.content.replace(/\r\n/g, '\n')).toBe(row.content)
+    }
+  })
+})

--- a/src/lib/services/packs/directory/serialize.test.ts
+++ b/src/lib/services/packs/directory/serialize.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest'
+import { hashContent } from '../hash'
+import {
+  DIRECTORY_FORMAT_VERSION,
+  parsePackFile,
+  parseTemplateFile,
+  serializePackFile,
+  serializeTemplate,
+  type PackFile,
+} from './serialize'
+
+const packFile: PackFile = {
+  formatVersion: DIRECTORY_FORMAT_VERSION,
+  appVersion: '0.7.9',
+  source: 'pack',
+  name: 'My Pack',
+  description: 'A pack',
+  author: 'Someone',
+  variables: [
+    {
+      variableName: 'writing_style',
+      displayName: 'Writing Style',
+      variableType: 'enum',
+      isRequired: true,
+      sortOrder: 1,
+      defaultValue: 'terse',
+      enumOptions: [
+        { label: 'Terse', value: 'terse' },
+        { label: 'Lush', value: 'lush' },
+      ],
+    },
+    {
+      variableName: 'aside_frequency',
+      displayName: 'Aside Frequency',
+      variableType: 'number',
+      isRequired: false,
+      sortOrder: 0,
+    },
+  ],
+}
+
+describe('serializePackFile', () => {
+  it('is byte-identical across two serialisations of the same pack', () => {
+    expect(serializePackFile(packFile)).toBe(serializePackFile(packFile))
+  })
+
+  it('orders variables by sortOrder then name, whatever order they arrive in', () => {
+    const reversed: PackFile = { ...packFile, variables: [...packFile.variables].reverse() }
+    expect(serializePackFile(reversed)).toBe(serializePackFile(packFile))
+
+    const yaml = serializePackFile(packFile)
+    expect(yaml.indexOf('aside_frequency')).toBeLessThan(yaml.indexOf('writing_style'))
+  })
+
+  it('writes the versions and source, and no timestamp', () => {
+    const yaml = serializePackFile(packFile)
+    expect(yaml).toContain(`formatVersion: ${DIRECTORY_FORMAT_VERSION}`)
+    expect(yaml).toContain('appVersion: 0.7.9')
+    expect(yaml).toContain('source: pack')
+    expect(yaml).not.toMatch(/\d{4}-\d{2}-\d{2}/)
+  })
+
+  it('omits an absent description and author rather than writing null', () => {
+    const bare: PackFile = { ...packFile, description: undefined, author: undefined }
+    const yaml = serializePackFile(bare)
+    expect(yaml).not.toContain('description:')
+    expect(yaml).not.toContain('author:')
+  })
+})
+
+describe('parsePackFile', () => {
+  it('round-trips a written file', () => {
+    const result = parsePackFile(serializePackFile(packFile))
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value.name).toBe('My Pack')
+      expect(result.value.variables).toHaveLength(2)
+      expect(result.value.variables[0].variableName).toBe('aside_frequency')
+    }
+  })
+
+  it('refuses a format version it cannot read, naming both versions', () => {
+    const future = serializePackFile({ ...packFile, formatVersion: DIRECTORY_FORMAT_VERSION + 1 })
+    const result = parsePackFile(future)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toContain(String(DIRECTORY_FORMAT_VERSION + 1))
+      expect(result.error).toContain(String(DIRECTORY_FORMAT_VERSION))
+    }
+  })
+
+  it('refuses malformed YAML', () => {
+    const result = parsePackFile('name: [unclosed')
+    expect(result.ok).toBe(false)
+  })
+
+  it('refuses a file missing required fields', () => {
+    const result = parsePackFile('name: Only a name\n')
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toContain('formatVersion')
+  })
+})
+
+describe('template text', () => {
+  it('writes line feeds ending in exactly one newline', () => {
+    expect(serializeTemplate('a\r\nb')).toBe('a\nb\n')
+    expect(serializeTemplate('a\nb\n\n\n')).toBe('a\nb\n')
+  })
+
+  it('leaves the stored hash untouched across a round trip through CRLF', () => {
+    const stored = 'You are a narrator.\n\n{{ protagonistName }} acts.'
+    const written = serializeTemplate(stored)
+    const throughWindowsEditor = written.replace(/\n/g, '\r\n')
+
+    expect(parseTemplateFile(throughWindowsEditor)).toBe(stored)
+    return Promise.all([
+      hashContent(stored),
+      hashContent(parseTemplateFile(throughWindowsEditor)),
+    ]).then(([before, after]) => expect(after).toBe(before))
+  })
+
+  it('is stable across export, import and export again', () => {
+    const stored = 'line one\nline two'
+    const once = serializeTemplate(stored)
+    expect(serializeTemplate(parseTemplateFile(once))).toBe(once)
+  })
+})

--- a/src/lib/services/packs/directory/serialize.ts
+++ b/src/lib/services/packs/directory/serialize.ts
@@ -1,0 +1,122 @@
+/**
+ * Reading and writing the files of an exported pack directory.
+ *
+ * Everything here is deterministic: the same pack serialises to the same bytes, because a
+ * tree that differs between two exports of identical content cannot be merged.
+ */
+
+import * as z from 'zod'
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml'
+import { CustomVariableSchema } from '../validation'
+
+/** Version of the directory layout, not of any pack. */
+export const DIRECTORY_FORMAT_VERSION = 1
+
+/** Whether a tree came from a pack's stored rows or from the text the app ships. */
+export type TreeSource = 'pack' | 'shipped-baseline'
+
+const PackFileSchema = z.object({
+  formatVersion: z.number().int().positive(),
+  appVersion: z.string(),
+  source: z.enum(['pack', 'shipped-baseline']),
+  name: z.string().min(1),
+  description: z.string().optional(),
+  author: z.string().optional(),
+  variables: z.array(CustomVariableSchema),
+})
+
+export type PackFile = z.infer<typeof PackFileSchema>
+
+export type ParseResult<T> = { ok: true; value: T } | { ok: false; error: string }
+
+/** Ordering that survives a rename: author intent first, then name for anything it leaves tied. */
+function bySortOrderThenName(
+  a: PackFile['variables'][number],
+  b: PackFile['variables'][number],
+): number {
+  const order = (a.sortOrder ?? 0) - (b.sortOrder ?? 0)
+  return order !== 0 ? order : a.variableName.localeCompare(b.variableName)
+}
+
+/**
+ * Write `pack.yaml`.
+ *
+ * Keys are emitted in a fixed order and no timestamp is written: a value that changes
+ * between two exports of the same pack conflicts on every merge and says nothing the commit
+ * does not already.
+ */
+export function serializePackFile(file: PackFile): string {
+  const ordered: Record<string, unknown> = {
+    formatVersion: file.formatVersion,
+    appVersion: file.appVersion,
+    source: file.source,
+    name: file.name,
+  }
+  if (file.description !== undefined) ordered.description = file.description
+  if (file.author !== undefined) ordered.author = file.author
+
+  ordered.variables = [...file.variables].sort(bySortOrderThenName).map((variable) => {
+    const entry: Record<string, unknown> = {
+      variableName: variable.variableName,
+      displayName: variable.displayName,
+      variableType: variable.variableType,
+      isRequired: variable.isRequired,
+      sortOrder: variable.sortOrder ?? 0,
+    }
+    if (variable.description !== undefined) entry.description = variable.description
+    if (variable.defaultValue !== undefined) entry.defaultValue = variable.defaultValue
+    if (variable.enumOptions !== undefined) {
+      entry.enumOptions = variable.enumOptions.map((option) => ({
+        label: option.label,
+        value: option.value,
+      }))
+    }
+    return entry
+  })
+
+  return stringifyYaml(ordered, { lineWidth: 0 })
+}
+
+/** Read `pack.yaml`, refusing a format this version cannot read. */
+export function parsePackFile(text: string): ParseResult<PackFile> {
+  let data: unknown
+  try {
+    data = parseYaml(text)
+  } catch (e) {
+    return { ok: false, error: `pack.yaml is not valid YAML: ${(e as Error).message}` }
+  }
+
+  const result = PackFileSchema.safeParse(data)
+  if (!result.success) {
+    const issues = result.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ')
+    return { ok: false, error: `pack.yaml is missing or malformed: ${issues}` }
+  }
+
+  if (result.data.formatVersion > DIRECTORY_FORMAT_VERSION) {
+    return {
+      ok: false,
+      error: `pack.yaml declares format version ${result.data.formatVersion}, but this version of the app reads up to ${DIRECTORY_FORMAT_VERSION}. Update the app to import this directory.`,
+    }
+  }
+
+  return { ok: true, value: result.data }
+}
+
+function toLineFeeds(content: string): string {
+  return content.replace(/\r\n/g, '\n')
+}
+
+/** Write a template's text: line feeds, ending in exactly one newline. */
+export function serializeTemplate(content: string): string {
+  return `${toLineFeeds(content).replace(/\n+$/, '')}\n`
+}
+
+/**
+ * Read a template's text back.
+ *
+ * Carriage returns an external editor introduced are dropped, so a round trip through one
+ * leaves the stored hash — which normalises the same way — untouched.
+ */
+export function parseTemplateFile(text: string): string {
+  return toLineFeeds(text).replace(/\n+$/, '')
+}

--- a/src/lib/services/packs/directory/support.test.ts
+++ b/src/lib/services/packs/directory/support.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { supportsDirectoryTransfer } from './support'
+
+const ANDROID_UA =
+  'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Mobile Safari/537.36'
+const DESKTOP_UA =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36'
+
+function withUserAgent(userAgent: string) {
+  vi.stubGlobal('navigator', { userAgent })
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('supportsDirectoryTransfer', () => {
+  it('is unavailable on Android, which has no folder picker', () => {
+    withUserAgent(ANDROID_UA)
+    expect(supportsDirectoryTransfer()).toBe(false)
+  })
+
+  it('is available on desktop', () => {
+    withUserAgent(DESKTOP_UA)
+    expect(supportsDirectoryTransfer()).toBe(true)
+  })
+})

--- a/src/lib/services/packs/directory/support.ts
+++ b/src/lib/services/packs/directory/support.ts
@@ -1,0 +1,12 @@
+import { isAndroid } from '$lib/utils/platform'
+
+/**
+ * Whether this platform can export or import a pack as a directory.
+ *
+ * Android has no folder picker at all -- `tauri-plugin-dialog` returns
+ * `FolderPickerNotImplemented` there -- so the actions are hidden rather than left to fail.
+ * The single-file `.prompt.json` export stays available on both.
+ */
+export function supportsDirectoryTransfer(): boolean {
+  return !isAndroid()
+}

--- a/src/lib/services/packs/directory/tree.test.ts
+++ b/src/lib/services/packs/directory/tree.test.ts
@@ -125,6 +125,25 @@ describe('unwritable template ids', () => {
     ).toThrow(/custom\/example/)
   })
 
+  it('refuses an id Windows cannot use as a filename', () => {
+    expect(() => buildTree({ ...input, templates: [{ templateId: 'a:b', content: 'x' }] })).toThrow(
+      /a:b/,
+    )
+  })
+
+  // One file on Windows and macOS, so one would silently overwrite the other.
+  it('refuses two ids that differ only in capitalisation', () => {
+    expect(() =>
+      buildTree({
+        ...input,
+        templates: [
+          { templateId: 'adventure', content: 'x' },
+          { templateId: 'Adventure', content: 'y' },
+        ],
+      }),
+    ).toThrow(/capitalisation/)
+  })
+
   it('accepts an id starting with an underscore, which is a template and not a folder', () => {
     const built = buildTree({ ...input, templates: [{ templateId: '_scratch', content: 'x' }] })
     expect(built.has(`${UNGROUPED_DIR}/_scratch.md`)).toBe(true)

--- a/src/lib/services/packs/directory/tree.test.ts
+++ b/src/lib/services/packs/directory/tree.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest'
+import { PROMPT_TEMPLATES } from '$lib/services/prompts/templates'
+import { ABOUT_FILE, GITATTRIBUTES_FILE, PACK_FILE, REFERENCE_DIR, UNGROUPED_DIR } from './layout'
+import {
+  buildShippedBaselineTree,
+  buildTree,
+  planPrune,
+  shippedTemplateRows,
+  type TreeInput,
+} from './tree'
+
+const input: TreeInput = {
+  source: 'pack',
+  appVersion: '0.7.9',
+  name: 'My Pack',
+  templates: [
+    { templateId: 'adventure', content: 'Narrate for {{ protagonistName }}.' },
+    { templateId: 'adventure-user', content: 'The player did: {{ userAction }}' },
+    { templateId: 'retired-prompt', content: 'An id the app no longer ships.' },
+  ],
+  variables: [],
+  status: { kind: 'custom-pack', rows: [] },
+}
+
+describe('buildTree', () => {
+  it('is byte-identical across two builds of the same pack', () => {
+    const first = buildTree(input)
+    const second = buildTree(input)
+
+    expect([...second.keys()].sort()).toEqual([...first.keys()].sort())
+    for (const [path, content] of first) expect(second.get(path)).toBe(content)
+  })
+
+  it('writes one file per stored row plus the reserved files', () => {
+    const tree = buildTree(input)
+
+    expect(tree.has('Story Generation/adventure.md')).toBe(true)
+    expect(tree.has('Story Generation/adventure-user.md')).toBe(true)
+    expect(tree.has(`${UNGROUPED_DIR}/retired-prompt.md`)).toBe(true)
+
+    expect(tree.has(PACK_FILE)).toBe(true)
+    expect(tree.has(ABOUT_FILE)).toBe(true)
+    expect(tree.has(GITATTRIBUTES_FILE)).toBe(true)
+    expect(tree.has(`${REFERENCE_DIR}/system-variables.md`)).toBe(true)
+    expect(tree.has(`${REFERENCE_DIR}/runtime-variables.md`)).toBe(true)
+    expect(tree.has(`${REFERENCE_DIR}/template-variables.md`)).toBe(true)
+    expect(tree.has(`${REFERENCE_DIR}/template-status.md`)).toBe(true)
+  })
+
+  it('writes a template file as its text and nothing else', () => {
+    const tree = buildTree(input)
+    expect(tree.get('Story Generation/adventure.md')).toBe('Narrate for {{ protagonistName }}.\n')
+  })
+})
+
+describe('buildShippedBaselineTree', () => {
+  it('covers every shipped row', () => {
+    const tree = buildShippedBaselineTree('0.7.9')
+    const templateFiles = [...tree.keys()].filter(
+      (p) => !p.startsWith(REFERENCE_DIR) && p.endsWith('.md') && p.includes('/'),
+    )
+
+    expect(templateFiles).toHaveLength(shippedTemplateRows().length)
+    expect(shippedTemplateRows().length).toBeGreaterThan(PROMPT_TEMPLATES.length)
+  })
+
+  it('declares itself a shipped baseline with no custom variables', () => {
+    const packFile = buildShippedBaselineTree('0.7.9').get(PACK_FILE)!
+    expect(packFile).toContain('source: shipped-baseline')
+    expect(packFile).toContain('variables: []')
+  })
+
+  it('reports nothing edited', () => {
+    const status = buildShippedBaselineTree('0.7.9').get(`${REFERENCE_DIR}/template-status.md`)!
+    expect(status).toContain('No template in this export carries an edit made in the app.')
+  })
+
+  it('is unaffected by anything stored in a pack', () => {
+    // It reads PROMPT_TEMPLATES, so no pack argument exists to influence it.
+    const first = buildShippedBaselineTree('0.7.9')
+    const second = buildShippedBaselineTree('0.7.9')
+    for (const [path, content] of first) expect(second.get(path)).toBe(content)
+  })
+})
+
+describe('planPrune', () => {
+  const tree = buildTree(input)
+
+  it('removes a template file the export no longer writes', () => {
+    const stale = 'Analysis/dropped-prompt.md'
+    expect(planPrune([...tree.keys(), stale], tree)).toEqual([stale])
+  })
+
+  it('removes stale generated reference material', () => {
+    const stale = `${REFERENCE_DIR}/old-index.md`
+    expect(planPrune([...tree.keys(), stale], tree)).toEqual([stale])
+  })
+
+  it('leaves the user’s own files alone', () => {
+    const untouched = ['README.md', 'NOTES.md', '.git/config', '.gitignore', 'notes/todo.txt']
+    expect(planPrune([...tree.keys(), ...untouched], tree)).toEqual([])
+  })
+
+  it('leaves everything alone when the tree is unchanged', () => {
+    expect(planPrune([...tree.keys()], tree)).toEqual([])
+  })
+
+  // On Windows and macOS these two spellings are one file: pruning the existing spelling
+  // after writing the generated one deletes the template the export just wrote.
+  it('does not prune a file it just wrote under different casing', () => {
+    const existing = [...tree.keys()].map((p) => p.toLowerCase())
+    expect(planPrune(existing, tree)).toEqual([])
+  })
+
+  it('still prunes a genuinely stale file whose casing differs from nothing written', () => {
+    const stale = 'analysis/dropped-prompt.md'
+    expect(planPrune([...tree.keys(), stale], tree)).toEqual([stale])
+  })
+})
+
+describe('unwritable template ids', () => {
+  it('refuses an id holding a path separator rather than changing what it is', () => {
+    expect(() =>
+      buildTree({ ...input, templates: [{ templateId: 'custom/example', content: 'x' }] }),
+    ).toThrow(/custom\/example/)
+  })
+
+  it('accepts an id starting with an underscore, which is a template and not a folder', () => {
+    const built = buildTree({ ...input, templates: [{ templateId: '_scratch', content: 'x' }] })
+    expect(built.has(`${UNGROUPED_DIR}/_scratch.md`)).toBe(true)
+  })
+})

--- a/src/lib/services/packs/directory/tree.ts
+++ b/src/lib/services/packs/directory/tree.ts
@@ -1,0 +1,150 @@
+/**
+ * The contents of an exported tree, as a map of relative path to text.
+ *
+ * Building the tree is kept apart from writing it: the determinism the format depends on is
+ * a property of this map, and a map is something a test can compare byte for byte.
+ */
+
+import { PROMPT_TEMPLATES } from '$lib/services/prompts/templates'
+import type { PackExport } from '../validation'
+import {
+  ABOUT_FILE,
+  GITATTRIBUTES_FILE,
+  PACK_FILE,
+  REFERENCE_DIR,
+  USER_HALF_SUFFIX,
+  classifyPath,
+  isRoundTrippableId,
+  templatePath,
+} from './layout'
+import {
+  aboutDoc,
+  gitattributesDoc,
+  templateStatusDoc,
+  templateVariablesDoc,
+  variablesDoc,
+  type StatusSource,
+} from './reference'
+import {
+  DIRECTORY_FORMAT_VERSION,
+  serializePackFile,
+  serializeTemplate,
+  type TreeSource,
+} from './serialize'
+
+export interface StoredTemplate {
+  templateId: string
+  content: string
+}
+
+export interface TreeInput {
+  source: TreeSource
+  appVersion: string
+  name: string
+  description?: string
+  author?: string
+  templates: StoredTemplate[]
+  variables: PackExport['variables']
+  status: StatusSource
+}
+
+/** A tree, as relative path to file contents. */
+export type Tree = Map<string, string>
+
+/** Every row a full pack holds: each shipped template's system half, and its user half where one ships. */
+export function shippedTemplateRows(): StoredTemplate[] {
+  const rows: StoredTemplate[] = []
+  for (const template of PROMPT_TEMPLATES) {
+    rows.push({ templateId: template.id, content: template.content })
+    if (template.userContent !== undefined) {
+      rows.push({
+        templateId: `${template.id}${USER_HALF_SUFFIX}`,
+        content: template.userContent,
+      })
+    }
+  }
+  return rows
+}
+
+export function buildTree(input: TreeInput): Tree {
+  const unwritable = input.templates
+    .map((t) => t.templateId)
+    .filter((id) => !isRoundTrippableId(id))
+    .sort()
+
+  if (unwritable.length > 0) {
+    throw new Error(
+      `These template ids cannot be written as filenames, so exporting them would change what they are: ${unwritable.join(', ')}`,
+    )
+  }
+
+  const tree: Tree = new Map()
+
+  const contentById = new Map<string, string>()
+  for (const template of input.templates) {
+    tree.set(templatePath(template.templateId), serializeTemplate(template.content))
+    contentById.set(template.templateId, template.content)
+  }
+
+  tree.set(
+    PACK_FILE,
+    serializePackFile({
+      formatVersion: DIRECTORY_FORMAT_VERSION,
+      appVersion: input.appVersion,
+      source: input.source,
+      name: input.name,
+      description: input.description,
+      author: input.author,
+      variables: input.variables,
+    }),
+  )
+  tree.set(ABOUT_FILE, aboutDoc())
+  tree.set(GITATTRIBUTES_FILE, gitattributesDoc())
+  tree.set(`${REFERENCE_DIR}/system-variables.md`, variablesDoc('system'))
+  tree.set(`${REFERENCE_DIR}/runtime-variables.md`, variablesDoc('runtime'))
+  tree.set(`${REFERENCE_DIR}/template-variables.md`, templateVariablesDoc(contentById))
+  tree.set(`${REFERENCE_DIR}/template-status.md`, templateStatusDoc(input.status))
+
+  return tree
+}
+
+/** The tree for the prompt text this version of the app ships, which no edit can reach. */
+export function buildShippedBaselineTree(appVersion: string): Tree {
+  return buildTree({
+    source: 'shipped-baseline',
+    appVersion,
+    name: `Aventuras ${appVersion} shipped prompts`,
+    description: 'The prompt text this version of Aventuras ships. Exported as a merge base.',
+    templates: shippedTemplateRows(),
+    variables: [],
+    status: { kind: 'shipped-baseline' },
+  })
+}
+
+/**
+ * Which files of an existing tree this export leaves behind.
+ *
+ * Confined to template files and generated reference material: a tree lives in a repository
+ * next to a README, notes and `.git`, and removing a file the export does not own would make
+ * that unsafe. A stale template file has to go, though — it would otherwise import as a
+ * template the pack no longer has.
+ */
+export function planPrune(existingPaths: string[], tree: Tree): string[] {
+  // Compared without case, because Windows and macOS resolve two spellings of a path to one
+  // file: pruning a path this export just wrote under different casing deletes the file it
+  // had only moments before written. Leaving a genuinely distinct file behind on a
+  // case-sensitive system is the safe failure -- it surfaces as a refused import naming both
+  // paths, not as a template silently missing from a successful export.
+  const written = new Set([...tree.keys()].map((path) => path.toLowerCase()))
+  const normalized = (path: string) => path.replace(/\\/g, '/')
+
+  return existingPaths
+    .map(normalized)
+    .filter((path) => !written.has(path.toLowerCase()))
+    .filter(
+      (path) =>
+        classifyPath(path) === 'template' ||
+        path.toLowerCase().startsWith(`${REFERENCE_DIR.toLowerCase()}/`),
+    )
+    .sort()
+}

--- a/src/lib/services/packs/directory/tree.ts
+++ b/src/lib/services/packs/directory/tree.ts
@@ -14,7 +14,7 @@ import {
   REFERENCE_DIR,
   USER_HALF_SUFFIX,
   classifyPath,
-  isRoundTrippableId,
+  isWritableTemplateId,
   templatePath,
 } from './layout'
 import {
@@ -67,14 +67,29 @@ export function shippedTemplateRows(): StoredTemplate[] {
 }
 
 export function buildTree(input: TreeInput): Tree {
-  const unwritable = input.templates
-    .map((t) => t.templateId)
-    .filter((id) => !isRoundTrippableId(id))
-    .sort()
+  const ids = input.templates.map((t) => t.templateId)
 
+  const unwritable = ids.filter((id) => !isWritableTemplateId(id)).sort()
   if (unwritable.length > 0) {
     throw new Error(
       `These template ids cannot be written as filenames, so exporting them would change what they are: ${unwritable.join(', ')}`,
+    )
+  }
+
+  // Two ids differing only in case are one file on Windows and macOS, so one would silently
+  // overwrite the other and the export would be missing a template.
+  const byLowercase = new Map<string, string[]>()
+  for (const id of ids) {
+    const key = id.toLowerCase()
+    byLowercase.set(key, [...(byLowercase.get(key) ?? []), id])
+  }
+  const colliding = [...byLowercase.values()]
+    .filter((group) => group.length > 1)
+    .map((group) => [...group].sort().join(' and '))
+    .sort()
+  if (colliding.length > 0) {
+    throw new Error(
+      `These template ids differ only in capitalisation, so they cannot both be written as files: ${colliding.join('; ')}`,
     )
   }
 

--- a/src/lib/services/packs/import-export.ts
+++ b/src/lib/services/packs/import-export.ts
@@ -1,5 +1,6 @@
 import { open } from '@tauri-apps/plugin-dialog'
 import { writeTextFile, readTextFile } from '@tauri-apps/plugin-fs'
+import { getVersion } from '@tauri-apps/api/app'
 import { resolveSaveTarget } from '$lib/services/exportTarget'
 import { packService } from './pack-service'
 import { database } from '$lib/services/database'
@@ -8,9 +9,22 @@ import { templateEngine } from '$lib/services/templates/engine'
 import { hashContent } from './hash'
 import { packUpdateSummary, type PackUpdateSummary } from './update-summary'
 import type { PresetPack } from './types'
+import { PACK_FILE } from './directory/layout'
+import { pickDirectory, readTree, writeTree } from './directory/io'
+import { validateTree, type DirectoryValidationResult } from './directory/parse'
+import {
+  buildShippedBaselineTree,
+  buildTree,
+  planPrune,
+  shippedTemplateRows,
+  type Tree,
+} from './directory/tree'
+import type { StatusSource } from './directory/reference'
 
 interface TemplateError {
   templateId: string
+  /** Where it was found, when the source was a directory rather than a single file. */
+  path?: string
   error: string
 }
 
@@ -27,6 +41,24 @@ export interface ImportValidationResult {
  * that happens to match.
  */
 export type ConflictStrategy = 'rename' | 'cancel'
+
+/** An export worked out but not yet written, so the user can be asked about an unfamiliar folder. */
+export interface DirectoryExportPlan {
+  root: string
+  tree: Tree
+  prunePaths: string[]
+  /**
+   * The folder holds files but carries no `pack.yaml`, so it is not a tree this export owns.
+   * Nothing is pruned in that case, but the user is asked before files land in it.
+   */
+  needsConfirmation: boolean
+}
+
+/** A directory read and validated, ready for the same import paths a `.prompt.json` takes. */
+export interface DirectoryImportCandidate {
+  root: string
+  validation: DirectoryValidationResult
+}
 
 class ImportExportService {
   async exportPack(packId: string): Promise<boolean> {
@@ -67,6 +99,93 @@ class ImportExportService {
 
     await writeTextFile(target.destPath, JSON.stringify(exportData))
     return true
+  }
+
+  /** Where an existing tree's files sit, and which of them this export would leave behind. */
+  private async planWrite(root: string, tree: Tree): Promise<DirectoryExportPlan> {
+    let existingPaths: string[] = []
+    try {
+      existingPaths = (await readTree(root)).allPaths
+    } catch (e) {
+      console.error('[ImportExportService] Failed to read the chosen folder:', e)
+    }
+
+    const isPreviousExport = existingPaths.some((p) => p.replace(/\\/g, '/') === PACK_FILE)
+
+    return {
+      root,
+      tree,
+      prunePaths: isPreviousExport ? planPrune(existingPaths, tree) : [],
+      needsConfirmation: !isPreviousExport && existingPaths.length > 0,
+    }
+  }
+
+  /** Plan an export of a pack as it is stored. `null` if the user cancelled the folder pick. */
+  async planPackDirectoryExport(packId: string): Promise<DirectoryExportPlan | null> {
+    const fullPack = await packService.getFullPack(packId)
+    if (!fullPack) return null
+
+    const root = await pickDirectory('Export prompt pack to folder')
+    if (!root) return null
+
+    const status: StatusSource = fullPack.pack.isDefault
+      ? { kind: 'default-pack', rows: fullPack.templates, shippedHashes: await shippedHashes() }
+      : { kind: 'custom-pack', rows: fullPack.templates }
+
+    const tree = buildTree({
+      source: 'pack',
+      appVersion: await getVersion(),
+      name: fullPack.pack.name,
+      description: fullPack.pack.description ?? undefined,
+      author: fullPack.pack.author ?? undefined,
+      templates: fullPack.templates.map((t) => ({ templateId: t.templateId, content: t.content })),
+      variables: fullPack.variables.map((v) => ({
+        variableName: v.variableName,
+        displayName: v.displayName,
+        variableType: v.variableType,
+        isRequired: v.isRequired,
+        defaultValue: v.defaultValue,
+        enumOptions: v.enumOptions,
+        description: v.description,
+        sortOrder: v.sortOrder,
+      })),
+      status,
+    })
+
+    return this.planWrite(root, tree)
+  }
+
+  /** Plan an export of the prompt text the app ships, which no pack can influence. */
+  async planShippedBaselineExport(): Promise<DirectoryExportPlan | null> {
+    const root = await pickDirectory('Export shipped prompts to folder')
+    if (!root) return null
+
+    return this.planWrite(root, buildShippedBaselineTree(await getVersion()))
+  }
+
+  async applyDirectoryExport(plan: DirectoryExportPlan): Promise<void> {
+    await writeTree(plan.root, plan.tree, plan.prunePaths)
+  }
+
+  /** Pick a folder and validate it in full. `null` if the user cancelled. */
+  async pickAndValidateDirectory(): Promise<DirectoryImportCandidate | null> {
+    const root = await pickDirectory('Import prompt pack from folder')
+    if (!root) return null
+
+    try {
+      const { contents } = await readTree(root)
+      return { root, validation: validateTree(contents) }
+    } catch (e) {
+      console.error('[ImportExportService] Failed to read the chosen folder:', e)
+      return {
+        root,
+        validation: {
+          valid: false,
+          structuralErrors: [`Could not read that folder: ${(e as Error).message}`],
+          templateErrors: [],
+        },
+      }
+    }
   }
 
   async pickAndReadImportFile(): Promise<string | null> {
@@ -210,6 +329,16 @@ class ImportExportService {
 
     return pack.id
   }
+}
+
+/** The hash of the text the app ships, per stored row id, for the status report. */
+async function shippedHashes(): Promise<Map<string, string>> {
+  const entries = await Promise.all(
+    shippedTemplateRows().map(
+      async (row) => [row.templateId, await hashContent(row.content)] as [string, string],
+    ),
+  )
+  return new Map(entries)
 }
 
 export const importExportService = new ImportExportService()

--- a/src/lib/services/packs/import-export.ts
+++ b/src/lib/services/packs/import-export.ts
@@ -12,6 +12,7 @@ import type { PresetPack } from './types'
 import { PACK_FILE } from './directory/layout'
 import { pickDirectory, readTree, writeTree } from './directory/io'
 import { validateTree, type DirectoryValidationResult } from './directory/parse'
+import { parsePackFile } from './directory/serialize'
 import {
   buildShippedBaselineTree,
   buildTree,
@@ -48,8 +49,9 @@ export interface DirectoryExportPlan {
   tree: Tree
   prunePaths: string[]
   /**
-   * The folder holds files but carries no `pack.yaml`, so it is not a tree this export owns.
-   * Nothing is pruned in that case, but the user is asked before files land in it.
+   * The folder holds files but did not prove to be a tree this export owns — no readable
+   * `pack.yaml` this version can parse. Nothing is pruned in that case, but a file sharing a
+   * name with one being written is still overwritten, so the user is asked first.
    */
   needsConfirmation: boolean
 }
@@ -104,13 +106,22 @@ class ImportExportService {
   /** Where an existing tree's files sit, and which of them this export would leave behind. */
   private async planWrite(root: string, tree: Tree): Promise<DirectoryExportPlan> {
     let existingPaths: string[] = []
+    let packFileText: string | undefined
     try {
-      existingPaths = (await readTree(root)).allPaths
+      const existing = await readTree(root)
+      existingPaths = existing.allPaths
+      packFileText = existing.contents.get(PACK_FILE)
     } catch (e) {
+      // A folder that cannot be read is not one this export owns: nothing is pruned from it,
+      // and the confirmation stands in for the certainty we could not get.
       console.error('[ImportExportService] Failed to read the chosen folder:', e)
+      return { root, tree, prunePaths: [], needsConfirmation: true }
     }
 
-    const isPreviousExport = existingPaths.some((p) => p.replace(/\\/g, '/') === PACK_FILE)
+    // Pruning deletes files, so the folder has to prove it is one of ours. The name
+    // `pack.yaml` alone does not: other tools use it too, and treating a stranger's folder
+    // as a previous export would delete the Markdown nested inside it.
+    const isPreviousExport = packFileText !== undefined && parsePackFile(packFileText).ok
 
     return {
       root,

--- a/src/lib/services/packs/import-export.ts
+++ b/src/lib/services/packs/import-export.ts
@@ -47,11 +47,15 @@ export type ConflictStrategy = 'rename' | 'cancel'
 export interface DirectoryExportPlan {
   root: string
   tree: Tree
+  /** Template and reference files of a previous export that this one no longer writes. */
   prunePaths: string[]
+  /** The folder carries a `pack.yaml` this version can parse, so it is a tree we own. */
+  isKnownExport: boolean
   /**
-   * The folder holds files but did not prove to be a tree this export owns — no readable
-   * `pack.yaml` this version can parse. Nothing is pruned in that case, but a file sharing a
-   * name with one being written is still overwritten, so the user is asked first.
+   * Ask before writing. True when the folder holds files we did not put there — one sharing a
+   * name with a file being written is still overwritten — and whenever anything would be
+   * deleted, because a `.md` a user kept beside the prompts is indistinguishable from a
+   * template this export has dropped.
    */
   needsConfirmation: boolean
 }
@@ -115,19 +119,21 @@ class ImportExportService {
       // A folder that cannot be read is not one this export owns: nothing is pruned from it,
       // and the confirmation stands in for the certainty we could not get.
       console.error('[ImportExportService] Failed to read the chosen folder:', e)
-      return { root, tree, prunePaths: [], needsConfirmation: true }
+      return { root, tree, prunePaths: [], isKnownExport: false, needsConfirmation: true }
     }
 
     // Pruning deletes files, so the folder has to prove it is one of ours. The name
     // `pack.yaml` alone does not: other tools use it too, and treating a stranger's folder
     // as a previous export would delete the Markdown nested inside it.
-    const isPreviousExport = packFileText !== undefined && parsePackFile(packFileText).ok
+    const isKnownExport = packFileText !== undefined && parsePackFile(packFileText).ok
+    const prunePaths = isKnownExport ? planPrune(existingPaths, tree) : []
 
     return {
       root,
       tree,
-      prunePaths: isPreviousExport ? planPrune(existingPaths, tree) : [],
-      needsConfirmation: !isPreviousExport && existingPaths.length > 0,
+      prunePaths,
+      isKnownExport,
+      needsConfirmation: (!isKnownExport && existingPaths.length > 0) || prunePaths.length > 0,
     }
   }
 


### PR DESCRIPTION
## Why

The built-in editor is the only way to read or change a pack's ~80 templates: one at a
time, with weak search and no diff. A set of edits cannot be reviewed, carried across a
release, or kept anywhere but the database. When a new version ships better defaults, a
user who has customised them has no way to combine the two other than re-typing.

Exporting a pack as a directory hands that job to tools that already do it well — an
editor, `ripgrep`, and git — and turns the release-to-release merge into an ordinary
vendor-branch workflow.

## What changed

- **Export a pack as a directory.** One `.md` file per stored row, in a folder named for
  its display group. `pack.yaml` at the root carries the format version, app version, pack
  metadata and custom variables.
- **Export the shipped baseline**, a separate action in the built-in pack's Pack Settings.
  It reads `PROMPT_TEMPLATES` rather than any pack's rows, so it is unedited by
  construction and safe as a merge base.
- **Import a directory back**, as a new pack or over an existing one. Replace semantics,
  matching `.prompt.json`. The built-in pack stays excluded as a target.
- **Generated `_reference/`** the importer ignores: the system and runtime variable
  registries, a template-to-variable index and its reverse, and a per-template status
  report naming what carries an edit.
- **Generated `ABOUT.md` and `.gitattributes`**, explaining the format and pinning LF.
- Pack cards now group all four transfer actions under one import/export dropdown, matching
  the story header's menu, instead of a row of near-identical icons.

Desktop only — `tauri-plugin-dialog`'s folder picker is `FolderPickerNotImplemented` on
mobile. The `.prompt.json` path is untouched and remains the Android route.

## Notes for review

**The filename is the identity; the folder is presentation.** Groups come from
`TEMPLATE_GROUP_MAP`, which is code and changes between releases. Were the path the
identity, a regrouped template would read as a delete plus an add of a file the user may
also have edited. As a stem it is a rename, which git detects.

**Determinism is load-bearing.** Two exports of unchanged content must be byte-identical or
git cannot merge them — hence LF endings, one trailing newline, fixed key order, variables
sorted, and deliberately no timestamp.

**Imports write rows as their own baseline** (`isBaseline: true`), as `updatePackFromFile`
does. The file *is* the pack's baseline; the user's edits live in git. With `false`, every
row reads as edited and `summarizeUpdate` warns about discarding ~80 edits on every import
— a warning that always fires stops being read.

**Liquid failures are asymmetric, and this is documented rather than fixed.** Structural
faults (unclosed tag, mismatched end tag, unknown filter) are refused whole, each file named
with line and column, nothing written. An unknown *variable* name is not a fault: Liquid
renders it empty and nothing reports it, ever. `ABOUT.md` leads with that, since it is what
a bad merge produces and no check can catch.

**`yaml` moved from devDependencies to dependencies.** `pack.yaml` is hand-edited during a
merge, so comments and unquoted multi-line strings were worth the dependency over JSON.

One capability change: `fs:allow-read-dir`.

## Verification

`npm run check` 0 errors · `npm run lint` 0 errors · `npm test` 1437 passed, 9 skipped
(79 new tests across 7 files).

A full desktop cycle was walked by hand: export the shipped baseline, commit it, edit a
template outside the app, import as a new pack, confirm no modified badge and that a bound
story generates from the edited text.

Three findings from an automated review are fixed in this branch, the first of which was a
genuine data-loss path: on a case-insensitive filesystem the prune planner could schedule a
file it had just written under different casing, so a *successful* export silently lost a
template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added folder-based import and export for prompt packs.
  * Added options to update packs from folders and export shipped prompts to a folder.
  * Added confirmation before exporting into folders containing existing files, including files that may be removed.
  * Separated file and folder transfer options.
  * Folder-transfer options are hidden on unsupported platforms; file-based transfer remains available.

* **Bug Fixes**
  * Improved import validation messages with file paths and clearer replacement guidance.
  * Prevented template files differing only by capitalization from being imported as duplicates.
  * Improved handling of concurrent folder transfers and canceled export confirmations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->