### PR TITLE
Narrator reinforcement: make the turn message a pack template

### DIFF
--- a/docs/architecture/prompts.md
+++ b/docs/architecture/prompts.md
@@ -16,8 +16,26 @@ Resolution order (`ContextBuilder.resolveTemplate`), first hit wins:
 
 A template has a system half (`content`) and an optional user half (`userContent`). The user half is
 stored under the id `<template-id>-user`, and `ContextBuilder.render(id)` returns `{ system, user }` by
-resolving both. A service that destructures only `system` silently drops the user half — every service
-except the two whose templates deliberately have none.
+resolving both. A service that destructures only `system` silently drops the user half, so a service whose
+template has one must take both.
+
+### The narrator's two prompts
+
+`adventure` and `creative-writing` each carry both halves. The system half is the narrator's standing
+instructions; the user half is prefixed to the turn message and repeats some of them, which helps models
+that expect a user-first conversation format and some smaller local models that need the rules closer to
+the generation point.
+
+How much it repeats is the story's `narratorReinforcement` setting, which reaches the template as the raw
+level — `full`, `minimal` or `none` — for the template to branch on, the way `pov` and `tense` already are.
+The pack therefore decides what each level says; the application only chooses between them. `full` is the
+default and is what a story that has never set it receives. `none` renders nothing, and
+`joinReinforcement` then sends the turn message alone rather than a blank prefix.
+
+A custom system prompt replaces the system half only. The turn message still comes from the pack, so
+Story Settings decides whether the reinforcement control is available by looking at the `-user` template
+regardless of an override — and at the effective system prompt too, since a pack may carry the
+reinforcement there instead.
 
 ### Which pack is "the active pack"
 

--- a/src/lib/components/settings/tabs/story-settings.svelte
+++ b/src/lib/components/settings/tabs/story-settings.svelte
@@ -7,6 +7,8 @@
     PROMPT_TEMPLATES,
     LENGTH_INSTRUCTION_VAR,
     templateUsesLengthInstruction,
+    NARRATOR_REINFORCEMENT_VAR,
+    narratorReinforcementIsHonoured,
   } from '$lib/services/prompts/templates'
   import { ContextBuilder } from '$lib/services/context'
   import { database } from '$lib/services/database'
@@ -43,6 +45,7 @@
     'runtimeVars_items',
     'runtimeVars_storyBeats',
     'runtimeVars_protagonist',
+    'narratorReinforcement',
   ])
 
   const VARIABLE_REFERENCE = [
@@ -181,6 +184,49 @@
       cancelled = true
     }
   })
+
+  /**
+   * Narrator Reinforcement is carried by the turn message, which comes from the pack whether
+   * or not a custom system prompt replaces the system half — so unlike Response Length this
+   * checks the `-user` template regardless of an override. A pack may carry the reinforcement
+   * in the system prompt instead, so a reference in either prompt counts.
+   */
+  let reinforcementUnavailableReason = $state<string | undefined>(undefined)
+  $effect(() => {
+    const storyId = story.currentStory?.id
+    const override = savedCustomPrompt
+    const templateId =
+      story.currentStory?.mode === 'creative-writing' ? 'creative-writing' : 'adventure'
+    if (!storyId) return
+
+    let cancelled = false
+    const resolve = async () => {
+      const packId = (await database.getStoryPackId(storyId)) || DEFAULT_PACK_ID
+      const ctx = new ContextBuilder(packId)
+      const [userTemplate, systemTemplate] = await Promise.all([
+        ctx.resolveTemplate(`${templateId}-user`),
+        ctx.resolveTemplate(templateId),
+      ])
+      return narratorReinforcementIsHonoured({
+        userTemplate: userTemplate?.content,
+        systemTemplate: systemTemplate?.content,
+        customSystemPrompt: override,
+      })
+    }
+
+    resolve().then((supported) => {
+      if (cancelled) return
+      reinforcementUnavailableReason = supported
+        ? undefined
+        : `Neither prompt this story sends references {{ ${NARRATOR_REINFORCEMENT_VAR} }}, so ` +
+          `this setting would have no effect. Add it to the narrator turn message in the ` +
+          `story's prompt pack, or switch the story to a pack that has it.`
+    })
+
+    return () => {
+      cancelled = true
+    }
+  })
   const isDirty = $derived(customPromptDraft !== (savedCustomPrompt ?? ''))
   const canSave = $derived(
     isDirty && (customPromptDraft.trim() === '' || (validationResult?.success ?? false)),
@@ -260,6 +306,9 @@
     onReferenceModeChange={(v) => story.updateStorySettings({ referenceMode: v })}
     onTargetLengthChange={(v) => story.updateStorySettings({ targetLength: v })}
     targetLengthDisabledReason={lengthUnavailableReason}
+    narratorReinforcement={storySettings.narratorReinforcement ?? 'full'}
+    onNarratorReinforcementChange={(v) => story.updateStorySettings({ narratorReinforcement: v })}
+    narratorReinforcementDisabledReason={reinforcementUnavailableReason}
     disabledFields={{ pov: true, tense: true, visualProseMode: true }}
     disabledReason="Cannot be changed mid-story. Set during story creation."
   />

--- a/src/lib/components/shared/WritingStyleFields.svelte
+++ b/src/lib/components/shared/WritingStyleFields.svelte
@@ -4,8 +4,14 @@
   import { Label } from '$lib/components/ui/label'
   import { Input } from '$lib/components/ui/input'
   import { Switch } from '$lib/components/ui/switch'
-  import { BookOpen, User, Eye, AlignLeft } from '@lucide/svelte'
-  import type { POV, Tense, TargetLength, ImageGenerationMode } from '$lib/types'
+  import { BookOpen, User, Eye, AlignLeft, Repeat } from '@lucide/svelte'
+  import type {
+    POV,
+    Tense,
+    TargetLength,
+    ImageGenerationMode,
+    NarratorReinforcement,
+  } from '$lib/types'
 
   interface Props {
     selectedPOV: POV
@@ -26,6 +32,9 @@
     mode?: 'adventure' | 'creative-writing'
     /** Set to disable the length control, e.g. a custom prompt that never renders it. */
     targetLengthDisabledReason?: string
+    narratorReinforcement?: NarratorReinforcement
+    /** Set to disable the reinforcement control, e.g. prompts that never reference it. */
+    narratorReinforcementDisabledReason?: string
     onPOVChange: (v: POV) => void
     onTenseChange: (v: Tense) => void
     onToneChange: (v: string) => void
@@ -34,6 +43,7 @@
     onBackgroundImagesEnabledChange: (v: boolean) => void
     onReferenceModeChange: (v: boolean) => void
     onTargetLengthChange?: (v: TargetLength) => void
+    onNarratorReinforcementChange?: (v: NarratorReinforcement) => void
     disabledFields?: {
       pov?: boolean
       tense?: boolean
@@ -56,6 +66,8 @@
     targetLength = 'dynamic',
     mode = 'adventure',
     targetLengthDisabledReason,
+    narratorReinforcement = 'full',
+    narratorReinforcementDisabledReason,
     onPOVChange,
     onTenseChange,
     onToneChange,
@@ -64,6 +76,7 @@
     onBackgroundImagesEnabledChange,
     onReferenceModeChange,
     onTargetLengthChange,
+    onNarratorReinforcementChange,
     disabledFields,
     disabledReason,
   }: Props = $props()
@@ -143,6 +156,37 @@
     { id: 'medium', label: 'Medium' },
     { id: 'long', label: 'Long' },
   ]
+
+  // The prompt pack decides what each level actually sends, so these describe the shipped
+  // text rather than a guarantee.
+  const REINFORCEMENT_OPTIONS: {
+    id: NarratorReinforcement
+    label: string
+    short: string
+    long: string
+  }[] = [
+    {
+      id: 'full',
+      label: 'Full',
+      short: 'Role + rules',
+      long: 'As shipped: repeats the narrator role, point of view, tense and the agency rules ahead of every turn.',
+    },
+    {
+      id: 'minimal',
+      label: 'Minimal',
+      short: 'Role only',
+      long: 'As shipped: names the narrator and player roles and nothing else.',
+    },
+    {
+      id: 'none',
+      label: 'None',
+      short: 'Nothing',
+      long: 'As shipped: sends nothing ahead of the story, leaving the system prompt to carry the rules.',
+    },
+  ]
+  const selectedReinforcement = $derived(
+    REINFORCEMENT_OPTIONS.find((o) => o.id === narratorReinforcement) ?? REINFORCEMENT_OPTIONS[0],
+  )
 </script>
 
 <div class="space-y-4">
@@ -290,6 +334,43 @@
           : 'text-muted-foreground'}"
       >
         {targetLengthDisabledReason ?? lengthRanges[selectedLength].long}
+      </p>
+    </section>
+  {/if}
+
+  <!-- Narrator Reinforcement -->
+  {#if onNarratorReinforcementChange}
+    {@const reinforcementDisabled = !!narratorReinforcementDisabledReason}
+    <section class="space-y-2 pt-1">
+      <Label class="flex items-center gap-2 text-base font-semibold">
+        <Repeat class="h-4 w-4" />
+        Narrator Reinforcement
+      </Label>
+      <RadioGroup.Root
+        value={narratorReinforcement}
+        onValueChange={(v) => onNarratorReinforcementChange?.(v as NarratorReinforcement)}
+        disabled={reinforcementDisabled}
+        class="grid grid-cols-3 gap-2 {reinforcementDisabled ? 'opacity-50' : ''}"
+      >
+        {#each REINFORCEMENT_OPTIONS as item (item.id)}
+          <Label
+            for={`reinforcement-${item.id}`}
+            class="border-muted bg-popover has-[[data-state=checked]]:border-primary has-[[data-state=checked]]:bg-primary/5 has-[:focus-visible]:ring-ring flex flex-col items-center justify-center rounded-md border-2 p-3 text-center has-[:focus-visible]:ring-2 {reinforcementDisabled
+              ? 'cursor-not-allowed'
+              : 'hover:bg-accent hover:text-accent-foreground cursor-pointer'}"
+          >
+            <RadioGroup.Item value={item.id} id={`reinforcement-${item.id}`} class="sr-only" />
+            <span class="font-medium">{item.label}</span>
+            <span class="text-muted-foreground text-xs">{item.short}</span>
+          </Label>
+        {/each}
+      </RadioGroup.Root>
+      <p
+        class="min-h-[1.25rem] text-xs {reinforcementDisabled
+          ? 'text-amber-500'
+          : 'text-muted-foreground'}"
+      >
+        {narratorReinforcementDisabledReason ?? selectedReinforcement.long}
       </p>
     </section>
   {/if}

--- a/src/lib/components/vault/prompts/TestVariablesModal.svelte
+++ b/src/lib/components/vault/prompts/TestVariablesModal.svelte
@@ -88,6 +88,7 @@
         'protagonistDescription',
         'povInstruction',
         'lengthInstruction',
+        'narratorReinforcement',
         'userInput',
       ],
     },

--- a/src/lib/components/vault/prompts/sampleContext.ts
+++ b/src/lib/components/vault/prompts/sampleContext.ts
@@ -63,6 +63,7 @@ export const runtimeSamples: Record<string, string> = {
   protagonistDescription: 'A young woman with silver hair and violet eyes',
   povInstruction: 'Write in second person perspective.',
   lengthInstruction: 'Write 2-3 paragraphs.',
+  narratorReinforcement: 'full',
 
   // Shared / Common
   userInput: 'I want to explore the ancient ruins to the north.',

--- a/src/lib/components/wizard/SetupWizard.svelte
+++ b/src/lib/components/wizard/SetupWizard.svelte
@@ -439,10 +439,12 @@
           backgroundImagesEnabled={wizard.narrative.backgroundImagesEnabled}
           referenceMode={wizard.narrative.referenceMode}
           targetLength={wizard.narrative.targetLength}
+          narratorReinforcement={wizard.narrative.narratorReinforcement}
           mode={wizard.narrative.selectedMode}
           onBackgroundImagesEnabledChange={(v) => (wizard.narrative.backgroundImagesEnabled = v)}
           onReferenceModeChange={(v) => (wizard.narrative.referenceMode = v)}
           onTargetLengthChange={(v) => (wizard.narrative.targetLength = v)}
+          onNarratorReinforcementChange={(v) => (wizard.narrative.narratorReinforcement = v)}
         />
       {:else if wizard.currentStep === 9}
         <Step8Opening

--- a/src/lib/components/wizard/steps/Step7WritingStyle.svelte
+++ b/src/lib/components/wizard/steps/Step7WritingStyle.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
   import WritingStyleFields from '$lib/components/shared/WritingStyleFields.svelte'
   import { ScrollArea } from '$lib/components/ui/scroll-area'
-  import type { POV, Tense, TargetLength, ImageGenerationMode } from '$lib/types'
+  import type {
+    POV,
+    Tense,
+    TargetLength,
+    NarratorReinforcement,
+    ImageGenerationMode,
+  } from '$lib/types'
 
   interface Props {
     selectedPOV: POV
@@ -13,6 +19,7 @@
     backgroundImagesEnabled: boolean
     referenceMode: boolean
     targetLength?: TargetLength
+    narratorReinforcement?: NarratorReinforcement
     mode?: 'adventure' | 'creative-writing'
     onPOVChange: (v: POV) => void
     onTenseChange: (v: Tense) => void
@@ -22,6 +29,7 @@
     onBackgroundImagesEnabledChange: (v: boolean) => void
     onReferenceModeChange: (v: boolean) => void
     onTargetLengthChange?: (v: TargetLength) => void
+    onNarratorReinforcementChange?: (v: NarratorReinforcement) => void
   }
 
   let {
@@ -34,6 +42,7 @@
     backgroundImagesEnabled,
     referenceMode,
     targetLength = 'dynamic',
+    narratorReinforcement = 'full',
     mode = 'adventure',
     onPOVChange,
     onTenseChange,
@@ -43,6 +52,7 @@
     onBackgroundImagesEnabledChange,
     onReferenceModeChange,
     onTargetLengthChange,
+    onNarratorReinforcementChange,
   }: Props = $props()
 
   // Force "none" mode when image generation is disabled (wizard only)
@@ -74,6 +84,7 @@
       {backgroundImagesEnabled}
       {referenceMode}
       {targetLength}
+      {narratorReinforcement}
       {mode}
       {onPOVChange}
       {onTenseChange}
@@ -83,6 +94,7 @@
       {onBackgroundImagesEnabledChange}
       {onReferenceModeChange}
       {onTargetLengthChange}
+      {onNarratorReinforcementChange}
     />
   </ScrollArea>
 </div>

--- a/src/lib/services/ai/generation/NarrativeService.test.ts
+++ b/src/lib/services/ai/generation/NarrativeService.test.ts
@@ -13,7 +13,36 @@ vi.mock('$lib/stores/settings.svelte', () => ({
   },
 }))
 
-import { buildChapterSummariesBlock } from './NarrativeService'
+import { buildChapterSummariesBlock, joinReinforcement } from './NarrativeService'
+
+describe('joinReinforcement', () => {
+  it('prefixes the turn message when the pack rendered reinforcement', () => {
+    expect(joinReinforcement('You are the narrator.', '## Current Action:\ngo north')).toBe(
+      'You are the narrator.\n\n## Current Action:\ngo north',
+    )
+  })
+
+  it('leaves the message untouched when nothing rendered', () => {
+    expect(joinReinforcement('', '## Current Action:\ngo north')).toBe(
+      '## Current Action:\ngo north',
+    )
+  })
+
+  it('leaves the message untouched when only whitespace rendered', () => {
+    // The likelier shape of `none`: the level's branches all miss and Liquid leaves the
+    // newlines between them behind.
+    expect(joinReinforcement('\n\n', '## Current Action:\ngo north')).toBe(
+      '## Current Action:\ngo north',
+    )
+    expect(joinReinforcement('   \n \t\n', '## Current Action:\ngo north')).toBe(
+      '## Current Action:\ngo north',
+    )
+  })
+
+  it('sends the untrimmed reinforcement, since trimming would change what full has always sent', () => {
+    expect(joinReinforcement('  padded  ', 'story')).toBe('  padded  \n\nstory')
+  })
+})
 
 const t = (years: number, days: number, hours: number, minutes: number): TimeTracker => ({
   years,

--- a/src/lib/services/ai/generation/NarrativeService.ts
+++ b/src/lib/services/ai/generation/NarrativeService.ts
@@ -148,6 +148,17 @@ export interface NarrativeWorldState extends WorldStateContext {
 }
 
 /**
+ * Prefix the turn message with the narrator reinforcement the pack rendered.
+ *
+ * Emptiness is decided on the trimmed render, but the untrimmed value is what is sent:
+ * a level whose branches all miss can still leave newlines behind, and trimming what goes
+ * out would change the text `full` has always sent.
+ */
+export function joinReinforcement(reinforcement: string, userPrompt: string): string {
+  return reinforcement.trim() ? `${reinforcement}\n\n${userPrompt}` : userPrompt
+}
+
+/**
  * Build a block containing chapter summaries for injection into the system prompt.
  * Per design doc: summarized entries are excluded from direct context,
  * but their summaries provide narrative continuity.
@@ -297,7 +308,7 @@ export class NarrativeService {
     })
 
     // Build system prompt via ContextBuilder pipeline
-    const { systemPrompt, primingMessage } = await this.buildPrompts(
+    const { systemPrompt, reinforcement } = await this.buildPrompts(
       story,
       worldState,
       tieredContextBlock,
@@ -315,7 +326,7 @@ export class NarrativeService {
       // Stream using the main narrative profile
       const stream = streamNarrative({
         system: systemPrompt,
-        prompt: `${primingMessage}\n\n${userPrompt}`,
+        prompt: joinReinforcement(reinforcement, userPrompt),
         signal,
       })
 
@@ -357,7 +368,7 @@ export class NarrativeService {
     log('generate', { entriesCount: entries.length })
 
     // Build system prompt via ContextBuilder pipeline
-    const { systemPrompt, primingMessage } = await this.buildPrompts(
+    const { systemPrompt, reinforcement } = await this.buildPrompts(
       story,
       worldState,
       tieredContextBlock,
@@ -371,13 +382,13 @@ export class NarrativeService {
 
     return generateNarrative({
       system: systemPrompt,
-      prompt: `${primingMessage}\n\n${userPrompt}`,
+      prompt: joinReinforcement(reinforcement, userPrompt),
       signal,
     })
   }
 
   /**
-   * Build system and priming prompts through the ContextBuilder pipeline.
+   * Build both halves of the prompt through the ContextBuilder pipeline.
    *
    * Creates a ContextBuilder from the story, adds runtime variables
    * (tiered context, chapter summaries, style guidance), then renders
@@ -390,7 +401,7 @@ export class NarrativeService {
     styleReview?: StyleReviewResult | null,
     retrievedChapterContext?: string | null,
     timelineFillResult?: TimelineFillResult | null,
-  ): Promise<{ systemPrompt: string; primingMessage: string }> {
+  ): Promise<{ systemPrompt: string; reinforcement: string }> {
     const mode = story?.mode ?? 'adventure'
 
     // Create ContextBuilder -- forStory auto-populates mode, pov, tense, genre,
@@ -433,6 +444,9 @@ export class NarrativeService {
         targetLength,
         lengthInstruction: formatLengthInstruction(targetLength, mode),
       })
+    }
+    if (!ctx.getContext().narratorReinforcement) {
+      ctx.add({ narratorReinforcement: story?.settings?.narratorReinforcement || 'full' })
     }
 
     // Add runtime variables for template rendering
@@ -483,6 +497,11 @@ export class NarrativeService {
 
     // Render system prompt — use per-story override when set, otherwise fall back to pack template
     let systemPrompt: string
+    // A custom system prompt replaces the system half only; the turn message still comes
+    // from the pack, so the user half is rendered either way.
+    const templateId = mode === 'creative-writing' ? 'creative-writing' : 'adventure'
+    const { system, user } = await ctx.render(templateId)
+
     const customPrompt = story?.settings?.customSystemPrompt
     if (customPrompt) {
       const rendered = templateEngine.render(customPrompt, ctx.getContext())
@@ -493,28 +512,17 @@ export class NarrativeService {
       }
       systemPrompt = rendered
     } else {
-      const templateId = mode === 'creative-writing' ? 'creative-writing' : 'adventure'
-      const { system } = await ctx.render(templateId)
       systemPrompt = system
     }
-
-    // Build priming message based on mode/pov/tense
-    const context = ctx.getContext()
-    const primingMessage = this.buildPrimingMessage(
-      mode,
-      (context.pov as string) ?? 'second',
-      (context.tense as string) ?? 'present',
-      (context.protagonistName as string) ?? 'the protagonist',
-    )
 
     log('buildPrompts complete', {
       mode,
       usingCustomPrompt: !!customPrompt,
       systemPromptLength: systemPrompt.length,
-      primingMessageLength: primingMessage.length,
+      reinforcementLength: user.length,
     })
 
-    return { systemPrompt, primingMessage }
+    return { systemPrompt, reinforcement: user }
   }
 
   /**
@@ -568,92 +576,5 @@ export class NarrativeService {
     prompt += 'Continue the narrative:'
 
     return prompt
-  }
-
-  /**
-   * Build a priming user message to establish the narrator role.
-   * This helps models that expect user-first conversation format.
-   */
-  private buildPrimingMessage(
-    mode: string,
-    pov: string,
-    tense: string,
-    protagonistName: string,
-  ): string {
-    if (mode === 'creative-writing') {
-      return this.buildCreativeWritingPriming(pov, tense, protagonistName)
-    }
-    return this.buildAdventurePriming(pov, tense, protagonistName)
-  }
-
-  private buildAdventurePriming(pov: string, tense: string, protagonistName: string): string {
-    const tenseWord = tense === 'past' ? 'past' : 'present'
-    const actionExample =
-      tense === 'past' ? 'pushed open the heavy door' : 'pushes open the heavy door'
-    const descWords =
-      tense === 'past'
-        ? 'saw, heard, and experienced as I explored'
-        : 'see, hear, and experience as I explore'
-
-    if (pov === 'third') {
-      return `You are the narrator of this interactive adventure. Write in ${tenseWord} tense, third person (they/the character name).
-
-Your role:
-- Describe ${protagonistName}'s experiences and the world around them
-- Control all NPCs and the environment
-- NEVER write ${protagonistName}'s dialogue, decisions, or inner thoughts - I decide those
-- When I say "I do X", describe the results in third person (e.g., "I open the door" -> "${protagonistName} ${actionExample}...")
-
-I am the player controlling ${protagonistName}. You narrate what happens. Begin when I take my first action.`
-    }
-
-    return `You are the narrator of this interactive adventure. Write in ${tenseWord} tense, second person (you/your).
-
-Your role:
-- Describe what I ${descWords}
-- Control all NPCs and the environment
-- NEVER write my dialogue, decisions, or inner thoughts
-- When I say "I do X", describe the results using "you" (e.g., "I open the door" -> "You ${actionExample}...")
-
-I am the player. You narrate the world around me. Begin when I take my first action.`
-  }
-
-  private buildCreativeWritingPriming(pov: string, tense: string, protagonistName: string): string {
-    const tenseWord = tense === 'past' ? 'past' : 'present'
-
-    if (pov === 'first') {
-      return `You are a skilled fiction writer. Write in ${tenseWord} tense, first person (I/me/my).
-
-Your role:
-- Write prose based on my directions from ${protagonistName}'s internal perspective
-- Bring scenes to life with vivid detail and internal monologue
-- Write for any character I direct you to, including dialogue, actions, and thoughts
-- Maintain consistent characterization throughout
-
-I am the author directing the story. Write what I ask for.`
-    }
-
-    if (pov === 'second') {
-      return `You are a skilled fiction writer. Write in ${tenseWord} tense, second person (you/your).
-
-Your role:
-- Write prose based on my directions, addressing ${protagonistName} directly
-- Bring scenes to life with vivid detail
-- Write for any character I direct you to, including dialogue, actions, and thoughts
-- Maintain consistent characterization throughout
-
-I am the author directing the story. Write what I ask for.`
-    }
-
-    // Third person (default for creative-writing)
-    return `You are a skilled fiction writer. Write in ${tenseWord} tense, third person (they/the character name).
-
-Your role:
-- Write prose based on my directions
-- Bring scenes to life with vivid detail
-- Write for any character I direct you to, including dialogue, actions, and thoughts
-- Maintain consistent characterization throughout
-
-I am the author directing the story. Write what I ask for.`
   }
 }

--- a/src/lib/services/ai/generation/NarrativeService.ts
+++ b/src/lib/services/ai/generation/NarrativeService.ts
@@ -496,13 +496,12 @@ export class NarrativeService {
     }
 
     // Render system prompt — use per-story override when set, otherwise fall back to pack template
-    let systemPrompt: string
-    // A custom system prompt replaces the system half only; the turn message still comes
-    // from the pack, so the user half is rendered either way.
     const templateId = mode === 'creative-writing' ? 'creative-writing' : 'adventure'
-    const { system, user } = await ctx.render(templateId)
-
     const customPrompt = story?.settings?.customSystemPrompt
+
+    let systemPrompt: string
+    let user: string
+
     if (customPrompt) {
       const rendered = templateEngine.render(customPrompt, ctx.getContext())
       if (rendered === null) {
@@ -511,8 +510,11 @@ export class NarrativeService {
         )
       }
       systemPrompt = rendered
+      // The override replaces the system half only; the turn message still comes from the
+      // pack, so its user half is rendered on its own rather than through `render`.
+      user = await ctx.renderTemplate(`${templateId}-user`)
     } else {
-      systemPrompt = system
+      ;({ system: systemPrompt, user } = await ctx.render(templateId))
     }
 
     log('buildPrompts complete', {

--- a/src/lib/services/ai/wizard/ScenarioService.ts
+++ b/src/lib/services/ai/wizard/ScenarioService.ts
@@ -9,6 +9,7 @@ import type {
   StoryMode,
   POV,
   TargetLength,
+  NarratorReinforcement,
   Character,
   Location,
   Item,
@@ -56,6 +57,7 @@ export interface WizardData {
     backgroundImagesEnabled?: boolean
     referenceMode?: boolean
     targetLength?: TargetLength
+    narratorReinforcement?: NarratorReinforcement
   }
   title: string
   openingGuidance?: string
@@ -806,6 +808,7 @@ class ScenarioService {
       backgroundImagesEnabled?: boolean
       referenceMode?: boolean
       targetLength?: TargetLength
+      narratorReinforcement?: NarratorReinforcement
     }
     protagonist: Partial<Character>
     startingLocation: Partial<Location>
@@ -832,6 +835,7 @@ class ScenarioService {
         backgroundImagesEnabled: writingStyle.backgroundImagesEnabled,
         referenceMode: writingStyle.referenceMode,
         targetLength: writingStyle.targetLength,
+        narratorReinforcement: writingStyle.narratorReinforcement,
       },
       protagonist: {
         name: protagonist?.name || (writingStyle.pov === 'second' ? 'You' : 'The Protagonist'),

--- a/src/lib/services/context/context-builder.ts
+++ b/src/lib/services/context/context-builder.ts
@@ -100,6 +100,7 @@ export class ContextBuilder {
       inlineImageMode: story.settings?.imageGenerationMode === 'inline',
       targetLength,
       lengthInstruction,
+      narratorReinforcement: story.settings?.narratorReinforcement || 'full',
     })
 
     // Protagonist

--- a/src/lib/services/context/context-builder.ts
+++ b/src/lib/services/context/context-builder.ts
@@ -161,26 +161,26 @@ export class ContextBuilder {
   async render(templateId: string): Promise<RenderResult> {
     log('render', { templateId, packId: this.packId })
 
-    const systemTemplate = await this.resolveTemplate(templateId)
-    const userTemplate = await this.resolveTemplate(`${templateId}-user`)
-
-    const systemResult = systemTemplate?.content
-      ? templateEngine.render(systemTemplate.content, this.context)
-      : ''
-    if (systemResult === null) {
-      log('ERROR: system template render failed, using raw content', { templateId })
-    }
-    const userResult = userTemplate?.content
-      ? templateEngine.render(userTemplate.content, this.context)
-      : ''
-    if (userResult === null) {
-      log('ERROR: user template render failed, using raw content', { templateId })
-    }
-
     return {
-      system: systemResult ?? systemTemplate?.content ?? '',
-      user: userResult ?? userTemplate?.content ?? '',
+      system: await this.renderTemplate(templateId),
+      user: await this.renderTemplate(`${templateId}-user`),
     }
+  }
+
+  /**
+   * Render one template id, for a caller that needs a single half — a story overriding
+   * its system prompt still takes its user half from the pack, and resolving the half it
+   * discards costs a lookup and a full render of the largest prompt in the app.
+   */
+  async renderTemplate(templateId: string): Promise<string> {
+    const template = await this.resolveTemplate(templateId)
+    if (!template?.content) return ''
+
+    const result = templateEngine.render(template.content, this.context)
+    if (result === null) {
+      log('ERROR: template render failed, using raw content', { templateId })
+    }
+    return result ?? template.content
   }
 
   /**

--- a/src/lib/services/prompts/templates/index.ts
+++ b/src/lib/services/prompts/templates/index.ts
@@ -24,3 +24,9 @@ export {
   formatLengthInstruction,
   templateUsesLengthInstruction,
 } from './lengthInstruction'
+
+export {
+  NARRATOR_REINFORCEMENT_VAR,
+  templateUsesNarratorReinforcement,
+  narratorReinforcementIsHonoured,
+} from './narratorReinforcement'

--- a/src/lib/services/prompts/templates/narrative.test.ts
+++ b/src/lib/services/prompts/templates/narrative.test.ts
@@ -235,3 +235,36 @@ describe('adventure system prompt covers every pov', () => {
     }
   })
 })
+
+describe.each(['adventure', 'creative-writing'])('%s — full survives an unexpected pov', (id) => {
+  // `pov` comes from the settings blob with no runtime validation. A `case` without a
+  // fallback renders nothing for a value it does not list, which degrades `full` to `none`
+  // with no error anywhere.
+  it('still renders for a pov the template does not name', async () => {
+    for (const pov of ['fourth', 'omniscient']) {
+      const out = await renderUser(id, 'full', pov, 'present')
+      expect(out.trim().length).toBeGreaterThan(0)
+      expect(out).toContain('Your role:')
+    }
+  })
+
+  it('leaves no dangling example for an unexpected pov', async () => {
+    const out = await renderUser(id, 'full', 'fourth', 'present')
+    expect(out).not.toMatch(/->\s*"\.\.\."/)
+    expect(out).not.toMatch(/->\s*""/)
+  })
+})
+
+describe.each(['adventure', 'creative-writing'])('%s — full is clean whitespace', (id) => {
+  // Whitespace-control slips leak literal spaces that survive into every turn. The
+  // machinery and trimmed-emptiness assertions elsewhere do not see them.
+  it('has no space before a line break and no double space', async () => {
+    for (const pov of ['first', 'second', 'third']) {
+      for (const tense of ['present', 'past']) {
+        const out = await renderUser(id, 'full', pov, tense)
+        expect(out).not.toMatch(/ \n/)
+        expect(out).not.toMatch(/ {2}/)
+      }
+    }
+  })
+})

--- a/src/lib/services/prompts/templates/narrative.test.ts
+++ b/src/lib/services/prompts/templates/narrative.test.ts
@@ -268,3 +268,21 @@ describe.each(['adventure', 'creative-writing'])('%s — full is clean whitespac
     }
   })
 })
+
+// The two templates fall back differently on purpose, each matching its own system half:
+// adventure's pov chain ends in SECOND PERSON, creative-writing's in THIRD PERSON. A turn
+// message that fell back the other way would contradict the system prompt beside it.
+describe('an unexpected pov falls back the way the system half does', () => {
+  it('adventure says second person and gives a second-person example', async () => {
+    const out = await renderUser('adventure', 'full', 'fourth', 'present')
+    expect(out).toContain('second person')
+    expect(out).toContain('You push open the heavy door')
+    expect(out).not.toContain('fourth person')
+  })
+
+  it('creative writing says third person', async () => {
+    const out = await renderUser('creative-writing', 'full', 'fourth', 'present')
+    expect(out).toContain('third person')
+    expect(out).not.toContain('fourth person')
+  })
+})

--- a/src/lib/services/prompts/templates/narrative.test.ts
+++ b/src/lib/services/prompts/templates/narrative.test.ts
@@ -83,3 +83,116 @@ describe.each(storyTemplates.map((t) => [t.id, t.content] as const))(
     })
   },
 )
+
+const userHalf = (id: string) => {
+  const template = storyTemplates.find((t) => t.id === id)
+  if (!template?.userContent) throw new Error(`${id} has no userContent`)
+  return template.userContent
+}
+
+const renderUser = (
+  id: string,
+  narratorReinforcement: string | undefined,
+  pov: string,
+  tense: string,
+) =>
+  engine.parseAndRender(userHalf(id), {
+    narratorReinforcement,
+    pov,
+    tense,
+    protagonistName: 'Aria',
+  })
+
+describe.each(['adventure', 'creative-writing'])('%s user message', (id) => {
+  const povs = ['first', 'second', 'third']
+
+  it('emits no template machinery at any level', async () => {
+    for (const level of ['full', 'minimal', 'none']) {
+      for (const pov of povs) {
+        for (const tense of ['present', 'past']) {
+          expect(await renderUser(id, level, pov, tense)).not.toMatch(/\{%|\{\{/)
+        }
+      }
+    }
+  })
+
+  it('renders nothing at none', async () => {
+    // Whitespace, not '': a level with no branch of its own still leaves the line breaks
+    // between the branches that did not match. `joinReinforcement` is what keeps that off
+    // the message.
+    for (const pov of povs) {
+      expect((await renderUser(id, 'none', pov, 'present')).trim()).toBe('')
+    }
+  })
+
+  it('renders something at full and minimal, and reaches every pov branch', async () => {
+    const seen = new Set<string>()
+    for (const pov of povs) {
+      const full = await renderUser(id, 'full', pov, 'present')
+      expect(full.length).toBeGreaterThan(0)
+      seen.add(full)
+    }
+    expect(seen.size).toBe(povs.length)
+    expect((await renderUser(id, 'minimal', povs[0], 'present')).length).toBeGreaterThan(0)
+  })
+
+  it('varies full with tense', async () => {
+    for (const pov of povs) {
+      const present = await renderUser(id, 'full', pov, 'present')
+      const past = await renderUser(id, 'full', pov, 'past')
+      expect(present).toContain('present tense')
+      expect(past).toContain('past tense')
+      expect(present).not.toBe(past)
+    }
+  })
+})
+
+// What the shipped `full` text must say, rather than the exact bytes it says it in. Pinning
+// the wording would fight every edit to the templates, which are meant to be edited; these
+// are the properties a reworded template still has to hold.
+describe.each(['adventure', 'creative-writing'])('%s — full is complete for every pov', (id) => {
+  it('names the point of view it was rendered for', async () => {
+    for (const [pov, word] of [
+      ['first', 'first person'],
+      ['second', 'second person'],
+      ['third', 'third person'],
+    ]) {
+      expect(await renderUser(id, 'full', pov, 'present')).toContain(word)
+    }
+  })
+
+  it('leaves no unsubstituted variable name behind', async () => {
+    // Not asserting the name is present: creative writing's third-person branch never needs
+    // it, since it directs the writer rather than describing the protagonist.
+    for (const pov of ['first', 'second', 'third']) {
+      expect(await renderUser(id, 'full', pov, 'present')).not.toContain('protagonistName')
+    }
+  })
+
+  it('leaves no dangling example where an assign did not resolve', async () => {
+    // The adventure template builds its "I do X" example through {% assign %} inside a
+    // nested {% case pov %}. A pov the inner case does not cover renders the example empty
+    // and the line reads `-> "..."`, which nothing else here would catch.
+    for (const pov of ['first', 'second', 'third']) {
+      const out = await renderUser(id, 'full', pov, 'present')
+      expect(out).not.toMatch(/->\s*"\.\.\."/)
+      expect(out).not.toMatch(/->\s*""/)
+    }
+  })
+})
+
+describe('the agency rule is what the levels actually differ on', () => {
+  const AGENCY = /NEVER write/
+
+  it('adventure carries it at full and not below', async () => {
+    expect(await renderUser('adventure', 'full', 'second', 'present')).toMatch(AGENCY)
+    expect(await renderUser('adventure', 'minimal', 'second', 'present')).not.toMatch(AGENCY)
+    expect(await renderUser('adventure', 'none', 'second', 'present')).not.toMatch(AGENCY)
+  })
+
+  it('creative writing never carries it, since the author controls every character', async () => {
+    for (const level of ['full', 'minimal', 'none']) {
+      expect(await renderUser('creative-writing', level, 'third', 'present')).not.toMatch(AGENCY)
+    }
+  })
+})

--- a/src/lib/services/prompts/templates/narrative.test.ts
+++ b/src/lib/services/prompts/templates/narrative.test.ts
@@ -196,3 +196,42 @@ describe('the agency rule is what the levels actually differ on', () => {
     }
   })
 })
+
+// The system half and the turn message must agree about the point of view. They disagreed
+// for first-person adventures: the system prompt fell through to its second-person branch
+// while the turn message named first person.
+describe('adventure system prompt covers every pov', () => {
+  const adventureSystem = storyTemplates.find((t) => t.id === 'adventure')!.content
+  const renderSystem = (pov: string, tense: string) =>
+    engine.parseAndRender(adventureSystem, {
+      pov,
+      tense,
+      protagonistName: 'Aria',
+      inlineImageMode: false,
+      visualProseMode: false,
+    })
+
+  it('gives first person its own voice rules in both tenses', async () => {
+    for (const tense of ['present', 'past']) {
+      const out = await renderSystem('first', tense)
+      expect(out).toContain('FIRST PERSON')
+      expect(out).not.toContain('SECOND PERSON')
+      expect(out).not.toMatch(/Use "you\/your" for the protagonist/)
+    }
+  })
+
+  it('leaves second and third person as they were', async () => {
+    expect(await renderSystem('second', 'present')).toContain('SECOND PERSON')
+    expect(await renderSystem('third', 'past')).toContain('THIRD PERSON')
+  })
+
+  it('agrees with the turn message about the pov', async () => {
+    for (const pov of ['first', 'second', 'third']) {
+      const system = await renderSystem(pov, 'present')
+      const turn = await renderUser('adventure', 'full', pov, 'present')
+      const word = { first: 'FIRST PERSON', second: 'SECOND PERSON', third: 'THIRD PERSON' }[pov]!
+      expect(system).toContain(word)
+      expect(turn).toContain(word.toLowerCase())
+    }
+  })
+})

--- a/src/lib/services/prompts/templates/narrative.ts
+++ b/src/lib/services/prompts/templates/narrative.ts
@@ -163,11 +163,11 @@ End with a natural opening for action, not a direct question.{% endif %}
   userContent: `{%- case narratorReinforcement %}
 {%- when 'minimal' %}You are the narrator of this interactive adventure. I am the player controlling protagonist named {{ protagonistName }}.
 {%- when 'full' %}You are the narrator of this interactive adventure. I am the player controlling protagonist named {{ protagonistName }}. Write in {{ tense }} tense, {{pov}} person.
-    {%- case pov %} 
-      {%- when 'first' %} {% assign actionExample = 'I push open the heavy door' %} 
-      {%- when 'second' %} {% assign actionExample = 'You push open the heavy door' %} 
-      {%- when 'third' %} {% assign actionExample =  protagonistName | append: ' pushes open the heavy door' %} 
-    {%- endcase %}
+{%- case pov -%}
+{%- when 'first' -%}{% assign actionExample = 'I push open the heavy door' %}
+{%- when 'second' -%}{% assign actionExample = 'You push open the heavy door' %}
+{%- else -%}{% assign actionExample = protagonistName | append: ' pushes open the heavy door' %}
+{%- endcase %}
 
 Your role:
 - Describe {{ protagonistName }}'s experiences and the world around them
@@ -379,7 +379,7 @@ Your role:
 - Maintain consistent characterization throughout
 
 I am the author directing the story. Write what I ask for.
-  {%- when 'third' %}You are a skilled fiction writer. Write in {{ tense }} tense, third person (they/their/character name).
+  {%- else %}You are a skilled fiction writer. Write in {{ tense }} tense, third person (they/their/character name).
 
 Your role:
 - Write prose based on my directions

--- a/src/lib/services/prompts/templates/narrative.ts
+++ b/src/lib/services/prompts/templates/narrative.ts
@@ -23,6 +23,12 @@ Example: "{{ protagonistName }} steps forward..." or "They examine the door..."
 Do NOT use "you" to refer to the protagonist.{% elsif pov == 'third' and tense == 'past' %}Write in PAST TENSE, THIRD PERSON.
 Refer to the protagonist as "{{ protagonistName }}" or "they/them".
 Example: "{{ protagonistName }} stepped forward..." or "They examined the door..."
+Do NOT use "you" to refer to the protagonist.{% elsif pov == 'first' and tense == 'past' %}Write in PAST TENSE, FIRST PERSON.
+Use "I/me/my" as {{ protagonistName }}, whom the player controls.
+Example: "I stepped forward..." or "I examined the door..."
+Do NOT use "you" to refer to the protagonist.{% elsif pov == 'first' %}Write in PRESENT TENSE, FIRST PERSON.
+Use "I/me/my" as {{ protagonistName }}, whom the player controls.
+Example: "I step forward..." or "I examine the door..."
 Do NOT use "you" to refer to the protagonist.{% elsif tense == 'past' %}Write in PAST TENSE, SECOND PERSON.
 Use "you/your" for the protagonist.
 Example: "You stepped forward..." or "You examined the door..."{% else %}Write in PRESENT TENSE, SECOND PERSON.
@@ -105,6 +111,17 @@ CRITICAL VOICE RULES:
 - Use THIRD PERSON. Refer to the protagonist as "{{ protagonistName }}" or "they/them".
 - Do NOT use "you" to address the protagonist.
 - You are the NARRATOR describing what happens, not the protagonist themselves.
+- NEVER write the protagonist's dialogue, thoughts, or decisions.
+
+End with a natural opening for action, not a direct question.{% elsif pov == 'first' %}Respond to the player's action with an engaging narrative continuation:
+1. Show the immediate results of their action through sensory detail
+2. Bring NPCs and environment to life with their own reactions
+3. Create new tension, opportunity, or discovery
+
+CRITICAL VOICE RULES:
+- Use FIRST PERSON (I/me/my) as {{ protagonistName }}. When the player writes "I do X", narrate the result as "I do X".
+- Do NOT use "you" to address the protagonist.
+- The player decides what {{ protagonistName }} does; you narrate what follows and what the world does back.
 - NEVER write the protagonist's dialogue, thoughts, or decisions.
 
 End with a natural opening for action, not a direct question.{% else %}Respond to the player's action with an engaging narrative continuation:

--- a/src/lib/services/prompts/templates/narrative.ts
+++ b/src/lib/services/prompts/templates/narrative.ts
@@ -162,18 +162,19 @@ End with a natural opening for action, not a direct question.{% endif %}
 {% endif %}{% if styleGuidance != blank %}{{ styleGuidance }}{% endif %}`,
   userContent: `{%- case narratorReinforcement %}
 {%- when 'minimal' %}You are the narrator of this interactive adventure. I am the player controlling protagonist named {{ protagonistName }}.
-{%- when 'full' %}You are the narrator of this interactive adventure. I am the player controlling protagonist named {{ protagonistName }}. Write in {{ tense }} tense, {{pov}} person.
+{%- when 'full' -%}
 {%- case pov -%}
-{%- when 'first' -%}{% assign actionExample = 'I push open the heavy door' %}
-{%- when 'second' -%}{% assign actionExample = 'You push open the heavy door' %}
-{%- else -%}{% assign actionExample = protagonistName | append: ' pushes open the heavy door' %}
-{%- endcase %}
+{%- when 'first' -%}{% assign povWord = 'first' %}{% assign actionExample = 'I push open the heavy door' %}
+{%- when 'third' -%}{% assign povWord = 'third' %}{% assign actionExample = protagonistName | append: ' pushes open the heavy door' %}
+{%- else -%}{% assign povWord = 'second' %}{% assign actionExample = 'You push open the heavy door' %}
+{%- endcase -%}
+You are the narrator of this interactive adventure. I am the player controlling protagonist named {{ protagonistName }}. Write in {{ tense }} tense, {{ povWord }} person.
 
 Your role:
 - Describe {{ protagonistName }}'s experiences and the world around them
 - Control all NPCs and the environment
 - NEVER write {{ protagonistName }}'s dialogue, decisions, or inner thoughts - I decide those
-- When I say "I do X", describe the results in {{pov}} person (e.g., "I open the door" -> "{{ actionExample }}...")
+- When I say "I do X", describe the results in {{ povWord }} person (e.g., "I open the door" -> "{{ actionExample }}...")
 
 I control {{protagonistName}}. You narrate what happens. Begin when I take my first action.
 {% endcase %}`,

--- a/src/lib/services/prompts/templates/narrative.ts
+++ b/src/lib/services/prompts/templates/narrative.ts
@@ -143,6 +143,23 @@ End with a natural opening for action, not a direct question.{% endif %}
 {% endif %}{% if tieredContextBlock != blank %}
 {{ tieredContextBlock }}
 {% endif %}{% if styleGuidance != blank %}{{ styleGuidance }}{% endif %}`,
+  userContent: `{%- case narratorReinforcement %}
+{%- when 'minimal' %}You are the narrator of this interactive adventure. I am the player controlling protagonist named {{ protagonistName }}.
+{%- when 'full' %}You are the narrator of this interactive adventure. I am the player controlling protagonist named {{ protagonistName }}. Write in {{ tense }} tense, {{pov}} person.
+    {%- case pov %} 
+      {%- when 'first' %} {% assign actionExample = 'I push open the heavy door' %} 
+      {%- when 'second' %} {% assign actionExample = 'You push open the heavy door' %} 
+      {%- when 'third' %} {% assign actionExample =  protagonistName | append: ' pushes open the heavy door' %} 
+    {%- endcase %}
+
+Your role:
+- Describe {{ protagonistName }}'s experiences and the world around them
+- Control all NPCs and the environment
+- NEVER write {{ protagonistName }}'s dialogue, decisions, or inner thoughts - I decide those
+- When I say "I do X", describe the results in {{pov}} person (e.g., "I open the door" -> "{{ actionExample }}...")
+
+I control {{protagonistName}}. You narrate what happens. Begin when I take my first action.
+{% endcase %}`,
 }
 
 const creativeWritingPromptTemplate: PromptTemplate = {
@@ -324,6 +341,39 @@ End at a natural narrative beat.{% endif %}
 {% endif %}{% if tieredContextBlock != blank %}
 {{ tieredContextBlock }}
 {% endif %}{% if styleGuidance != blank %}{{ styleGuidance }}{% endif %}`,
+  userContent: `{%- if narratorReinforcement == 'minimal' %}You are a skilled fiction writer. I am the author directing the story. Write what I ask for.{% endif %}
+{%- if narratorReinforcement == 'full' %}
+{%- case pov %}
+  {%- when 'first' %}You are a skilled fiction writer. Write in {{ tense }} tense, first person (I/me/my).
+
+Your role:
+- Write prose based on my directions from {{ protagonistName }}'s internal perspective
+- Bring scenes to life with vivid detail and internal monologue
+- Write for any character I direct you to, including dialogue, actions, and thoughts
+- Maintain consistent characterization throughout
+
+I am the author directing the story. Write what I ask for.
+  {%- when 'second' %}You are a skilled fiction writer. Write in {{ tense }} tense, second person (you/your).
+
+Your role:
+- Write prose based on my directions, addressing {{ protagonistName }} directly
+- Bring scenes to life with vivid detail
+- Write for any character I direct you to, including dialogue, actions, and thoughts
+- Maintain consistent characterization throughout
+
+I am the author directing the story. Write what I ask for.
+  {%- when 'third' %}You are a skilled fiction writer. Write in {{ tense }} tense, third person (they/their/character name).
+
+Your role:
+- Write prose based on my directions
+- Bring scenes to life with vivid detail
+- Write for any character I direct you to, including dialogue, actions, and thoughts
+- Maintain consistent characterization throughout
+
+I am the author directing the story. Write what I ask for.
+{%- endcase %}
+{%- endif %}
+`,
 }
 
 export const storyTemplates: PromptTemplate[] = [

--- a/src/lib/services/prompts/templates/narratorReinforcement.test.ts
+++ b/src/lib/services/prompts/templates/narratorReinforcement.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest'
+import {
+  templateUsesNarratorReinforcement,
+  narratorReinforcementIsHonoured,
+} from './narratorReinforcement'
+import { storyTemplates } from './narrative'
+
+describe('templateUsesNarratorReinforcement', () => {
+  it('sees the level branched on in a conditional', () => {
+    expect(
+      templateUsesNarratorReinforcement(`{% if narratorReinforcement == 'full' %}x{% endif %}`),
+    ).toBe(true)
+    expect(
+      templateUsesNarratorReinforcement(
+        `{% case narratorReinforcement %}{% when 'full' %}x{% endcase %}`,
+      ),
+    ).toBe(true)
+    expect(
+      templateUsesNarratorReinforcement(
+        `{% unless narratorReinforcement == 'none' %}x{% endunless %}`,
+      ),
+    ).toBe(true)
+  })
+
+  it('sees the level emitted directly', () => {
+    expect(templateUsesNarratorReinforcement('{{ narratorReinforcement }}')).toBe(true)
+  })
+
+  it('does not see an absent or unrelated template', () => {
+    expect(templateUsesNarratorReinforcement('{{ lengthInstruction }}')).toBe(false)
+    expect(templateUsesNarratorReinforcement('')).toBe(false)
+    expect(templateUsesNarratorReinforcement(null)).toBe(false)
+    expect(templateUsesNarratorReinforcement(undefined)).toBe(false)
+  })
+
+  it('does not match the identifier as part of a longer word', () => {
+    expect(templateUsesNarratorReinforcement('{{ narratorReinforcementLevel }}')).toBe(false)
+  })
+
+  it('holds for the templates the application ships', () => {
+    for (const template of storyTemplates) {
+      expect(templateUsesNarratorReinforcement(template.userContent)).toBe(true)
+    }
+  })
+})
+
+// The precedence a turn actually uses. Checking the system half alone -- the shape the
+// Response Length guard has, and the obvious thing to "simplify" this back to -- refuses the
+// setting for a story whose turn message honours it perfectly well.
+describe('narratorReinforcementIsHonoured', () => {
+  const BRANCHES = `{% if narratorReinforcement == 'full' %}x{% endif %}`
+  const PLAIN = 'You are the narrator.'
+
+  it('is honoured when the turn message branches on it', () => {
+    expect(
+      narratorReinforcementIsHonoured({
+        userTemplate: BRANCHES,
+        systemTemplate: PLAIN,
+        customSystemPrompt: undefined,
+      }),
+    ).toBe(true)
+  })
+
+  it('is honoured when a custom system prompt ignores it but the turn message does not', () => {
+    expect(
+      narratorReinforcementIsHonoured({
+        userTemplate: BRANCHES,
+        systemTemplate: PLAIN,
+        customSystemPrompt: PLAIN,
+      }),
+    ).toBe(true)
+  })
+
+  it('is honoured when only the system prompt carries it', () => {
+    expect(
+      narratorReinforcementIsHonoured({
+        userTemplate: PLAIN,
+        systemTemplate: BRANCHES,
+        customSystemPrompt: undefined,
+      }),
+    ).toBe(true)
+  })
+
+  it('is honoured when only a custom system prompt carries it', () => {
+    expect(
+      narratorReinforcementIsHonoured({
+        userTemplate: PLAIN,
+        systemTemplate: PLAIN,
+        customSystemPrompt: BRANCHES,
+      }),
+    ).toBe(true)
+  })
+
+  it('is not honoured when neither prompt references it', () => {
+    expect(
+      narratorReinforcementIsHonoured({
+        userTemplate: PLAIN,
+        systemTemplate: PLAIN,
+        customSystemPrompt: undefined,
+      }),
+    ).toBe(false)
+  })
+
+  it('ignores the pack system half that a custom system prompt has replaced', () => {
+    expect(
+      narratorReinforcementIsHonoured({
+        userTemplate: PLAIN,
+        systemTemplate: BRANCHES,
+        customSystemPrompt: PLAIN,
+      }),
+    ).toBe(false)
+  })
+
+  it('is honoured for a story on the shipped pack', () => {
+    for (const template of storyTemplates) {
+      expect(
+        narratorReinforcementIsHonoured({
+          userTemplate: template.userContent,
+          systemTemplate: template.content,
+          customSystemPrompt: undefined,
+        }),
+      ).toBe(true)
+    }
+  })
+})

--- a/src/lib/services/prompts/templates/narratorReinforcement.test.ts
+++ b/src/lib/services/prompts/templates/narratorReinforcement.test.ts
@@ -123,3 +123,40 @@ describe('narratorReinforcementIsHonoured', () => {
     }
   })
 })
+
+describe('templateUsesNarratorReinforcement — comments do not count', () => {
+  it('ignores a reference inside a comment block', () => {
+    expect(
+      templateUsesNarratorReinforcement(
+        `{% comment %}{% if narratorReinforcement == 'full' %}x{% endif %}{% endcomment %}`,
+      ),
+    ).toBe(false)
+  })
+
+  it('ignores a reference inside an inline comment', () => {
+    expect(templateUsesNarratorReinforcement(`{% # narratorReinforcement was here %}`)).toBe(false)
+  })
+
+  it('ignores whitespace-controlled comment tags', () => {
+    expect(
+      templateUsesNarratorReinforcement(`{%- comment -%}narratorReinforcement{%- endcomment -%}`),
+    ).toBe(false)
+  })
+
+  it('still sees an active branch alongside a commented one', () => {
+    expect(
+      templateUsesNarratorReinforcement(
+        `{% comment %}narratorReinforcement{% endcomment %}{% if narratorReinforcement == 'full' %}x{% endif %}`,
+      ),
+    ).toBe(true)
+  })
+
+  it('does not swallow the template around a comment', () => {
+    // The shipped adventure system prompt carries a {% comment %} block; stripping must not
+    // take the rest of the template with it.
+    const adventure = storyTemplates.find((t) => t.id === 'adventure')
+    expect(adventure?.content).toContain('{% comment %}')
+    expect(templateUsesNarratorReinforcement(adventure?.content)).toBe(false)
+    expect(templateUsesNarratorReinforcement(adventure?.userContent)).toBe(true)
+  })
+})

--- a/src/lib/services/prompts/templates/narratorReinforcement.test.ts
+++ b/src/lib/services/prompts/templates/narratorReinforcement.test.ts
@@ -160,3 +160,31 @@ describe('templateUsesNarratorReinforcement — comments do not count', () => {
     expect(templateUsesNarratorReinforcement(adventure?.userContent)).toBe(true)
   })
 })
+
+describe('templateUsesNarratorReinforcement — prose does not count', () => {
+  it('ignores the variable name written as prose', () => {
+    expect(
+      templateUsesNarratorReinforcement(
+        'Your narratorReinforcement level decides how much this prompt repeats.',
+      ),
+    ).toBe(false)
+  })
+
+  it('ignores it inside a quoted mention in prose', () => {
+    expect(templateUsesNarratorReinforcement('Set "narratorReinforcement" to none.')).toBe(false)
+  })
+
+  it('still sees a real branch alongside prose that names it', () => {
+    expect(
+      templateUsesNarratorReinforcement(
+        `Docs: narratorReinforcement picks a level.{% if narratorReinforcement == 'full' %}x{% endif %}`,
+      ),
+    ).toBe(true)
+  })
+
+  it('sees it in a tag split across lines', () => {
+    expect(
+      templateUsesNarratorReinforcement(`{% if\n  narratorReinforcement == 'full'\n%}x{% endif %}`),
+    ).toBe(true)
+  })
+})

--- a/src/lib/services/prompts/templates/narratorReinforcement.test.ts
+++ b/src/lib/services/prompts/templates/narratorReinforcement.test.ts
@@ -188,3 +188,40 @@ describe('templateUsesNarratorReinforcement — prose does not count', () => {
     ).toBe(true)
   })
 })
+
+describe('templateUsesNarratorReinforcement — unevaluated regions do not count', () => {
+  it('ignores a reference inside a raw block', () => {
+    expect(
+      templateUsesNarratorReinforcement(
+        `{% raw %}{% if narratorReinforcement == 'full' %}x{% endif %}{% endraw %}`,
+      ),
+    ).toBe(false)
+  })
+
+  it('ignores a reference inside a string literal', () => {
+    expect(templateUsesNarratorReinforcement(`{% assign label = 'narratorReinforcement' %}`)).toBe(
+      false,
+    )
+    expect(templateUsesNarratorReinforcement(`{{ "narratorReinforcement" }}`)).toBe(false)
+  })
+
+  it('still sees the variable in a tag that also carries a string literal', () => {
+    expect(
+      templateUsesNarratorReinforcement(`{% if narratorReinforcement == 'full' %}x{% endif %}`),
+    ).toBe(true)
+  })
+
+  it('still sees a real branch outside a raw block', () => {
+    expect(
+      templateUsesNarratorReinforcement(
+        `{% raw %}narratorReinforcement{% endraw %}{% if narratorReinforcement == 'none' %}x{% endif %}`,
+      ),
+    ).toBe(true)
+  })
+
+  it('holds for the templates the application ships', () => {
+    for (const template of storyTemplates) {
+      expect(templateUsesNarratorReinforcement(template.userContent)).toBe(true)
+    }
+  })
+})

--- a/src/lib/services/prompts/templates/narratorReinforcement.ts
+++ b/src/lib/services/prompts/templates/narratorReinforcement.ts
@@ -9,14 +9,21 @@
 /** The template variable this feeds. A prompt without it cannot honour the setting. */
 export const NARRATOR_REINFORCEMENT_VAR = 'narratorReinforcement'
 
+/** `{% comment %}` blocks and `{% # %}` inline comments, which Liquid renders as nothing. */
+const LIQUID_COMMENT =
+  /\{%-?\s*comment\s*-?%\}[\s\S]*?\{%-?\s*endcomment\s*-?%\}|\{%-?\s*#[\s\S]*?%\}/g
+
 /**
  * Whether a template would honour the setting at all.
  *
  * A bare mention rather than a `{{ }}` match: the level is branched on, so it appears in
- * `{% if %}`, `{% case %}` or `{% unless %}` as readily as in an output tag.
+ * `{% if %}`, `{% case %}` or `{% unless %}` as readily as in an output tag. Comments are
+ * removed first, so a branch someone commented out does not report the setting as working.
  */
 export function templateUsesNarratorReinforcement(content: string | null | undefined): boolean {
-  return !!content && new RegExp(`\\b${NARRATOR_REINFORCEMENT_VAR}\\b`).test(content)
+  if (!content) return false
+  const active = content.replace(LIQUID_COMMENT, '')
+  return new RegExp(`\\b${NARRATOR_REINFORCEMENT_VAR}\\b`).test(active)
 }
 
 /** The two prompts a turn sends, as the bodies that will actually run. */

--- a/src/lib/services/prompts/templates/narratorReinforcement.ts
+++ b/src/lib/services/prompts/templates/narratorReinforcement.ts
@@ -1,0 +1,47 @@
+/**
+ * The `narratorReinforcement` template variable, which the narrative templates branch on to
+ * decide how much of the narrator's role and the agency rules the turn message repeats.
+ *
+ * Unlike `lengthInstruction` this reaches the template as the raw level, not as a formatted
+ * sentence, so a pack decides what each level says.
+ */
+
+/** The template variable this feeds. A prompt without it cannot honour the setting. */
+export const NARRATOR_REINFORCEMENT_VAR = 'narratorReinforcement'
+
+/**
+ * Whether a template would honour the setting at all.
+ *
+ * A bare mention rather than a `{{ }}` match: the level is branched on, so it appears in
+ * `{% if %}`, `{% case %}` or `{% unless %}` as readily as in an output tag.
+ */
+export function templateUsesNarratorReinforcement(content: string | null | undefined): boolean {
+  return !!content && new RegExp(`\\b${NARRATOR_REINFORCEMENT_VAR}\\b`).test(content)
+}
+
+/** The two prompts a turn sends, as the bodies that will actually run. */
+export interface NarratorPrompts {
+  /** The pack's `<template-id>-user` half, which carries the turn message. */
+  userTemplate: string | null | undefined
+  /** The pack's system half. Ignored when a custom system prompt replaces it. */
+  systemTemplate: string | null | undefined
+  /** A per-story system prompt, when the story has one. */
+  customSystemPrompt: string | null | undefined
+}
+
+/**
+ * Whether the reinforcement setting can take effect for a story.
+ *
+ * The turn message comes from the pack whether or not a custom system prompt replaces the
+ * system half, so it counts either way — checking the system half alone, as the length
+ * guard does, would refuse a setting that works. A pack may carry the reinforcement in the
+ * system prompt instead, so a reference in either prompt is enough.
+ */
+export function narratorReinforcementIsHonoured({
+  userTemplate,
+  systemTemplate,
+  customSystemPrompt,
+}: NarratorPrompts): boolean {
+  if (templateUsesNarratorReinforcement(userTemplate)) return true
+  return templateUsesNarratorReinforcement(customSystemPrompt || systemTemplate)
+}

--- a/src/lib/services/prompts/templates/narratorReinforcement.ts
+++ b/src/lib/services/prompts/templates/narratorReinforcement.ts
@@ -9,26 +9,34 @@
 /** The template variable this feeds. A prompt without it cannot honour the setting. */
 export const NARRATOR_REINFORCEMENT_VAR = 'narratorReinforcement'
 
-/** `{% comment %}` blocks and `{% # %}` inline comments, which Liquid renders as nothing. */
-const LIQUID_COMMENT =
-  /\{%-?\s*comment\s*-?%\}[\s\S]*?\{%-?\s*endcomment\s*-?%\}|\{%-?\s*#[\s\S]*?%\}/g
+/**
+ * Regions Liquid never evaluates: `{% comment %}` blocks, `{% # %}` inline comments, and
+ * `{% raw %}` blocks, whose contents are emitted as text.
+ */
+const LIQUID_INERT =
+  /\{%-?\s*comment\s*-?%\}[\s\S]*?\{%-?\s*endcomment\s*-?%\}|\{%-?\s*raw\s*-?%\}[\s\S]*?\{%-?\s*endraw\s*-?%\}|\{%-?\s*#[\s\S]*?%\}/g
 
 /** Tags and output expressions — the only places a template can read a variable. */
 const LIQUID_EXPRESSION = /\{%-?[\s\S]*?-?%\}|\{\{-?[\s\S]*?-?\}\}/g
+
+/** String literals, which name no variable however they read. */
+const LIQUID_STRING = /'[^']*'|"[^"]*"/g
 
 /**
  * Whether a template would honour the setting at all.
  *
  * Any tag rather than a `{{ }}` match: the level is branched on, so it appears in
- * `{% if %}`, `{% case %}` or `{% unless %}` as readily as in an output tag. Comments are
- * removed and prose is ignored, so neither a branch someone commented out nor the variable's
- * name written in the prompt text reports the setting as working.
+ * `{% if %}`, `{% case %}` or `{% unless %}` as readily as in an output tag. What Liquid
+ * would not evaluate does not count -- comments, raw blocks, prose, and string literals --
+ * so only a reference the template can actually read reports the setting as working.
  */
 export function templateUsesNarratorReinforcement(content: string | null | undefined): boolean {
   if (!content) return false
-  const active = content.replace(LIQUID_COMMENT, '')
+  const active = content.replace(LIQUID_INERT, '')
   const reference = new RegExp(`\\b${NARRATOR_REINFORCEMENT_VAR}\\b`)
-  return (active.match(LIQUID_EXPRESSION) ?? []).some((expression) => reference.test(expression))
+  return (active.match(LIQUID_EXPRESSION) ?? []).some((expression) =>
+    reference.test(expression.replace(LIQUID_STRING, '')),
+  )
 }
 
 /** The two prompts a turn sends, as the bodies that will actually run. */

--- a/src/lib/services/prompts/templates/narratorReinforcement.ts
+++ b/src/lib/services/prompts/templates/narratorReinforcement.ts
@@ -13,17 +13,22 @@ export const NARRATOR_REINFORCEMENT_VAR = 'narratorReinforcement'
 const LIQUID_COMMENT =
   /\{%-?\s*comment\s*-?%\}[\s\S]*?\{%-?\s*endcomment\s*-?%\}|\{%-?\s*#[\s\S]*?%\}/g
 
+/** Tags and output expressions — the only places a template can read a variable. */
+const LIQUID_EXPRESSION = /\{%-?[\s\S]*?-?%\}|\{\{-?[\s\S]*?-?\}\}/g
+
 /**
  * Whether a template would honour the setting at all.
  *
- * A bare mention rather than a `{{ }}` match: the level is branched on, so it appears in
+ * Any tag rather than a `{{ }}` match: the level is branched on, so it appears in
  * `{% if %}`, `{% case %}` or `{% unless %}` as readily as in an output tag. Comments are
- * removed first, so a branch someone commented out does not report the setting as working.
+ * removed and prose is ignored, so neither a branch someone commented out nor the variable's
+ * name written in the prompt text reports the setting as working.
  */
 export function templateUsesNarratorReinforcement(content: string | null | undefined): boolean {
   if (!content) return false
   const active = content.replace(LIQUID_COMMENT, '')
-  return new RegExp(`\\b${NARRATOR_REINFORCEMENT_VAR}\\b`).test(active)
+  const reference = new RegExp(`\\b${NARRATOR_REINFORCEMENT_VAR}\\b`)
+  return (active.match(LIQUID_EXPRESSION) ?? []).some((expression) => reference.test(expression))
 }
 
 /** The two prompts a turn sends, as the bodies that will actually run. */

--- a/src/lib/services/templates/variables.ts
+++ b/src/lib/services/templates/variables.ts
@@ -473,6 +473,14 @@ export const RUNTIME_VARIABLES: VariableDefinition[] = [
     description: 'Response length instruction',
     required: false,
   },
+  {
+    name: 'narratorReinforcement',
+    type: 'text',
+    category: 'runtime',
+    description:
+      "How much the turn message repeats the narrator's role and agency rules: full, minimal or none",
+    required: false,
+  },
 
   // === Shared / Common ===
   {

--- a/src/lib/stores/wizard/narrativeStore.svelte.ts
+++ b/src/lib/stores/wizard/narrativeStore.svelte.ts
@@ -7,7 +7,14 @@ import {
 import { aiService } from '$lib/services/ai'
 import { TranslationService } from '$lib/services/ai/utils/TranslationService'
 import { settings } from '$lib/stores/settings.svelte'
-import type { StoryMode, POV, TargetLength, VaultLorebook, ImageGenerationMode } from '$lib/types'
+import type {
+  StoryMode,
+  POV,
+  TargetLength,
+  NarratorReinforcement,
+  VaultLorebook,
+  ImageGenerationMode,
+} from '$lib/types'
 import type { ImportedLorebookItem } from '$lib/components/wizard/wizardTypes'
 import type { GeneratedOpening } from '$lib/services/ai/sdk'
 
@@ -32,6 +39,7 @@ export class NarrativeStore {
   backgroundImagesEnabled = $state(false)
   referenceMode = $state(false)
   targetLength = $state<TargetLength>('dynamic')
+  narratorReinforcement = $state<NarratorReinforcement>('full')
 
   // Step 9: Opening
   storyTitle = $state('')

--- a/src/lib/stores/wizard/wizard.svelte.ts
+++ b/src/lib/stores/wizard/wizard.svelte.ts
@@ -416,6 +416,8 @@ export class WizardStore {
           imageGenerationMode: this.narrative.imageGenerationMode,
           backgroundImagesEnabled: this.narrative.backgroundImagesEnabled,
           referenceMode: this.narrative.referenceMode,
+          targetLength: this.narrative.targetLength,
+          narratorReinforcement: this.narrative.narratorReinforcement,
         },
         title: this.narrative.storyTitle,
         openingGuidance: this.narrative.openingGuidance.trim() || undefined,

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -113,6 +113,12 @@ export interface MemoryConfig {
 /** Target narration length for a turn. Drives `{{ lengthInstruction }}` in the prompt. */
 export type TargetLength = 'short' | 'medium' | 'long' | 'dynamic'
 
+/**
+ * How much of the narrator's role and the agency rules the turn message repeats ahead of the
+ * story content. The pack's narrator templates decide what each level says.
+ */
+export type NarratorReinforcement = 'full' | 'minimal' | 'none'
+
 /** How a story generates images: not at all, on the model's initiative, or embedded in the prose. */
 export type ImageGenerationMode = 'none' | 'agentic' | 'inline'
 
@@ -129,6 +135,7 @@ export interface StorySettings {
   backgroundImagesEnabled?: boolean
   referenceMode?: boolean
   targetLength?: TargetLength
+  narratorReinforcement?: NarratorReinforcement
   customSystemPrompt?: string // Per-story Liquid template override; bypasses pack template when set
 }
 


### PR DESCRIPTION
## Why

Every narrator turn sends two prompts. The system prompt is a pack template a user can edit; the user message was not — `NarrativeService` built it in TypeScript and prefixed it to every turn, restating the player-agency rules the pack already carries, including `NEVER write my dialogue, decisions, or inner thoughts`.

A user who reworded that rule in their own pack did not change it. They got both versions, and the one they did not write sat closest to the generation point — an open contradiction the model then spent its reasoning arbitrating.

Whether repeating those rules helps is model-dependent: a capable model needs them once, a smaller local one may do better with them twice. That was a per-story judgement frozen into the application.

## What changes

- **A `narratorReinforcement` story setting** — `full`, `minimal`, `none` — in the Writing Style controls the wizard and Story Settings share. Defaults to `full`.
- **The narrator turn message becomes a pack template.** `adventure` and `creative-writing` gain the `userContent` half every other prompt already has. The templates branch on the level in Liquid, the way they already branch on `pov` and `tense`, so **the pack decides what each level says** — the app only chooses between them.
- **`NarrativeService` stops building it.** Takes both halves of `ContextBuilder.render()` instead of discarding the user half; `buildPrimingMessage`, `buildAdventurePriming` and `buildCreativeWritingPriming` are gone.
- **The reinforcement is reworded while it moves.** The old text branched on `pov == 'third'` and treated everything else as second person, so a **first-person adventure was handed second-person instructions**. All three points of view now have their own text in both modes, and the tense comes from the story.
- **A setting that cannot take effect says so.** Story Settings disables the control when neither prompt references the variable — checking the user half *regardless* of a custom system prompt, since a custom system prompt replaces the system half only.
- **`docs/architecture/prompts.md` corrected.** It stated the two narrative templates deliberately had no user half, and never mentioned the hardcoded message standing in for it. That sentence is why this was hard to find.

## Compatibility

Existing stories default to `full`, so none loses its reinforcement — but **the wording changes**, deliberately. Only first-person adventures change materially, and they change from wrong to right.

No migration: `StorySettings` is a JSON blob and an absent key reads as the default. Existing packs pick up the two new templates through `backfillMissingTemplates`, which only ever inserts, so edited templates are untouched.

## Also fixed

`createStory` omitted `targetLength` from the `writingStyle` object it builds, so a Response Length chosen in the wizard never reached the created story even though `ScenarioService.prepareStoryData` maps it. Found while adding the new key to the same literal.

## Testing

`npm run check` 0 errors · `npm test` 1390 passed · `npm run lint` 0 errors.

Template tests assert the properties a reworded template must still hold — every POV names its own person, no unsubstituted variable survives, the agency rule appears at `full` and not below, `none` renders empty — rather than pinning wording that is meant to be edited. The availability precedence has its own tests taking prompt bodies as plain arguments, so nothing is mocked.

Manually verified in the app: the control, wizard persistence, the Vault insert menu, and the outgoing message at each level.

## Known gap, deferred

`backfillMissingTemplates` runs only from `PackService.initialize`, which is guarded by `this.initialized` and therefore runs once at startup. Neither `applyImport` nor `updatePackFromFile` calls it, so a pack imported from a file has no row for a template added since that file was exported, until the next launch. It still renders correctly — `ContextBuilder.resolveTemplate` falls back to `default-pack` and then to the compiled-in baseline — but the Vault editor lists rows, so the template is invisible and uneditable in that session.

This change makes it easier to hit by adding two templates. Closing it means making the backfill callable outside `initialize` (ideally per-pack, since an import knows which pack it wrote) and running it after both import paths; the invariant to preserve is that backfill only ever inserts, which is what makes running it more often safe. Left out of this PR because it belongs to the import path, not to narrator prompts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Narrator Reinforcement settings with Full, Minimal, and None options.
  * Made the setting available during story setup and preserved it in story configuration.
  * Applied reinforcement to narrative prompts according to the selected level.
  * Added reinforcement details to prompt previews and template testing.
  * Indicates when reinforcement is unavailable for selected templates.
  * Improved first-person narrative guidance for adventure stories.
* **Tests**
  * Added coverage for reinforcement rendering, prompt behavior, template detection, and supported narrative perspectives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
