### PR TITLE
feat: Q4 — classifier-emitted retrieval queries on the piggyback path

### DIFF
--- a/bench/fixture.ts
+++ b/bench/fixture.ts
@@ -338,20 +338,23 @@ export function passInputs(
   { sqlite, sceneCharacterIds, centroids }: Fixture,
   dim: number,
   chapterBudget: 'on' | 'off' = 'on',
+  emitted: number = 0,
 ) {
   const queryAll: QueryAll = async (sql, params) =>
     (sqlite.prepare(sql).all(...(params as never[])) as Record<string, unknown>[]).map((r) =>
       Object.values(r),
     )
   const rand = seededRandom(7)
-  // Each query sits near a different topic, so the three of them together
-  // reach a realistic slice of the pool rather than all of it or none.
-  const queryVectors = [0, 0, 0].map((t) => topical(centroids, t, rand, 0.9))
+  // One vector per live slot, each near a DIFFERENT topic. All three previously sat
+  // on centroid 0 and differed only by noise draw, so their KNN top-200 sets largely
+  // coincided — the pool union, and the ranker cost that scales with it, read
+  // optimistic in the very table this fixture prices. TOPICS is 12, so six fit.
+  const queryVectors = [0, 1, 2, 3, 4, 5].map((t) => topical(centroids, t, rand, 0.9))
 
   const deps = {
     queryAll,
     embedTexts: async (texts: string[]) => ({
-      vectors: texts.map((_, i) => queryVectors[i % 3]!),
+      vectors: texts.map((_, i) => queryVectors[i % queryVectors.length]!),
       dim,
     }),
     loadStaleRows: async () => [],
@@ -372,8 +375,11 @@ export function passInputs(
     query: {
       userAction,
       eraName: null,
-      // Non-null so all three queries stay live — steady-state, not the turn-1 cold start.
+      // Non-null so all three fixed queries stay live — steady-state, not the turn-1 cold start.
       piggybackSummary: prose(rand, 20),
+      // retrieval.md → Q4. 0 is the pre-PR-2 regime, 3 the worst case the cost
+      // budget has to hold at.
+      emittedQueries: Array.from({ length: emitted }, (_, i) => `${prose(rand, 8)} ${i}`),
     },
     sceneCharacterIds,
     sceneEntityIds: sceneCharacterIds,

--- a/bench/fixture.ts
+++ b/bench/fixture.ts
@@ -345,10 +345,9 @@ export function passInputs(
       Object.values(r),
     )
   const rand = seededRandom(7)
-  // One vector per live slot, each near a DIFFERENT topic. All three previously sat
-  // on centroid 0 and differed only by noise draw, so their KNN top-200 sets largely
-  // coincided — the pool union, and the ranker cost that scales with it, read
-  // optimistic in the very table this fixture prices. TOPICS is 12, so six fit.
+  // One vector per live slot, each near a DIFFERENT topic: same-centroid vectors' KNN
+  // top-200s coincide, making the pool union — and the ranker cost that scales with it —
+  // read optimistic. TOPICS is 12, so six fit.
   const queryVectors = [0, 1, 2, 3, 4, 5].map((t) => topical(centroids, t, rand, 0.9))
 
   const deps = {

--- a/bench/fixture.ts
+++ b/bench/fixture.ts
@@ -377,8 +377,8 @@ export function passInputs(
       eraName: null,
       // Non-null so all three fixed queries stay live — steady-state, not the turn-1 cold start.
       piggybackSummary: prose(rand, 20),
-      // retrieval.md → Q4. 0 is the pre-PR-2 regime, 3 the worst case the cost
-      // budget has to hold at.
+      // retrieval.md → Q4. 0 is the three-vector stack, 3 the Q4 cap and the worst
+      // case the cost budget has to hold at.
       emittedQueries: Array.from({ length: emitted }, (_, i) => `${prose(rand, 8)} ${i}`),
     },
     sceneCharacterIds,

--- a/bench/fixture.ts
+++ b/bench/fixture.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readdirSync, readFileSync } from 'node:fs'
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
@@ -113,7 +113,24 @@ export function build(scale: Scale, dim: number): Fixture {
   // File-backed, not :memory: — the pass is read-heavy and an in-memory db
   // prices away the page-cache and I/O the desktop app actually pays.
   const dir = mkdtempSync(join(tmpdir(), 'retrieval-bench-'))
-  const sqlite = new DatabaseSync(join(dir, 'bench.db'), { allowExtension: true })
+  let sqlite: DatabaseSync | undefined
+  try {
+    sqlite = new DatabaseSync(join(dir, 'bench.db'), { allowExtension: true })
+    return populate(sqlite, dir, scale, dim)
+  } catch (err) {
+    // A caller can only close what build returned, so a throw before that strands
+    // the temp db for the process's lifetime — 24 fixtures a run.
+    try {
+      sqlite?.close()
+    } catch {
+      // The construction failure is the useful one; don't mask it.
+    }
+    rmSync(dir, { recursive: true, force: true })
+    throw err
+  }
+}
+
+function populate(sqlite: DatabaseSync, dir: string, scale: Scale, dim: number): Fixture {
   sqlite.loadExtension(getLoadablePath())
   migrateInto(sqlite)
   for (const kind of [

--- a/bench/retrieval-cost.test.ts
+++ b/bench/retrieval-cost.test.ts
@@ -26,24 +26,26 @@ describe('retrieval cost', () => {
   for (const dim of [384, 768]) {
     for (const scale of SCALES) {
       for (const chapterBudget of ['on', 'off'] as const) {
-        it(`dim ${dim} — ${scale.label} — boost ${chapterBudget}`, async () => {
-          // A pass that throws mid-run must still drop its handle and temp dir:
-          // the run is 12 fixtures, each a file-backed db under tmpdir.
-          let sqlite: DatabaseSync | undefined
-          let dir: string | undefined
-          try {
-            const fixture = build(scale, dim)
-            sqlite = fixture.sqlite
-            dir = fixture.dir
-            await measure(fixture, dim, scale, chapterBudget)
-          } finally {
+        for (const emitted of [0, 3]) {
+          it(`dim ${dim} — ${scale.label} — boost ${chapterBudget} — Q4 ${emitted}`, async () => {
+            // A pass that throws mid-run must still drop its handle and temp dir:
+            // the run is 24 fixtures, each a file-backed db under tmpdir.
+            let sqlite: DatabaseSync | undefined
+            let dir: string | undefined
             try {
-              sqlite?.close()
+              const fixture = build(scale, dim)
+              sqlite = fixture.sqlite
+              dir = fixture.dir
+              await measure(fixture, dim, scale, chapterBudget, emitted)
             } finally {
-              if (dir !== undefined) rmSync(dir, { recursive: true, force: true })
+              try {
+                sqlite?.close()
+              } finally {
+                if (dir !== undefined) rmSync(dir, { recursive: true, force: true })
+              }
             }
-          }
-        }, 300_000)
+          }, 300_000)
+        }
       }
     }
   }
@@ -54,8 +56,9 @@ async function measure(
   dim: number,
   scale: Scale,
   chapterBudget: 'on' | 'off',
+  emitted: number,
 ): Promise<void> {
-  const { deps, params } = passInputs(fixture, dim, chapterBudget)
+  const { deps, params } = passInputs(fixture, dim, chapterBudget, emitted)
 
   const samples: Record<string, number>[] = []
   let funnels = ''
@@ -72,7 +75,7 @@ async function measure(
     .map((k) => `${k.replace('Ms', '')}=${median(samples.map((s) => s[k]!)).toFixed(1)}`)
     .join('  ')
   process.stdout.write(
-    `  dim=${dim} ${scale.label.padEnd(16)} boost=${chapterBudget.padEnd(3)} ${line}\n` +
+    `  dim=${dim} ${scale.label.padEnd(16)} boost=${chapterBudget.padEnd(3)} q4=${emitted} ${line}\n` +
       `    pools ${funnels}\n`,
   )
 }

--- a/components/compounds/entry-card.stories.tsx
+++ b/components/compounds/entry-card.stories.tsx
@@ -976,6 +976,7 @@ const reportedProps = {
   currentLocationId: LOC_A,
   entityNames,
   summary: 'Aria pushed into the marshes and met an exiled noble.',
+  retrievalQueries: ["House Eldrin's history and its sigil", 'exiled nobility of the marshes'],
   stateReport: {
     layer: 'piggyback_tagged_block' as const,
     sceneEntities: [CHAR_A, CHAR_B],
@@ -1005,6 +1006,20 @@ export const WorldStateReported: StoryT = {
     expect(screen.getByText('Ashfen Marshes')).toBeVisible()
     expect(screen.getByText('cloak now muddied to the waist')).toBeVisible()
     expect(screen.getByText('120s')).toBeVisible()
+    expect(screen.getByText("House Eldrin's history and its sigil")).toBeVisible()
+    expect(screen.getByText('exiled nobility of the marshes')).toBeVisible()
+  },
+}
+
+/** An empty array is a legal `retrievalQueries` value (the classifier emitted no queries
+ *  this turn), distinct from `undefined` (no metadata at all) — but both must render no
+ *  group, since a labelled group with no rows beneath it is a visible defect. */
+export const WorldStateEmptyRetrievalQueries: StoryT = {
+  ...wrap,
+  args: { ...baseProps, ...aiEntry, ...reportedProps, retrievalQueries: [] },
+  play: async () => {
+    await openPanel()
+    expect(screen.queryByText('Retrieval asks')).not.toBeInTheDocument()
   },
 }
 

--- a/components/compounds/entry-card.stories.tsx
+++ b/components/compounds/entry-card.stories.tsx
@@ -1011,9 +1011,8 @@ export const WorldStateReported: StoryT = {
   },
 }
 
-/** An empty array is a legal `retrievalQueries` value (the classifier emitted no queries
- *  this turn), distinct from `undefined` (no metadata at all) — but both must render no
- *  group, since a labelled group with no rows beneath it is a visible defect. */
+/** Empty `retrievalQueries` (classifier emitted none) and `undefined` (no metadata) must both
+ *  render no group — a labelled group with no rows beneath it is a visible defect. */
 export const WorldStateEmptyRetrievalQueries: StoryT = {
   ...wrap,
   args: { ...baseProps, ...aiEntry, ...reportedProps, retrievalQueries: [] },

--- a/components/compounds/entry-card.tsx
+++ b/components/compounds/entry-card.tsx
@@ -110,9 +110,10 @@ type EntryCardProps = {
   /** What this turn reported. Absent means the entry reported nothing. */
   stateReport?: EntryMetadata['stateReport']
   summary?: string
-  /** Up to three classifier-emitted queries for next turn's retrieval; deduplicated
-   *  at parse time. Read-only — whether they helped is answered in the probe. */
-  retrievalQueries?: string[]
+  /** Up to three classifier-emitted queries for next turn's retrieval; trimmed,
+   *  deduplicated and capped on the write path. Read-only — whether they helped is
+   *  answered in the probe. */
+  retrievalQueries?: readonly string[]
   /**
    * Desktop/tablet: fired by the in-card Dialog's Save. Resolve `{ ok: false }` to
    * report a failed write, carrying the action layer's rejection code where there is
@@ -498,7 +499,7 @@ function WorldStatePanel({
   entityNames: readonly ResolvedEntity[]
   stateReport?: EntryMetadata['stateReport']
   summary?: string
-  retrievalQueries?: string[]
+  retrievalQueries?: readonly string[]
   legacyStateRaw?: string
   onOpenSceneEdit?: () => void
   editTriggerRef: RefObject<View | null>

--- a/components/compounds/entry-card.tsx
+++ b/components/compounds/entry-card.tsx
@@ -110,6 +110,9 @@ type EntryCardProps = {
   /** What this turn reported. Absent means the entry reported nothing. */
   stateReport?: EntryMetadata['stateReport']
   summary?: string
+  /** Up to three classifier-emitted queries for next turn's retrieval; deduplicated
+   *  at parse time. Read-only — whether they helped is answered in the probe. */
+  retrievalQueries?: string[]
   /**
    * Desktop/tablet: fired by the in-card Dialog's Save. Resolve `{ ok: false }` to
    * report a failed write, carrying the action layer's rejection code where there is
@@ -485,6 +488,7 @@ function WorldStatePanel({
   entityNames,
   stateReport,
   summary,
+  retrievalQueries,
   legacyStateRaw,
   onOpenSceneEdit,
   editTriggerRef,
@@ -494,6 +498,7 @@ function WorldStatePanel({
   entityNames: readonly ResolvedEntity[]
   stateReport?: EntryMetadata['stateReport']
   summary?: string
+  retrievalQueries?: string[]
   legacyStateRaw?: string
   onOpenSceneEdit?: () => void
   editTriggerRef: RefObject<View | null>
@@ -647,6 +652,16 @@ function WorldStatePanel({
         </StateGroup>
       ) : null}
 
+      {/* Read-only, like the rest of the panel: it records what was asked, and the
+          probe is where whether it helped gets answered (entry-card.md → Panel anatomy). */}
+      {retrievalQueries != null && retrievalQueries.length > 0 ? (
+        <StateGroup label={t('reader:entryCard.stateRetrievalAsks')}>
+          {retrievalQueries.map((query) => (
+            <StateLine key={query}>{query}</StateLine>
+          ))}
+        </StateGroup>
+      ) : null}
+
       {failedFields.length > 0 ? (
         <View className="mt-2 rounded border border-warning p-1.5">
           <Text size="xs" className="text-warning">
@@ -731,6 +746,7 @@ export function EntryCard({
   entityNames,
   stateReport,
   summary,
+  retrievalQueries,
   onEditScene,
   onRequestEditScene,
   sceneOptions,
@@ -904,6 +920,7 @@ export function EntryCard({
             entityNames={entityNames ?? []}
             stateReport={stateReport}
             summary={summary}
+            retrievalQueries={retrievalQueries}
             legacyStateRaw={stateRaw}
             onOpenSceneEdit={sceneEdit?.open}
             editTriggerRef={sceneTriggerRef}

--- a/components/compounds/entry-card.tsx
+++ b/components/compounds/entry-card.tsx
@@ -653,8 +653,7 @@ function WorldStatePanel({
         </StateGroup>
       ) : null}
 
-      {/* Read-only, like the rest of the panel: it records what was asked, and the
-          probe is where whether it helped gets answered (entry-card.md → Panel anatomy). */}
+      {/* Read-only, like the rest of the panel (entry-card.md → Panel anatomy). */}
       {retrievalQueries != null && retrievalQueries.length > 0 ? (
         <StateGroup label={t('reader:entryCard.stateRetrievalAsks')}>
           {retrievalQueries.map((query) => (

--- a/components/reader/reader-surface.tsx
+++ b/components/reader/reader-surface.tsx
@@ -170,6 +170,7 @@ const ReaderRow = memo(function ReaderRow({
       entityNames={entityNames}
       stateReport={row.metadata?.stateReport}
       summary={row.metadata?.summary}
+      retrievalQueries={row.metadata?.retrievalQueries}
       sceneOptions={sceneEditable ? sceneOptions : undefined}
       onEditScene={sceneEditable ? (next) => onEditScene(row.id, next) : undefined}
       onRequestEditScene={sceneEditable ? () => onRequestEditScene(row.id) : undefined}

--- a/docs/implementation/triage.md
+++ b/docs/implementation/triage.md
@@ -73,3 +73,19 @@ slice-planning gate forces its resolution before that slice is planned.
   query, so this has no home there. Revisit once real captures
   accumulate; the answer may be that no automatic drop is wanted and the
   number stays diagnostic.
+
+- **The Q4-saturated retrieval pass breaches its own cost ceiling at
+  dim 768, and no one has chosen a response.**
+  [`retrieval.md → Per-turn cost budget`](../memory/retrieval.md#per-turn-cost-budget)
+  measures it at ~319ms against the Target bullet's stated ceiling of
+  under ~250ms at the top of the projected range on desktop. Not an
+  outlier: it is the worst case the Q4 cap allows — top of the
+  projected range, all three Q4 slots filled, dim 768. The doc names
+  three options without choosing one: move the ceiling, tighten the Q4
+  cap, or drop dim 768 as a desktop default. Dim 384 at the same scale
+  measures ~182ms and sits comfortably inside, so the breach is
+  specific to the larger embedding model. Unowned because commit
+  `220e94a2` correctly deleted the triage entry that used to own Q4's
+  projected cost once this branch measured it — but that left the
+  decision living only as canon prose, with no queue entry to route it
+  to an owner.

--- a/docs/implementation/triage.md
+++ b/docs/implementation/triage.md
@@ -60,27 +60,6 @@ slice-planning gate forces its resolution before that slice is planned.
     every file sets for itself through the global decorator in
     `.storybook/preview.tsx`.
 
-- **The Q4 query slot's cost is projected, not measured, and no slice
-  owns measuring it.** The
-  [query-stack design](../explorations/2026-09-06-retrieval-query-stack.md)
-  takes the retrieval pass from three query vectors to as many as six,
-  and states plainly that the numbers in
-  [`retrieval.md → Per-turn cost budget`](../memory/retrieval.md#per-turn-cost-budget)
-  were not re-run: the ~143ms / ~250ms figures are a linear
-  extrapolation of a measured three-query table. Two terms sit outside
-  even that extrapolation — the embedder, which every figure in that
-  table explicitly excludes and which doubles from three calls per turn
-  to six, and mobile, which has never run the ranker at all and now
-  doubles an already-open risk. The doc assigns both to "whichever slice
-  implements Q4"; no such slice exists, and M3.4 is closed. Route this
-  to that slice's Open questions the moment it is drafted, so the
-  planning gate forces `pnpm bench:retrieval` to be re-run against the
-  real stack before the numbers in canon are trusted.
-  **Owner: PR 2 of the query-stack stack**, the one that sources Q4
-  from `metadata.retrievalQueries` — the mechanism landed without a
-  slice, so nothing will fire the routing above. PR 2 is where Q4
-  first costs anything, and it carries the re-run.
-
 - **Nothing decides when a degenerate retrieval query should be
   dropped.**
   [`retrieval.md → Redundancy`](../memory/retrieval.md#redundancy--reporting-a-degenerate-query)

--- a/docs/memory/probe.md
+++ b/docs/memory/probe.md
@@ -139,9 +139,17 @@ Per capture:
   — the share of its own top-K that the structural floor had already
   seated. That number is the only way to tell a degenerate query from a
   useful one after the fact, which is the failure the removed
-  prose-extract slot could never report. Query **vectors are never
-  stored**, in either mode — see
-  [Deep mode](#deep-mode-per-capture-opt-in).
+  prose-extract slot could never report. The cut is the **ten nearest
+  rows**, merged across
+  [the kinds the floor can seat](./retrieval.md#structural-floor--always-inject)
+  — entities, lore and threads, and no others — and `redundancy_k`
+  stores the realised size of that cut beside the ratio. Both are
+  needed: at small `k` the ratio describes the corpus as much as the
+  query, since one duplicate reads as 0.33 over three rows and 0.10
+  over ten, and `funnels.pool_size` cannot stand in for the
+  denominator because that is the post-filter pool rather than the cut
+  the ratio was taken over. Query **vectors are never stored**, in
+  either mode — see [Deep mode](#deep-mode-per-capture-opt-in).
 - **Keyword scan surface.** `scan_text` — the narrative text
   `kw_boost_value` was matched against, per
   [`retrieval.md → Keyword scan surface`](./retrieval.md#keyword-scan-surface).

--- a/docs/memory/retrieval.md
+++ b/docs/memory/retrieval.md
@@ -870,6 +870,15 @@ over exactly the kinds the
 [structural floor](#structural-floor--always-inject) can seat, and no
 others.
 
+**The denominator moves with `keywordRetrieval.mode`.** It counts
+only `floor.seatedIds`, which is exact under the default `boost`
+mode but excludes rows [keyword injection](#keyword-injection) seats
+under `inject`, so a query can ask for something the prompt already
+carries via injection and still score near 0. Not a defect — canon's
+"structural floor" means the floor, not the full prompt — but it is
+a caveat whoever eventually sets the warn threshold will need to
+weigh.
+
 **The realised `k` travels with the ratio.** A corpus too small to fill
 the cut yields fewer than ten rows, and one duplicate in three is not
 the same evidence as one in ten. The probe stores both
@@ -1940,6 +1949,10 @@ saturated)** and the second are the same pass with the Q4 slot at its
 cap of three emitted queries, which is the worst case the budget has to
 hold at. Lower scales are cheaper roughly in proportion: at `q4=0`,
 ~68ms / ~126ms at 1200 happenings and ~110ms / ~179ms at 3600.
+`rankMs` carries no `q4` axis because it does not move with query
+count — the pre-filter caps what gets scored before ranking runs
+regardless of how many query vectors fed KNN. Measured at dim 384:
+~41.7ms at `q4=0` versus ~41.9ms at `q4=3`.
 
 **Why the shipped figures moved.** The bench fixture built all three
 query vectors on one topic centroid — the topic index was mapped over
@@ -1976,10 +1989,10 @@ not:
   endpoints measured under the pre-fix fixture, so read the drop and
   not the figures. The saving is not separately quotable: tokenization
   runs inside the same kept-row map that feeds MMR, so the two rows
-  this table used to carry are one row and one `rankMs` span. Scoring and the sort do
-  still walk the whole pool — the bench's 477-row swing between boost
-  on and off moves `rankMs` by ~1ms, which is what "scales with pool
-  size" is now worth here.
+  this table used to carry are one row and one `rankMs` span. Scoring
+  and the sort do still walk the whole pool — the bench's 477-row
+  swing between boost on and off moves `rankMs` by ~1ms, which is what
+  "scales with pool size" is now worth here.
 - **MMR is not the problem it looked like.** The measured ~6.5ms per
   type at N=200 is real, but only happenings reaches 200 in a typical
   story: entities, lore and threads are human-authored and sit in the
@@ -2036,8 +2049,8 @@ per-query KNN numbers under
 [Performance characteristics](#performance-characteristics--poc-findings)
 are the only mobile evidence and they predate the shipped pass, which
 issues five KNN passes per live query rather than three total — up to
-thirty with Q4 at its cap. Nothing has run the ranker on-device. Treat the mobile budget as open, not as a scaled
-copy of this table.
+thirty with Q4 at its cap. Nothing has run the ranker on-device.
+Treat the mobile budget as open, not as a scaled copy of this table.
 
 ### Pseudocode
 

--- a/docs/memory/retrieval.md
+++ b/docs/memory/retrieval.md
@@ -795,9 +795,11 @@ schema. Answering it requires seeing what the turn was already given,
 which is why the fallback receives the assembled memory blocks
 ([`piggyback.md → Fallback classifier context`](./piggyback.md#fallback-classifier-context)).
 
-**Capped at three, and the cap is a cost decision.** KNN scales
-linearly in query count and is the pass's second-largest term; six
-queries doubles it to thirty passes across five types. See
+**Capped at three, and the cap is a cost decision.** KNN is the pass's
+largest measured span and it scales in query count: six live queries
+take it from fifteen `sqlite-vec` passes to thirty, measured at
+~77ms → ~121ms at dim 384 and ~150ms → ~244ms at dim 768. Well under a
+doubling, but it is the term the cap exists to bound. See
 [Per-turn cost budget](#per-turn-cost-budget).
 
 **Emission contract.** Absent-tolerant and malformed-tolerant. Absence
@@ -845,12 +847,48 @@ Near 1.0 means the query asked for what the turn already had; near 0
 means it surfaced something the
 [structural floor](#structural-floor--always-inject) did not.
 
-Nothing new is computed. Pool assembly already discards that
+**The cut is the ten nearest rows, taken globally.** `topK` is the ten
+rows the query wanted most, merged across the floor-seatable kinds and
+re-sorted by distance — not each kind's own cut, and not the full
+`KNN_K` pass. Global rather than per-kind because a per-kind cut then
+unioned dilutes by the kinds that rarely reach the floor: lore reaches
+it only through a user-marked `always`. Merging is legitimate because
+distances are comparable across those tables — every stored and query
+vector is unit-norm, so L2 order is cosine order.
+
+Pinning the cut is what makes the ratio mean anything. Read instead as
+the full `KNN_K = 200` pass unioned over those kinds, `k` runs to ~600
+against a floor holding ~12 ids: the ratio is then bounded above at
+~0.02, a maximally degenerate query and a perfectly novel one land four
+thousandths apart, and the "near 1.0" above is arithmetically
+unreachable.
+
+**Entities, lore and threads only.** `floor.seatedIds` can hold no
+chapter or happening id, so admitting either kind's top-K to the
+denominator would deflate every ratio by construction. The cut is taken
+over exactly the kinds the
+[structural floor](#structural-floor--always-inject) can seat, and no
+others.
+
+**The realised `k` travels with the ratio.** A corpus too small to fill
+the cut yields fewer than ten rows, and one duplicate in three is not
+the same evidence as one in ten. The probe stores both
+([`probe.md → What gets captured`](./probe.md#what-gets-captured--light-mode-default)).
+
+**Cheap, but not free.** Pool assembly already discards that
 intersection on every pass — the floor filters run after KNN, not
-inside it — so this records what is currently dropped silently. It is
-captured per query in the probe ([`probe.md`](./probe.md)) and is
-**observability only** in v1: no automatic dropping, because the
-threshold that would justify one needs data nobody has yet.
+inside it — so the metric reads what was being dropped silently. What
+it costs is granularity: assembly used to collapse its KNN hits into a
+single union set, and keeping them per query meant widening the KNN
+result rows it carries and reshaping what it returns.
+
+It is **observability only** in v1: no automatic dropping, because the
+threshold that would justify one needs data nobody has yet. A pinned
+cut makes the full range reachable and so makes a warn threshold
+meaningful for the first time — the
+[memory probe](../ui/screens/memory-probe/memory-probe.md#queries-tab)
+marks a degenerate emission with ⚠ — but no number is set for it, here
+or in code. Choosing one is open.
 
 What it does not catch is a query retrieving novel but irrelevant rows.
 It detects "asked for what it already had", which is the predicted
@@ -1610,7 +1648,9 @@ vector fetched by id — and `id` is a vec0 metadata column with no
 push-down, so that fetch scans the branch partition. Measured at dim
 384: seating five of sixty chapters admits ~480 happenings on top of a
 ~290-row KNN pool, and the whole mechanism costs ~24ms of a ~108ms pass
-at 6000 happenings, against ~5ms at 1200. It cost ~44ms before
+at 6000 happenings, against ~5ms at 1200 — figures from the pre-fix
+bench fixture, so read the share rather than the milliseconds
+([Per-turn cost budget](#per-turn-cost-budget)). It cost ~44ms before
 tokenization moved past the pre-filter: the admitted rows land beyond
 rank 200 and are no longer priced. Two consequences worth holding:
 
@@ -1726,7 +1766,7 @@ worst case at ~6.5ms per type at dim 384 and ~12.5ms at dim 768.
 
 In practice only happenings reaches 200; the other four types are
 bounded by how much a person authored. Measured across all five types
-together, scoring plus tokenization plus MMR plus budget fill is ~29ms
+together, scoring plus tokenization plus MMR plus budget fill is ~40ms
 at dim 384 — see [Per-turn cost budget](#per-turn-cost-budget). The
 bench no longer separates MMR from the tokenization the same map does,
 so the ~6.5ms figure above predates that merge and is not re-derivable
@@ -1866,10 +1906,10 @@ sound because a pre-filtered row can never be seated — not by the pass
 and not by the probe simulator, which cannot un-drop it without the
 per-row vectors that would let it re-run MMR. Per-row cost is ~45-60 µs
 with js-tiktoken `o200k_base`; capping the row count is what took the
-pass from ~140ms to ~108ms at dim 384 (see
-[Per-turn cost budget](#per-turn-cost-budget)). A `token_count INTEGER`
-column per table remains the fallback if that is not enough, with cache
-invalidation on row update.
+pass from ~140ms to ~108ms at dim 384 — both endpoints from the pre-fix
+bench fixture (see [Per-turn cost budget](#per-turn-cost-budget)).
+A `token_count INTEGER` column per table remains the fallback if that
+is not enough, with cache invalidation on row update.
 
 ### Per-turn cost budget
 
@@ -1877,29 +1917,52 @@ Measured, not estimated: `bench/retrieval-cost.test.ts` (`pnpm
 bench:retrieval`) prices the shipped pass against the volumes
 [Scale assumptions](#scale-assumptions) projects. Numbers below are
 desktop (Node 24 / V8, file-backed SQLite, `sqlite-vec` 0.1.9),
-median of seven warm passes, **excluding the embedder and IPC**.
+median of seven warm passes, **excluding the embedder and IPC**, taken
+on an otherwise-quiet machine across two consecutive runs that agreed
+within 2-4%.
 
-| Step                                    | dim 384 | dim 768 | Scales with                           |
-| --------------------------------------- | ------- | ------- | ------------------------------------- |
-| Source reads, awareness, chapter JOIN   | ~21ms   | ~21ms   | branch entity / lore / thread count   |
-| KNN — 3 vectors × 5 types               | ~35ms   | ~75ms   | **query count**, rows per family, dim |
-| Chapter-range admission                 | ~21ms   | ~24ms   | happenings on the branch              |
-| Candidate assembly                      | ~6ms    | ~8ms    | pool size                             |
-| Scoring, tokenization, MMR, budget fill | ~29ms   | ~44ms   | min(pool, `preFilterTopN`) per type   |
-| **Total**                               | ~108ms  | ~175ms  |                                       |
+| Step                                                   | dim 384 | dim 768 | Scales with                           |
+| ------------------------------------------------------ | ------- | ------- | ------------------------------------- |
+| `knnMs` — 3 live queries (`q4=0`)                      | ~77ms   | ~150ms  | **query count**, rows per family, dim |
+| `knnMs` — 6 live queries (`q4=3`, the Q4 cap)          | ~121ms  | ~244ms  | **query count**, rows per family, dim |
+| `rankMs` — scoring, tokenization, MMR, budget fill     | ~40ms   | ~57ms   | min(pool, `preFilterTopN`) per type   |
+| **Total**                                              | ~136ms  | ~228ms  |                                       |
+| **Total (Q4 saturated)**                               | ~182ms  | ~319ms  |                                       |
+| M3.4 sub-split — source reads, awareness, chapter JOIN | ~21ms   | ~21ms   | branch entity / lore / thread count   |
+| M3.4 sub-split — KNN, 3 vectors × 5 types              | ~35ms   | ~75ms   | **query count**, rows per family, dim |
+| M3.4 sub-split — chapter-range admission               | ~21ms   | ~24ms   | happenings on the branch              |
+| M3.4 sub-split — candidate assembly                    | ~6ms    | ~8ms    | pool size                             |
 
-Read at 6000 happenings / 15 000 awareness / 60 chapters — the top of
-the projected range. Lower scales are cheaper roughly in proportion:
-~51ms / ~91ms at 1200 happenings, ~87ms / ~134ms at 3600.
+Read at 6000 happenings / 15 000 awareness / 60 chapters with the
+chapter-match boost on — the top of the projected range. **Total** and
+the first `knnMs` row are the three-vector stack; **Total (Q4
+saturated)** and the second are the same pass with the Q4 slot at its
+cap of three emitted queries, which is the worst case the budget has to
+hold at. Lower scales are cheaper roughly in proportion: at `q4=0`,
+~68ms / ~126ms at 1200 happenings and ~110ms / ~179ms at 3600.
+
+**Why the shipped figures moved.** The bench fixture built all three
+query vectors on one topic centroid — the topic index was mapped over
+but never read — so their KNN top-200 sets largely coincided, the pool
+union came out small, and every term that scales with that union read
+optimistic in the table that exists to price it. The fixture now takes
+one centroid per query and carries a `q4` axis. That is what moved
+**Total** from ~108ms to ~136ms at dim 384 and `rankMs` from ~29ms to
+~40ms, and it is where the saturated rows come from.
 
 **Which rows a re-run reproduces.** The bench emits five spans:
-`totalMs`, `syncMs`, `embedMs`, `knnMs`, `rankMs`. Only two table rows
-map onto one of them — **Total** is `totalMs`, and **Scoring,
-tokenization, MMR, budget fill** is `rankMs`. The four rows above it
-are an ad-hoc M3.4 sub-split of `knnMs` and of the unnamed span before
-it (source loading has no `RetrievalTimings` member), hand-measured
-once and not instrumented since. Read them as proportions of the
-whole, not as figures `pnpm bench:retrieval` re-derives.
+`totalMs`, `syncMs`, `embedMs`, `knnMs`, `rankMs`. The first five table
+rows are spans: **Total** and **Total (Q4 saturated)** are `totalMs` at
+`q4=0` and `q4=3`, the two `knnMs` rows are that span at the same two
+settings, and the `rankMs` row is that span. The four **M3.4
+sub-split** rows are not. They are an ad-hoc split of `knnMs` and of
+the unnamed span before it (source loading has no `RetrievalTimings`
+member), hand-measured once during M3.4 and not instrumented since — so
+they predate the fixture fix and no longer sum to **Total**, and their
+KNN row is one component of that split rather than `knnMs` itself, so
+the gap between its ~35ms / ~75ms and the measured `knnMs` rows is not
+a discrepancy. Re-deriving them would mean instrumenting `runRetrieval`
+for a doc's sake. Read them as proportions, not as figures.
 
 Three things the table makes visible that the previous estimate did
 not:
@@ -1909,10 +1972,11 @@ not:
   to fill a non-nullable trace field — a 771-row happenings pool
   tokenized to seat 22. `rankPerType` now defers it past the
   pre-filter slice and leaves `tokensEstimated` null on dropped rows,
-  which is what took the total from ~140ms to ~108ms at dim 384. The
-  saving is not separately quotable: tokenization runs inside the same
-  kept-row map that feeds MMR, so the two rows this table used to
-  carry are one row and one `rankMs` span. Scoring and the sort do
+  which is what took the total from ~140ms to ~108ms at dim 384 — both
+  endpoints measured under the pre-fix fixture, so read the drop and
+  not the figures. The saving is not separately quotable: tokenization
+  runs inside the same kept-row map that feeds MMR, so the two rows
+  this table used to carry are one row and one `rankMs` span. Scoring and the sort do
   still walk the whole pool — the bench's 477-row swing between boost
   on and off moves `rankMs` by ~1ms, which is what "scales with pool
   size" is now worth here.
@@ -1920,11 +1984,10 @@ not:
   type at N=200 is real, but only happenings reaches 200 in a typical
   story: entities, lore and threads are human-authored and sit in the
   low hundreds. Scoring, tokenization, MMR and budget fill together
-  are ~29ms at dim 384 against a 1067-row pool of which 496 survive
-  the pre-filter. A story that saturates the pre-filter on all five
-  types tokenizes and ranks 1000 rows rather than 496 — the honest
-  worst case, not the common one, and the one term in this table that
-  the bench fixture does not reach.
+  are ~40ms at dim 384. A story that saturates the pre-filter on all
+  five types tokenizes and ranks 1000 rows, which the bench fixture's
+  pool does not reach — the honest worst case, not the common one, and
+  the one term in this table left unpriced.
 - **The chapter-range admission is a first-class cost**, not a
   rounding error on the happenings pool. See
   [Chapter-match boost](#chapter-match-boost-on-happenings).
@@ -1944,28 +2007,28 @@ rather than an absolute:
 - Terms proportional to **happenings on the branch** are accepted but
   budgeted, because that count is bounded by the chapter threshold.
 
-**The query stack is no longer three vectors, and the table above has
-not been re-run.** [Q4](#q4-classifier-emitted-queries) takes the worst
-case to six live queries, so KNN goes to thirty passes — linearly, since
-each is an independent `sqlite-vec` query. Extrapolating the row above
-puts KNN at ~70ms / ~150ms and the total at ~143ms / ~250ms, which
-lands dim 768 on the stated ceiling. That extrapolation is not a
-measurement and must not be quoted as one.
+**The Q4-saturated pass at dim 768 is over that first bullet's
+ceiling** — ~319ms against ~250ms, measured, and it is the worst case
+the [Q4 cap](#q4-classifier-emitted-queries) allows rather than an
+outlier. Nothing here resolves it. Whether the ceiling moves, the cap
+tightens, or dim 768 stops being a desktop default is a decision this
+doc records the number for rather than makes. The other two obligations
+hold: query count is a fixed small constant, not a term proportional to
+awareness rows or branch entries.
 
-Desktop is nonetheless the least interesting part of it. The scaling
-obligations below are unaffected — query count is a fixed small
-constant, not a term proportional to awareness rows or branch entries —
-and retrieval remains under 1% of a turn. The doubling bites in the two
-places this table does not cover, and both are obligations on whoever
-sources Q4 rather than assumptions the design may make:
+Desktop is nonetheless the least interesting part of the widening —
+retrieval stays under 1% of a turn even saturated. The widening bites
+in the two places this table does not cover, and both are obligations
+on whoever sources Q4 rather than assumptions the design may make:
 
-- **The embedder is excluded from every row of this table, though the
-  bench does measure it** — `embedMs` is one of the five spans it
-  emits, so re-running it reports the real figure. The per-turn embed
-  is **one batched call** whose text count goes from three to six, not
-  three calls becoming six; a local ONNX runtime may still loop per
-  text inside that call. Nothing has re-run it against the wider
-  stack.
+- **The embedder is excluded from every row of this table, and the
+  bench cannot fill the gap.** It emits an `embedMs` span, but its
+  fixture stubs the embed call with precomputed vectors, so that span
+  reads 0.0 and prices nothing. The per-turn embed is **one batched
+  call** whose text count goes from three to six, not three calls
+  becoming six; a local ONNX runtime may still loop per text inside
+  that call. Nothing has measured it against the wider stack, and a
+  bench that could would need a real embedder wired into the fixture.
 - **Mobile doubles an already-open risk** — see below.
 
 **Mobile is unmeasured.** Every figure here is desktop. The PoC's
@@ -1973,7 +2036,7 @@ per-query KNN numbers under
 [Performance characteristics](#performance-characteristics--poc-findings)
 are the only mobile evidence and they predate the shipped pass, which
 issues five KNN passes per live query rather than three total — up to
-thirty once Q4 lands. Nothing has run the ranker on-device. Treat the mobile budget as open, not as a scaled
+thirty with Q4 at its cap. Nothing has run the ranker on-device. Treat the mobile budget as open, not as a scaled
 copy of this table.
 
 ### Pseudocode

--- a/docs/ui/screens/memory-probe/memory-probe.md
+++ b/docs/ui/screens/memory-probe/memory-probe.md
@@ -241,11 +241,17 @@ template (sceneEntities count, location, active thread count).
 **Q4 carries a redundancy ratio per query**, the share of that query's
 own top-K the structural floor had already seated — see
 [`retrieval.md → Redundancy`](../../../memory/retrieval.md#redundancy--reporting-a-degenerate-query).
+The top-K is ten rows, which is what the "n of 10" reading above
+renders; the panel shows the captured `redundancy_k` rather than a
+literal 10, because a corpus too small to fill the cut realises fewer.
 It is the panel's most load-bearing number: a high ratio means the
 model asked for context the turn already had, and the query spent its
 weight retrieving duplicates. Ratios above a warn threshold carry the
 ⚠ marker so a degenerate emission is visible at a glance rather than
-requiring the reader to cross-reference the floor tab by hand.
+requiring the reader to cross-reference the floor tab by hand. **The
+threshold itself is unset** — the pinned cut makes one meaningful, but
+no value exists in canon or in code, so the ⚠ rule is a placeholder
+until one is chosen.
 
 #### Per-type tabs (Entities / Lore / Happenings / Threads / Chapter summaries)
 

--- a/e2e/harness/seed.ts
+++ b/e2e/harness/seed.ts
@@ -213,6 +213,25 @@ export function setClassifierCadence(dbPath: string, storyId: string, cadence: n
   }
 }
 
+// Arm the story half of the probe's two gates (the app half is enableDiagnostics).
+// Both must be on before a turn writes a capture. Runs before launch.
+export function enableStoryProbeMode(dbPath: string, storyId: string): void {
+  const db = new DatabaseSync(dbPath)
+  try {
+    const row = db.prepare(`SELECT settings FROM stories WHERE id = ?`).get(storyId) as {
+      settings: string
+    }
+    const settings = JSON.parse(row.settings) as Record<string, unknown>
+    settings.probe_mode_active = true
+    db.prepare(`UPDATE stories SET settings = ? WHERE id = ?`).run(
+      JSON.stringify(settings),
+      storyId,
+    )
+  } finally {
+    db.close()
+  }
+}
+
 function parkWatermark(db: DatabaseSync, branchId: string, processedThrough: number): void {
   db.prepare(
     `UPDATE branches SET classifier_status = json_set(

--- a/e2e/locators/reader.ts
+++ b/e2e/locators/reader.ts
@@ -75,6 +75,10 @@ export const reader = {
     reader.worldTimeDialog(page).getByRole('textbox', { name: tier }),
   worldTimeSave: (page: Page): Locator =>
     reader.worldTimeDialog(page).getByRole('button', { name: t('save') }),
+  // Row-scoped: every ai_reply/opening row renders this toggle with the same
+  // accessible name, so an unscoped query is ambiguous once more than one exists.
+  showState: (page: Page, entryId: string): Locator =>
+    reader.row(page, entryId).getByRole('button', { name: t('reader:entryCard.showState') }),
   monotonicityIndicator: (page: Page, entryId: string): Locator =>
     reader.row(page, entryId).getByLabel(WORLD_TIME_BREAK_LABEL),
 

--- a/e2e/tests/retrieval-q4.spec.ts
+++ b/e2e/tests/retrieval-q4.spec.ts
@@ -1,0 +1,194 @@
+import { expect, test, type Page } from '@playwright/test'
+import { gunzipSync } from 'fflate'
+
+import type { EntryMetadata, ProbeCapturePayload } from '@/lib/db'
+
+import { queryApp } from '../harness/db'
+import { installEmbedderModel } from '../harness/embedder'
+import { launchApp, type LaunchedApp } from '../harness/launch'
+import { startMockLlm, type MockLlm } from '../harness/mock-llm'
+import {
+  createSeededUserDataDir,
+  enableDiagnostics,
+  enableStoryProbeMode,
+  removeUserDataDir,
+  setProviderEndpoint,
+} from '../harness/seed'
+import { home } from '../locators/home'
+import { reader } from '../locators/reader'
+
+// Q4 end-to-end (docs/memory/retrieval.md#q4-classifier-emitted-queries). The seam only a
+// running app reaches is the two-turn one: turn 1's tagged block writes
+// metadata.retrievalQueries, and turn 2's retrieval pass reads that row back as its
+// direct-slot queries. Parsing, capping and blending have thorough unit coverage and are
+// not re-driven here (docs/testing.md → Coverage).
+
+const HERO_TITLE = 'The Veilstone Courier'
+const HERO_STORY_ID = 'story_hero'
+
+const ASK_A = 'E2E-Q4-ASK House Eldrin sigil provenance'
+const ASK_B = 'E2E-Q4-ASK marsh territory exile customs'
+
+const narrative = (marker: string) => `${marker} The storm bends the reeds flat.
+<state>
+  <scene_entities></scene_entities>
+  <world_time_delta>0</world_time_delta>
+  <summary>The courier crossed the marsh under storm light.</summary>
+  <retrieval_queries>
+    <query>${ASK_A}</query>
+    <query>${ASK_B}</query>
+  </retrieval_queries>
+</state>`
+
+async function currentBranchId(page: Page): Promise<string> {
+  const rows = await queryApp(
+    page,
+    `SELECT current_branch_id FROM stories WHERE id = '${HERO_STORY_ID}'`,
+  )
+  return rows[0]?.[0] as string
+}
+
+// queryApp is a raw SQL bridge, not drizzle's typed select, so the column's
+// `mode: 'json'` transform never runs — parse it here instead.
+async function tailMetadata(page: Page, branchId: string): Promise<EntryMetadata | null> {
+  const rows = await queryApp(
+    page,
+    `SELECT metadata FROM story_entries WHERE branch_id = ? AND kind = 'ai_reply'
+     ORDER BY position DESC LIMIT 1`,
+    [branchId],
+  )
+  const raw = rows[0]?.[0] as string | null | undefined
+  return raw ? (JSON.parse(raw) as EntryMetadata) : null
+}
+
+async function tailEntryId(page: Page, branchId: string): Promise<string> {
+  const rows = await queryApp(
+    page,
+    `SELECT id FROM story_entries WHERE branch_id = ? AND kind = 'ai_reply'
+     ORDER BY position DESC LIMIT 1`,
+    [branchId],
+  )
+  return rows[0]?.[0] as string
+}
+
+const LATEST_CAPTURE_SQL = `SELECT payload FROM probe_captures
+   WHERE branch_id = ? ORDER BY captured_at DESC, id DESC LIMIT 1`
+
+// The payload is a gzipped blob; page.evaluate's bridge does not carry a Uint8Array
+// back out of the page intact, so it is widened to a number array in-page and
+// rebuilt + gunzipped here in Node.
+async function latestCapture(page: Page, branchId: string): Promise<ProbeCapturePayload | null> {
+  const bytes = await page.evaluate(
+    async ({ sql, branchId }) => {
+      const { rows } = await (
+        window as unknown as {
+          aventurasDb: {
+            query: (s: string, p: unknown[], m: string) => Promise<{ rows: unknown[][] }>
+          }
+        }
+      ).aventurasDb.query(sql, [branchId], 'all')
+      const blob = rows[0]?.[0] as ArrayLike<number> | undefined
+      return blob === undefined ? null : Array.from(blob)
+    },
+    { sql: LATEST_CAPTURE_SQL, branchId },
+  )
+  if (bytes === null) return null
+  const json = new TextDecoder().decode(gunzipSync(Uint8Array.from(bytes)))
+  return JSON.parse(json) as ProbeCapturePayload
+}
+
+test.describe('retrieval Q4 — classifier-emitted queries across a turn boundary', () => {
+  let app: LaunchedApp
+  let mock: MockLlm
+  let userDataDir: string | undefined
+
+  test.beforeAll(async () => {
+    // Retrieval blocks ahead of narrative, so a turn without an installed embedder
+    // never reaches the reply (model-management.md → Embed failure is blocking).
+    // Cold cache downloads ~24 MB from Hugging Face before launch.
+    test.setTimeout(180_000)
+    const seeded = createSeededUserDataDir()
+    userDataDir = seeded.userDataDir
+    await installEmbedderModel(userDataDir)
+    mock = await startMockLlm()
+    mock.setNarrative(narrative('E2E-Q4-TURN'))
+    setProviderEndpoint(seeded.dbPath, mock.url)
+    // Both probe gates: app half (diagnostics) and story half (probe_mode_active).
+    enableDiagnostics(seeded.dbPath)
+    enableStoryProbeMode(seeded.dbPath, HERO_STORY_ID)
+    app = await launchApp({ userDataDir, cleanupUserData: true })
+  })
+
+  test.afterAll(async () => {
+    await app?.close()
+    await mock?.close()
+    removeUserDataDir(userDataDir)
+  })
+
+  test('turn 1 emits queries into metadata; turn 2 embeds them as direct-slot queries', async () => {
+    test.setTimeout(120_000)
+
+    let branchId = ''
+
+    await test.step('turn 1 persists the emitted asks and renders them', async () => {
+      await home.openStory(app.window, HERO_TITLE).click()
+      await expect(reader.composer(app.window)).toBeVisible({ timeout: 20_000 })
+      await reader.composer(app.window).fill('E2E-Q4-USER-1 I press toward the ridge.')
+      await reader.send(app.window).click()
+      await expect(app.window.getByText('E2E-Q4-TURN', { exact: false })).toBeVisible({
+        timeout: 30_000,
+      })
+
+      branchId = await currentBranchId(app.window)
+
+      await expect
+        .poll(async () => (await tailMetadata(app.window, branchId))?.retrievalQueries, {
+          timeout: 30_000,
+        })
+        .toEqual([ASK_A, ASK_B])
+
+      // Only unit/Storybook-unreachable coverage of the reader-surface.tsx pass-through:
+      // the panel is otherwise pinned by entry-card's own stories.
+      const entryId = await tailEntryId(app.window, branchId)
+      await reader.showState(app.window, entryId).click()
+      await expect(app.window.getByText(ASK_A)).toBeVisible()
+      await expect(app.window.getByText(ASK_B)).toBeVisible()
+    })
+
+    await test.step('turn 2 embeds them as direct-slot queries and captures redundancy', async () => {
+      await reader.composer(app.window).fill('E2E-Q4-USER-2 I ask what the sigil means.')
+      await reader.send(app.window).click()
+
+      // Turn 1 wrote its own capture with three slots (Q1-Q3, no emitted Q4 yet), so
+      // polling for five is what waits for turn 2's row specifically.
+      await expect
+        .poll(async () => (await latestCapture(app.window, branchId))?.queries.length, {
+          timeout: 30_000,
+        })
+        .toBe(5)
+
+      const capture = (await latestCapture(app.window, branchId))!
+      expect(capture.capture_version).toBe(7)
+      expect(capture.queries.map((q) => q.source)).toEqual([
+        'user_action',
+        'structural_digest',
+        'piggyback_summary',
+        'classifier_emitted',
+        'classifier_emitted',
+      ])
+      expect(capture.queries.slice(3).map((q) => q.text)).toEqual([ASK_A, ASK_B])
+      expect(capture.queries.slice(0, 3).every((q) => q.redundancy === null)).toBe(true)
+      for (const q of capture.queries.slice(3)) {
+        expect(q.redundancy).toBeGreaterThanOrEqual(0)
+        expect(q.redundancy).toBeLessThanOrEqual(1)
+        // The cut is REDUNDANCY_K = 10 nearest rows globally, not the full KNN pass —
+        // a regression to the old unpinned denominator would blow past this
+        // (docs/memory/retrieval.md → Redundancy).
+        expect(q.redundancy_k).toBeGreaterThan(0)
+        expect(q.redundancy_k).toBeLessThanOrEqual(10)
+      }
+      // Positionally aligned with the queries, which is what blendSims indexes on.
+      expect(capture.pools.entities[0]?.sims).toHaveLength(5)
+    })
+  })
+})

--- a/e2e/tests/retrieval-q4.spec.ts
+++ b/e2e/tests/retrieval-q4.spec.ts
@@ -17,11 +17,9 @@ import {
 import { home } from '../locators/home'
 import { reader } from '../locators/reader'
 
-// Q4 end-to-end (docs/memory/retrieval.md#q4-classifier-emitted-queries). The seam only a
-// running app reaches is the two-turn one: turn 1's tagged block writes
-// metadata.retrievalQueries, and turn 2's retrieval pass reads that row back as its
-// direct-slot queries. Parsing, capping and blending have thorough unit coverage and are
-// not re-driven here (docs/testing.md → Coverage).
+// Q4 end-to-end (docs/memory/retrieval.md#q4-classifier-emitted-queries) — the only seam a
+// running app reaches: turn 1 writes metadata.retrievalQueries, turn 2 reads it back as
+// direct-slot queries.
 
 const HERO_TITLE = 'The Veilstone Courier'
 const HERO_STORY_ID = 'story_hero'
@@ -79,9 +77,8 @@ async function tailEntryId(page: Page, branchId: string): Promise<string> {
 const LATEST_CAPTURE_SQL = `SELECT payload FROM probe_captures
    WHERE branch_id = ? ORDER BY captured_at DESC, id DESC LIMIT 1`
 
-// The payload is a gzipped blob; queryApp's evaluate bridge carries the BLOB column
-// back out as a real Uint8Array (Playwright has serialized typed arrays since 1.44),
-// so it can be gunzipped directly with no in-page widening/rebuild step.
+// Payload is a gzipped blob; queryApp's evaluate bridge returns the BLOB column as a real
+// Uint8Array (Playwright has serialized typed arrays since 1.44), so it gunzips directly.
 async function latestCapture(page: Page, branchId: string): Promise<ProbeCapturePayload | null> {
   const rows = await queryApp(page, LATEST_CAPTURE_SQL, [branchId])
   const blob = rows[0]?.[0] as Uint8Array | undefined
@@ -96,9 +93,8 @@ test.describe('retrieval Q4 — classifier-emitted queries across a turn boundar
   let userDataDir: string | undefined
 
   test.beforeAll(async () => {
-    // Retrieval blocks ahead of narrative, so a turn without an installed embedder
-    // never reaches the reply (model-management.md → Embed failure is blocking).
-    // Cold cache downloads ~24 MB from Hugging Face before launch.
+    // Embed failure blocks the reply (model-management.md → Embed failure is blocking); cold
+    // cache pulls ~24 MB from Hugging Face before launch, hence the long timeout.
     test.setTimeout(180_000)
     const seeded = createSeededUserDataDir()
     userDataDir = seeded.userDataDir
@@ -153,9 +149,8 @@ test.describe('retrieval Q4 — classifier-emitted queries across a turn boundar
     })
 
     await test.step('turn 2 embeds them as direct-slot queries and captures redundancy', async () => {
-      // Turn 2 emits different asks (ASK_C/ASK_D) so the capture assertion below
-      // discriminates "read the previous turn's row" (ASK_A/ASK_B, correct) from
-      // "read my own" (ASK_C/ASK_D, the regression this test exists to catch).
+      // Turn 2 emits different asks (ASK_C/ASK_D) so the capture below distinguishes "read the
+      // previous turn's row" (correct) from "read my own" — the regression this test catches.
       mock.setNarrative(narrative('E2E-Q4-TURN-2', ASK_C, ASK_D))
       await reader.composer(app.window).fill('E2E-Q4-USER-2 I ask what the sigil means.')
       await reader.send(app.window).click()
@@ -169,9 +164,8 @@ test.describe('retrieval Q4 — classifier-emitted queries across a turn boundar
         .toBe(5)
 
       const capture = (await latestCapture(app.window, branchId))!
-      // Hardcoded, not imported from CAPTURE_VERSION: a legitimate version bump is
-      // expected to require touching this line, so the failure points at the
-      // migration rather than looking like an E2E bug.
+      // Hardcoded, not imported from CAPTURE_VERSION: a version bump must touch this line, so
+      // a failure here points at the migration, not a mystery E2E regression.
       expect(capture.capture_version).toBe(7)
       expect(capture.queries.map((q) => q.source)).toEqual([
         'user_action',
@@ -186,9 +180,8 @@ test.describe('retrieval Q4 — classifier-emitted queries across a turn boundar
         // redundancy = matched / topK.length is closed on [0, 1] by construction; the
         // informative check is that it was computed at all (not null).
         expect(typeof q.redundancy).toBe('number')
-        // The cut is REDUNDANCY_K = 10 nearest rows globally, not the full KNN pass —
-        // a regression to the old unpinned denominator would blow past this
-        // (docs/memory/retrieval.md → Redundancy).
+        // Cut is REDUNDANCY_K = 10 nearest rows globally, not the full KNN pass — a regression
+        // to the old unpinned denominator would blow past this (retrieval.md → Redundancy).
         expect(q.redundancy_k).toBeGreaterThan(0)
         expect(q.redundancy_k).toBeLessThanOrEqual(10)
       }

--- a/e2e/tests/retrieval-q4.spec.ts
+++ b/e2e/tests/retrieval-q4.spec.ts
@@ -28,23 +28,28 @@ const HERO_STORY_ID = 'story_hero'
 
 const ASK_A = 'E2E-Q4-ASK House Eldrin sigil provenance'
 const ASK_B = 'E2E-Q4-ASK marsh territory exile customs'
+const ASK_C = 'E2E-Q4-ASK ferry schedules along the reed channels'
+const ASK_D = 'E2E-Q4-ASK who last carried the courier seal'
 
-const narrative = (marker: string) => `${marker} The storm bends the reeds flat.
+const narrative = (
+  marker: string,
+  askOne: string,
+  askTwo: string,
+) => `${marker} The storm bends the reeds flat.
 <state>
   <scene_entities></scene_entities>
   <world_time_delta>0</world_time_delta>
   <summary>The courier crossed the marsh under storm light.</summary>
   <retrieval_queries>
-    <query>${ASK_A}</query>
-    <query>${ASK_B}</query>
+    <query>${askOne}</query>
+    <query>${askTwo}</query>
   </retrieval_queries>
 </state>`
 
 async function currentBranchId(page: Page): Promise<string> {
-  const rows = await queryApp(
-    page,
-    `SELECT current_branch_id FROM stories WHERE id = '${HERO_STORY_ID}'`,
-  )
+  const rows = await queryApp(page, `SELECT current_branch_id FROM stories WHERE id = ?`, [
+    HERO_STORY_ID,
+  ])
   return rows[0]?.[0] as string
 }
 
@@ -74,26 +79,14 @@ async function tailEntryId(page: Page, branchId: string): Promise<string> {
 const LATEST_CAPTURE_SQL = `SELECT payload FROM probe_captures
    WHERE branch_id = ? ORDER BY captured_at DESC, id DESC LIMIT 1`
 
-// The payload is a gzipped blob; page.evaluate's bridge does not carry a Uint8Array
-// back out of the page intact, so it is widened to a number array in-page and
-// rebuilt + gunzipped here in Node.
+// The payload is a gzipped blob; queryApp's evaluate bridge carries the BLOB column
+// back out as a real Uint8Array (Playwright has serialized typed arrays since 1.44),
+// so it can be gunzipped directly with no in-page widening/rebuild step.
 async function latestCapture(page: Page, branchId: string): Promise<ProbeCapturePayload | null> {
-  const bytes = await page.evaluate(
-    async ({ sql, branchId }) => {
-      const { rows } = await (
-        window as unknown as {
-          aventurasDb: {
-            query: (s: string, p: unknown[], m: string) => Promise<{ rows: unknown[][] }>
-          }
-        }
-      ).aventurasDb.query(sql, [branchId], 'all')
-      const blob = rows[0]?.[0] as ArrayLike<number> | undefined
-      return blob === undefined ? null : Array.from(blob)
-    },
-    { sql: LATEST_CAPTURE_SQL, branchId },
-  )
-  if (bytes === null) return null
-  const json = new TextDecoder().decode(gunzipSync(Uint8Array.from(bytes)))
+  const rows = await queryApp(page, LATEST_CAPTURE_SQL, [branchId])
+  const blob = rows[0]?.[0] as Uint8Array | undefined
+  if (blob === undefined) return null
+  const json = new TextDecoder().decode(gunzipSync(blob))
   return JSON.parse(json) as ProbeCapturePayload
 }
 
@@ -111,7 +104,7 @@ test.describe('retrieval Q4 — classifier-emitted queries across a turn boundar
     userDataDir = seeded.userDataDir
     await installEmbedderModel(userDataDir)
     mock = await startMockLlm()
-    mock.setNarrative(narrative('E2E-Q4-TURN'))
+    mock.setNarrative(narrative('E2E-Q4-TURN', ASK_A, ASK_B))
     setProviderEndpoint(seeded.dbPath, mock.url)
     // Both probe gates: app half (diagnostics) and story half (probe_mode_active).
     enableDiagnostics(seeded.dbPath)
@@ -151,11 +144,19 @@ test.describe('retrieval Q4 — classifier-emitted queries across a turn boundar
       // the panel is otherwise pinned by entry-card's own stories.
       const entryId = await tailEntryId(app.window, branchId)
       await reader.showState(app.window, entryId).click()
-      await expect(app.window.getByText(ASK_A)).toBeVisible()
-      await expect(app.window.getByText(ASK_B)).toBeVisible()
+      await expect(reader.row(app.window, entryId).getByText(ASK_A)).toBeVisible()
+      await expect(reader.row(app.window, entryId).getByText(ASK_B)).toBeVisible()
+
+      // The five-slot poll in step 2 only distinguishes turn 2's capture from turn 1's
+      // because turn 1 had no prior row to read: three fixed slots, no Q4.
+      expect((await latestCapture(app.window, branchId))?.queries.length).toBe(3)
     })
 
     await test.step('turn 2 embeds them as direct-slot queries and captures redundancy', async () => {
+      // Turn 2 emits different asks (ASK_C/ASK_D) so the capture assertion below
+      // discriminates "read the previous turn's row" (ASK_A/ASK_B, correct) from
+      // "read my own" (ASK_C/ASK_D, the regression this test exists to catch).
+      mock.setNarrative(narrative('E2E-Q4-TURN-2', ASK_C, ASK_D))
       await reader.composer(app.window).fill('E2E-Q4-USER-2 I ask what the sigil means.')
       await reader.send(app.window).click()
 
@@ -168,6 +169,9 @@ test.describe('retrieval Q4 — classifier-emitted queries across a turn boundar
         .toBe(5)
 
       const capture = (await latestCapture(app.window, branchId))!
+      // Hardcoded, not imported from CAPTURE_VERSION: a legitimate version bump is
+      // expected to require touching this line, so the failure points at the
+      // migration rather than looking like an E2E bug.
       expect(capture.capture_version).toBe(7)
       expect(capture.queries.map((q) => q.source)).toEqual([
         'user_action',
@@ -177,10 +181,11 @@ test.describe('retrieval Q4 — classifier-emitted queries across a turn boundar
         'classifier_emitted',
       ])
       expect(capture.queries.slice(3).map((q) => q.text)).toEqual([ASK_A, ASK_B])
-      expect(capture.queries.slice(0, 3).every((q) => q.redundancy === null)).toBe(true)
+      expect(capture.queries.slice(0, 3).map((q) => q.redundancy)).toEqual([null, null, null])
       for (const q of capture.queries.slice(3)) {
-        expect(q.redundancy).toBeGreaterThanOrEqual(0)
-        expect(q.redundancy).toBeLessThanOrEqual(1)
+        // redundancy = matched / topK.length is closed on [0, 1] by construction; the
+        // informative check is that it was computed at all (not null).
+        expect(typeof q.redundancy).toBe('number')
         // The cut is REDUNDANCY_K = 10 nearest rows globally, not the full KNN pass —
         // a regression to the old unpinned denominator would blow past this
         // (docs/memory/retrieval.md → Redundancy).

--- a/lib/db/embeddings/knn.ts
+++ b/lib/db/embeddings/knn.ts
@@ -30,8 +30,9 @@ export type KnnParams = {
  * `embedding` rides along because vec0 returns it on the match row for almost
  * nothing, whereas fetching vectors by id afterwards cannot: `id` is a metadata
  * column with no push-down, so such a query scans the whole partition instead.
- * Nothing reads `distance`: the ranker computes cosine over the returned vectors
- * instead, and vec0 will not return the match row without it. That top-k is
+ * Nothing SCORES on `distance` — the ranker computes cosine over the returned
+ * vectors instead — though the redundancy cut orders by it, and vec0 will not
+ * return the match row without it either way. That top-k is
  * cosine's top-k only because every stored and query vector is unit-norm —
  * enforced by lib/embedder's embedTexts and re-checked in lib/retrieval's
  * cosine, not by vec0 — which makes L2 order and cosine order the same order.

--- a/lib/db/embeddings/knn.ts
+++ b/lib/db/embeddings/knn.ts
@@ -22,20 +22,12 @@ export type KnnParams = {
 }
 
 /**
- * One KNN pass over a single (kind, dim) family. `branch_id` is a vec0
- * partition key so the engine pre-filters on it; `model_id` is a metadata
- * column constraint. Pool predicates (injection_mode, status, POV union) are
- * not expressible here — they filter the returned ids afterwards.
- *
- * `embedding` rides along because vec0 returns it on the match row for almost
- * nothing, whereas fetching vectors by id afterwards cannot: `id` is a metadata
- * column with no push-down, so such a query scans the whole partition instead.
- * Nothing SCORES on `distance` — the ranker computes cosine over the returned
- * vectors instead — though the redundancy cut orders by it, and vec0 will not
- * return the match row without it either way. That top-k is
- * cosine's top-k only because every stored and query vector is unit-norm —
- * enforced by lib/embedder's embedTexts and re-checked in lib/retrieval's
- * cosine, not by vec0 — which makes L2 order and cosine order the same order.
+ * `branch_id`/`model_id` push down in the vec0 query; other pool predicates
+ * (injection_mode, status, POV) don't, and filter ids afterwards. `embedding`
+ * rides along because `id` has no push-down, so a by-id refetch would scan
+ * the whole partition instead. `distance` isn't a score — cosine is
+ * recomputed — but it orders, and unit-norm vectors make that order equal
+ * cosine's, comparable across kinds.
  */
 export function knnQuery(kind: VecTargetKind, dim: number, p: KnnParams): RowQuery {
   // vec0 treats k = 0 as valid and returns nothing, so a misconfigured budget

--- a/lib/db/probe-capture-types.ts
+++ b/lib/db/probe-capture-types.ts
@@ -90,10 +90,10 @@ type CaptureQuery = {
    */
   redundancy: number | null
   /**
-   * The top-K size `redundancy` was measured over — that query's KNN cut unioned over
-   * the three kinds the floor can seat, so its ceiling is 3 × KNN_K, not KNN_K. Stored
-   * because at small `k` the ratio describes the corpus rather than the query, and
-   * nothing else in the capture says so — `funnels.pool_size` is the post-filter size.
+   * The realised size of the cut `redundancy` was measured over, below REDUNDANCY_K
+   * only on a corpus too small to fill it. Stored because at small `k` the ratio
+   * describes the corpus rather than the query, and nothing else in the capture says
+   * so — `funnels.pool_size` is the post-filter size, not this.
    */
   redundancy_k: number | null
 }

--- a/lib/db/probe-capture-types.ts
+++ b/lib/db/probe-capture-types.ts
@@ -83,6 +83,19 @@ type CaptureQuery = {
   text: string
   token_count: number
   source: QuerySource
+  /**
+   * Q4 only (retrieval.md → Redundancy): the share of this query's own pre-filter
+   * top-K the structural floor had already seated. Null on the three fixed slots and
+   * on a query whose top-K came back empty.
+   */
+  redundancy: number | null
+  /**
+   * The top-K size `redundancy` was measured over — that query's KNN cut unioned over
+   * the three kinds the floor can seat, so its ceiling is 3 × KNN_K, not KNN_K. Stored
+   * because at small `k` the ratio describes the corpus rather than the query, and
+   * nothing else in the capture says so — `funnels.pool_size` is the post-filter size.
+   */
+  redundancy_k: number | null
 }
 
 /** A new ranker tunable must be a type error here, not a silently absent capture field. */
@@ -104,9 +117,9 @@ type CaptureTokenizer = { encoding: string; version: string }
 /**
  * Bumped when a captured field's shape or meaning changes, so a decode refuses
  * rather than misreading an older payload. 5 added keyword_injections; 6 made
- * the query stack variable-length.
+ * the query stack variable-length; 7 added per-Q4 redundancy.
  */
-export const CAPTURE_VERSION = 6 as const
+export const CAPTURE_VERSION = 7 as const
 
 export type ProbeCapturePayload = {
   capture_version: number

--- a/lib/db/story-entries/entry-metadata.test.ts
+++ b/lib/db/story-entries/entry-metadata.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
+import { MAX_RETRIEVAL_QUERIES } from '@/lib/piggyback'
+
 import { entryMetadataSchema } from './entry-metadata'
 
 describe('entryMetadataSchema', () => {
@@ -60,6 +62,15 @@ describe('entryMetadataSchema', () => {
       entryMetadataSchema.safeParse({ sceneEntities: [], currentLocationId: null, worldTime: -1 })
         .success,
     ).toBe(false)
+  })
+
+  it('rejects more queries than lib/piggyback caps the emission at', () => {
+    const base = { sceneEntities: [], currentLocationId: null, worldTime: 0 }
+    const over = Array.from({ length: MAX_RETRIEVAL_QUERIES + 1 }, (_, i) => `q${i}`)
+    expect(entryMetadataSchema.safeParse({ ...base, retrievalQueries: over }).success).toBe(false)
+    expect(
+      entryMetadataSchema.safeParse({ ...base, retrievalQueries: over.slice(0, -1) }).success,
+    ).toBe(true)
   })
 })
 

--- a/lib/db/story-entries/entry-metadata.ts
+++ b/lib/db/story-entries/entry-metadata.ts
@@ -12,6 +12,11 @@ export const entryMetadataSchema = z.object({
   // Feeds the NEXT turn's Q3 retrieval query (docs/memory/retrieval.md#q3-piggyback-summary).
   // Optional — absent on parse failure or restart is fine per docs/memory/piggyback.md.
   summary: z.string().optional(),
+  // Feeds the NEXT turn's Q4 slot (docs/memory/retrieval.md#q4-classifier-emitted-queries).
+  // Never inherited, and excluded from stateReport. `.max(3)` states the contract; it
+  // does not enforce it — this schema is parsed only at create-story and in the seed,
+  // never on the piggyback write path. lib/piggyback caps at parse.
+  retrievalQueries: z.array(z.string()).max(3).optional(),
   sceneEntities: z.array(z.string()),
   currentLocationId: z.string().nullable(),
   worldTime: z.number().min(0),

--- a/lib/db/story-entries/entry-metadata.ts
+++ b/lib/db/story-entries/entry-metadata.ts
@@ -13,9 +13,7 @@ export const entryMetadataSchema = z.object({
   // Optional — absent on parse failure or restart is fine per docs/memory/piggyback.md.
   summary: z.string().optional(),
   // Feeds the NEXT turn's Q4 slot (docs/memory/retrieval.md#q4-classifier-emitted-queries).
-  // Never inherited, and excluded from stateReport. `.max(3)` states the contract; it
-  // does not enforce it — this schema is parsed only at create-story and in the seed,
-  // never on the piggyback write path. lib/piggyback caps at parse.
+  // `.max(3)` documents the cap; lib/piggyback enforces it at parse.
   retrievalQueries: z.array(z.string()).max(3).optional(),
   sceneEntities: z.array(z.string()),
   currentLocationId: z.string().nullable(),

--- a/lib/db/story-entries/entry-metadata.ts
+++ b/lib/db/story-entries/entry-metadata.ts
@@ -13,7 +13,7 @@ export const entryMetadataSchema = z.object({
   // Optional — absent on parse failure or restart is fine per docs/memory/piggyback.md.
   summary: z.string().optional(),
   // Feeds the NEXT turn's Q4 slot (docs/memory/retrieval.md#q4-classifier-emitted-queries).
-  // `.max(3)` documents the cap; lib/piggyback enforces it at parse.
+  // `.max(3)` documents the cap; lib/piggyback and the fallback classifier schema both enforce it.
   retrievalQueries: z.array(z.string()).max(3).optional(),
   sceneEntities: z.array(z.string()),
   currentLocationId: z.string().nullable(),

--- a/lib/db/story-entries/inherited-metadata.test.ts
+++ b/lib/db/story-entries/inherited-metadata.test.ts
@@ -38,9 +38,8 @@ describe('inheritedEntryMetadata', () => {
     })
   })
 
-  // Never inherited, unlike the scene triple beside it: a query carried forward from
-  // three turns ago is exactly the staleness Q4 exists to avoid
-  // (docs/memory/retrieval.md#q4-classifier-emitted-queries).
+  // Never inherited, unlike the scene triple beside it: a carried-forward query
+  // is the staleness Q4 exists to avoid (retrieval.md#q4-classifier-emitted-queries).
   it('does not carry retrievalQueries forward', () => {
     const tail: EntryMetadata = {
       sceneEntities: ['char_a'],

--- a/lib/db/story-entries/inherited-metadata.test.ts
+++ b/lib/db/story-entries/inherited-metadata.test.ts
@@ -36,4 +36,17 @@ describe('inheritedEntryMetadata', () => {
       worldTime: 0,
     })
   })
+
+  // Never inherited, unlike the scene triple beside it: a query carried forward from
+  // three turns ago is exactly the staleness Q4 exists to avoid
+  // (docs/memory/retrieval.md#q4-classifier-emitted-queries).
+  it('does not carry retrievalQueries forward', () => {
+    const inherited = inheritedEntryMetadata({
+      sceneEntities: ['char_a'],
+      currentLocationId: 'loc_a',
+      worldTime: 10,
+      retrievalQueries: ['House Eldrin sigil'],
+    } as never)
+    expect(inherited).not.toHaveProperty('retrievalQueries')
+  })
 })

--- a/lib/db/story-entries/inherited-metadata.test.ts
+++ b/lib/db/story-entries/inherited-metadata.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import type { EntryMetadata } from './entry-metadata'
 import { inheritedEntryMetadata } from './inherited-metadata'
 
 describe('inheritedEntryMetadata', () => {
@@ -41,12 +42,12 @@ describe('inheritedEntryMetadata', () => {
   // three turns ago is exactly the staleness Q4 exists to avoid
   // (docs/memory/retrieval.md#q4-classifier-emitted-queries).
   it('does not carry retrievalQueries forward', () => {
-    const inherited = inheritedEntryMetadata({
+    const tail: EntryMetadata = {
       sceneEntities: ['char_a'],
       currentLocationId: 'loc_a',
       worldTime: 10,
       retrievalQueries: ['House Eldrin sigil'],
-    } as never)
-    expect(inherited).not.toHaveProperty('retrievalQueries')
+    }
+    expect(inheritedEntryMetadata(tail)).not.toHaveProperty('retrievalQueries')
   })
 })

--- a/lib/piggyback/apply.test.ts
+++ b/lib/piggyback/apply.test.ts
@@ -89,6 +89,20 @@ describe('buildPiggybackActions', () => {
     expect(result.metadata).not.toHaveProperty('retrievalQueries')
   })
 
+  // The parser cannot produce [] today, but the fallback classifier's schema can.
+  it('leaves retrievalQueries absent when the block emitted an empty array', () => {
+    const result = buildPiggybackActions({
+      source: 'ai_classifier',
+      entryId: 'entry_1',
+      block: { sceneEntities: [], retrievalQueries: [] },
+      entities: [],
+      previousMetadata,
+      branchId: 'main',
+    })
+
+    expect(result.metadata).not.toHaveProperty('retrievalQueries')
+  })
+
   it('promotes staged entities named in sceneEntities', () => {
     const stagedChar = mockEntity({ id: 'char_staged', status: 'staged' })
     const activeChar = mockEntity({ id: 'char_active', status: 'active' })

--- a/lib/piggyback/apply.test.ts
+++ b/lib/piggyback/apply.test.ts
@@ -63,6 +63,32 @@ describe('buildPiggybackActions', () => {
     })
   })
 
+  it('carries an emitted retrievalQueries onto the entry metadata', () => {
+    const result = buildPiggybackActions({
+      source: 'ai_classifier',
+      entryId: 'entry_1',
+      block: { sceneEntities: [], retrievalQueries: ['marsh nobility'] },
+      entities: [],
+      previousMetadata,
+      branchId: 'main',
+    })
+
+    expect(result.metadata.retrievalQueries).toEqual(['marsh nobility'])
+  })
+
+  it('leaves retrievalQueries absent when the block emitted none', () => {
+    const result = buildPiggybackActions({
+      source: 'ai_classifier',
+      entryId: 'entry_1',
+      block: { sceneEntities: [] },
+      entities: [],
+      previousMetadata,
+      branchId: 'main',
+    })
+
+    expect(result.metadata).not.toHaveProperty('retrievalQueries')
+  })
+
   it('promotes staged entities named in sceneEntities', () => {
     const stagedChar = mockEntity({ id: 'char_staged', status: 'staged' })
     const activeChar = mockEntity({ id: 'char_active', status: 'active' })

--- a/lib/piggyback/apply.test.ts
+++ b/lib/piggyback/apply.test.ts
@@ -103,6 +103,60 @@ describe('buildPiggybackActions', () => {
     expect(result.metadata).not.toHaveProperty('retrievalQueries')
   })
 
+  // The next four pin the normalisation the fallback classifier's schema does not do:
+  // its .max() only counts, so blanks and repeats arrive here unfiltered.
+  it('stores a repeated query once', () => {
+    const result = buildPiggybackActions({
+      source: 'ai_classifier',
+      entryId: 'entry_1',
+      block: { sceneEntities: [], retrievalQueries: ['marsh nobility', 'marsh nobility'] },
+      entities: [],
+      previousMetadata,
+      branchId: 'main',
+    })
+
+    expect(result.metadata.retrievalQueries).toEqual(['marsh nobility'])
+  })
+
+  it('drops empty and whitespace-only queries', () => {
+    const result = buildPiggybackActions({
+      source: 'ai_classifier',
+      entryId: 'entry_1',
+      block: { sceneEntities: [], retrievalQueries: ['', '   ', 'House Eldrin sigil'] },
+      entities: [],
+      previousMetadata,
+      branchId: 'main',
+    })
+
+    expect(result.metadata.retrievalQueries).toEqual(['House Eldrin sigil'])
+  })
+
+  it('caps a four-query emission at MAX_RETRIEVAL_QUERIES', () => {
+    const result = buildPiggybackActions({
+      source: 'ai_classifier',
+      entryId: 'entry_1',
+      block: { sceneEntities: [], retrievalQueries: ['one', 'two', 'three', 'four'] },
+      entities: [],
+      previousMetadata,
+      branchId: 'main',
+    })
+
+    expect(result.metadata.retrievalQueries).toEqual(['one', 'two', 'three'])
+  })
+
+  it('leaves retrievalQueries absent when every emitted query is blank', () => {
+    const result = buildPiggybackActions({
+      source: 'ai_classifier',
+      entryId: 'entry_1',
+      block: { sceneEntities: [], retrievalQueries: ['', '  '] },
+      entities: [],
+      previousMetadata,
+      branchId: 'main',
+    })
+
+    expect(result.metadata).not.toHaveProperty('retrievalQueries')
+  })
+
   it('promotes staged entities named in sceneEntities', () => {
     const stagedChar = mockEntity({ id: 'char_staged', status: 'staged' })
     const activeChar = mockEntity({ id: 'char_active', status: 'active' })

--- a/lib/piggyback/apply.ts
+++ b/lib/piggyback/apply.ts
@@ -6,11 +6,9 @@ import { dedupeSceneEntities, scenePromotionActions, sceneTrackingActions } from
 import { MAX_RETRIEVAL_QUERIES, type ParsedStateBlock } from './types'
 import { resolvePiggybackWorldTimeDelta } from './world-time'
 
-// Both producers of the field converge here, and only one filters its own input:
-// the tagged-block parser trims/drops/dedupes before capping, while the fallback
-// classifier's schema only counts, so it stores blanks and duplicates verbatim.
-// Deduping before the cap is what stops a repeat spending a slot the next distinct
-// ask needed (retrieval.md → Q4). Idempotent for the parser, which already did it.
+// Two producers write this field; only the tagged-block parser filters itself (trims,
+// dedupes, caps) — the classifier fallback only counts, so blanks/dupes reach here raw.
+// Dedupe before the cap so a repeat doesn't spend a slot a distinct ask needed (retrieval.md → Q4).
 function normalizeRetrievalQueries(queries: readonly string[]): string[] {
   const distinct = new Set(queries.map((q) => q.trim()).filter((q) => q !== ''))
   return [...distinct].slice(0, MAX_RETRIEVAL_QUERIES)
@@ -29,10 +27,8 @@ type BuildArgs = {
   entities: readonly Entity[]
   previousMetadata: PreviousMetadata
   branchId: string
-  // Which caller produced this block — piggyback's own direct tagged-block
-  // emission ('piggyback_tagged_block') or the synchronous per-turn fallback
-  // ('per_turn_classifier'). Not hardcoded here: the two paths are distinct
-  // agents and their deltas' provenance must say so (docs/memory/piggyback.md).
+  // Caller-supplied, not hardcoded: the two producers are distinct agents whose deltas'
+  // provenance must say so (docs/memory/piggyback.md).
   source: DeltaSource
 }
 

--- a/lib/piggyback/apply.ts
+++ b/lib/piggyback/apply.ts
@@ -3,8 +3,18 @@ import type { CharacterState, Entity, EntryMetadata } from '@/lib/db'
 import { logger } from '@/lib/diagnostics'
 
 import { dedupeSceneEntities, scenePromotionActions, sceneTrackingActions } from './scene-tracking'
-import type { ParsedStateBlock } from './types'
+import { MAX_RETRIEVAL_QUERIES, type ParsedStateBlock } from './types'
 import { resolvePiggybackWorldTimeDelta } from './world-time'
+
+// Both producers of the field converge here, and only one filters its own input:
+// the tagged-block parser trims/drops/dedupes before capping, while the fallback
+// classifier's schema only counts, so it stores blanks and duplicates verbatim.
+// Deduping before the cap is what stops a repeat spending a slot the next distinct
+// ask needed (retrieval.md → Q4). Idempotent for the parser, which already did it.
+function normalizeRetrievalQueries(queries: readonly string[]): string[] {
+  const distinct = new Set(queries.map((q) => q.trim()).filter((q) => q !== ''))
+  return [...distinct].slice(0, MAX_RETRIEVAL_QUERIES)
+}
 
 type PreviousMetadata = {
   entryId?: string
@@ -71,7 +81,8 @@ export function buildPiggybackActions(args: BuildArgs): BuildResult {
 
   const metadata: BuildResult['metadata'] = { sceneEntities, currentLocationId, worldTime }
   if (block.summary !== undefined) metadata.summary = block.summary
-  if (block.retrievalQueries?.length) metadata.retrievalQueries = block.retrievalQueries
+  const retrievalQueries = normalizeRetrievalQueries(block.retrievalQueries ?? [])
+  if (retrievalQueries.length > 0) metadata.retrievalQueries = retrievalQueries
   // visual/inventory/stackables only exist on CharacterState (entity-state-schema.ts) —
   // an id that resolves but belongs to a location/item/faction would otherwise get
   // those fields merged onto its state unvalidated (state-patch-actions.ts never

--- a/lib/piggyback/apply.ts
+++ b/lib/piggyback/apply.ts
@@ -1,5 +1,5 @@
 import type { DeltaSource, PipelineAction } from '@/lib/actions'
-import type { CharacterState, Entity } from '@/lib/db'
+import type { CharacterState, Entity, EntryMetadata } from '@/lib/db'
 import { logger } from '@/lib/diagnostics'
 
 import { dedupeSceneEntities, scenePromotionActions, sceneTrackingActions } from './scene-tracking'
@@ -27,13 +27,10 @@ type BuildArgs = {
 }
 
 type BuildResult = {
-  metadata: {
-    sceneEntities: string[]
-    currentLocationId: string | null
-    worldTime: number
-    summary?: string
-    retrievalQueries?: string[]
-  }
+  metadata: Pick<
+    EntryMetadata,
+    'sceneEntities' | 'currentLocationId' | 'worldTime' | 'summary' | 'retrievalQueries'
+  >
   actions: PipelineAction[]
   /** What validation did to the emitted values, for stateReport — so the reader renders
    *  the emitted-vs-applied divergence as fact instead of inferring a cause from it. */
@@ -74,7 +71,7 @@ export function buildPiggybackActions(args: BuildArgs): BuildResult {
 
   const metadata: BuildResult['metadata'] = { sceneEntities, currentLocationId, worldTime }
   if (block.summary !== undefined) metadata.summary = block.summary
-  if (block.retrievalQueries !== undefined) metadata.retrievalQueries = block.retrievalQueries
+  if (block.retrievalQueries?.length) metadata.retrievalQueries = block.retrievalQueries
   // visual/inventory/stackables only exist on CharacterState (entity-state-schema.ts) —
   // an id that resolves but belongs to a location/item/faction would otherwise get
   // those fields merged onto its state unvalidated (state-patch-actions.ts never

--- a/lib/piggyback/apply.ts
+++ b/lib/piggyback/apply.ts
@@ -32,6 +32,7 @@ type BuildResult = {
     currentLocationId: string | null
     worldTime: number
     summary?: string
+    retrievalQueries?: string[]
   }
   actions: PipelineAction[]
   /** What validation did to the emitted values, for stateReport — so the reader renders
@@ -73,6 +74,7 @@ export function buildPiggybackActions(args: BuildArgs): BuildResult {
 
   const metadata: BuildResult['metadata'] = { sceneEntities, currentLocationId, worldTime }
   if (block.summary !== undefined) metadata.summary = block.summary
+  if (block.retrievalQueries !== undefined) metadata.retrievalQueries = block.retrievalQueries
   // visual/inventory/stackables only exist on CharacterState (entity-state-schema.ts) —
   // an id that resolves but belongs to a location/item/faction would otherwise get
   // those fields merged onto its state unvalidated (state-patch-actions.ts never

--- a/lib/piggyback/parse.test.ts
+++ b/lib/piggyback/parse.test.ts
@@ -19,6 +19,10 @@ const WELL_FORMED = `Some narrative prose here.
     <stackable key="gold" amount="50" to="c1" from="c3" />
   </transfers>
   <summary>Aria pushed into the marshes.</summary>
+  <retrieval_queries>
+    <query>House Eldrin's history and its sigil</query>
+    <query>exiled nobility of the marshes</query>
+  </retrieval_queries>
 </state>`
 
 describe('parseStateBlock', () => {
@@ -39,6 +43,7 @@ describe('parseStateBlock', () => {
         stackables: [{ key: 'gold', amount: 50, to: 'c1', from: 'c3' }],
       },
       summary: 'Aria pushed into the marshes.',
+      retrievalQueries: ["House Eldrin's history and its sigil", 'exiled nobility of the marshes'],
     })
   })
 
@@ -203,6 +208,17 @@ describe('parseStateBlock', () => {
 
     it('caps the emission at MAX_RETRIEVAL_QUERIES', () => {
       const queries = ['a', 'b', 'c', 'd'].map((q) => `<query>${q}</query>`).join('')
+      const { block: parsed } = parseStateBlock(
+        block(`<retrieval_queries>${queries}</retrieval_queries>`),
+      )
+      expect(parsed.retrievalQueries).toEqual(['a', 'b', 'c'])
+    })
+
+    // The cap counts DISTINCT queries, matching emittedSpecs (lib/retrieval/queries.ts).
+    // A cap that counted repeats would spend a stored slot on a duplicate and silently
+    // drop the distinct ask behind it.
+    it('dedupes before capping, so a repeat does not cost a distinct query its slot', () => {
+      const queries = ['a', 'a', 'b', 'c'].map((q) => `<query>${q}</query>`).join('')
       const { block: parsed } = parseStateBlock(
         block(`<retrieval_queries>${queries}</retrieval_queries>`),
       )

--- a/lib/piggyback/parse.test.ts
+++ b/lib/piggyback/parse.test.ts
@@ -179,11 +179,8 @@ describe('parseStateBlock', () => {
     expect(result.failures).toEqual([])
   })
 
-  // retrieval.md → Q4 and piggyback.md → Parse strategy both state this exception,
-  // because it reads like an inconsistency someone will later "fix": every other
-  // nested-tag field here throws when content resolves to no entries, which fires a
-  // full extra structured call. Spending one to recover an optional retrieval hint
-  // inverts the cost of the recovery it triggers, so this parser must never raise.
+  // Reads like inconsistency but isn't: every other field here throws on empty content,
+  // which fires a full extra LLM call — recovering an optional hint that way inverts cost.
   describe('<retrieval_queries> — total by contract', () => {
     const block = (inner: string) => `prose\n<state>\n${inner}\n</state>`
 
@@ -214,9 +211,8 @@ describe('parseStateBlock', () => {
       expect(parsed.retrievalQueries).toEqual(['a', 'b', 'c'])
     })
 
-    // The cap counts DISTINCT queries, matching emittedSpecs (lib/retrieval/queries.ts).
-    // A cap that counted repeats would spend a stored slot on a duplicate and silently
-    // drop the distinct ask behind it.
+    // Cap counts DISTINCT queries (matches emittedSpecs in lib/retrieval/queries.ts) —
+    // counting repeats would spend a slot on a duplicate and drop the distinct ask behind it.
     it('dedupes before capping, so a repeat does not cost a distinct query its slot', () => {
       const queries = ['a', 'a', 'b', 'c'].map((q) => `<query>${q}</query>`).join('')
       const { block: parsed } = parseStateBlock(
@@ -225,16 +221,14 @@ describe('parseStateBlock', () => {
       expect(parsed.retrievalQueries).toEqual(['a', 'b', 'c'])
     })
 
-    // The cap is stated in two modules that cannot import one another (see
-    // MAX_RETRIEVAL_QUERIES' comment). Drift here means storage and the query
-    // stack disagree about how many asks a turn gets.
+    // The cap lives in two modules that can't import each other (see MAX_RETRIEVAL_QUERIES) —
+    // drift here means storage and the query stack disagree on how many asks a turn gets.
     it('caps at the same number the query stack embeds', () => {
       expect(MAX_RETRIEVAL_QUERIES).toBe(MAX_EMITTED_QUERIES)
     })
 
-    // Not cosmetic: parseStateBlock judges an empty block on Object.keys(block).length,
-    // so a key set to undefined would read as a clean parse and suppress the fallback
-    // this turn needs — losing every other field with it.
+    // Not cosmetic: parseStateBlock judges emptiness via Object.keys(block).length, so a
+    // key set to undefined would read as a clean parse and suppress the fallback this turn needs.
     it('leaves a state block carrying only an unusable retrieval_queries reported empty', () => {
       const { block: parsed, failures } = parseStateBlock(
         block('<retrieval_queries>nothing parseable</retrieval_queries>'),

--- a/lib/piggyback/parse.test.ts
+++ b/lib/piggyback/parse.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
+import { MAX_EMITTED_QUERIES } from '@/lib/retrieval'
+
 import { parseStateBlock, parseSuggestionsBlock, stripTrailingBlocks } from './parse'
+import { MAX_RETRIEVAL_QUERIES } from './types'
 
 const WELL_FORMED = `Some narrative prose here.
 <state>
@@ -169,6 +172,63 @@ describe('parseStateBlock', () => {
     const result = parseStateBlock('<state><summary>Kael left.</summary></state>')
     expect(result.block).toEqual({ summary: 'Kael left.' })
     expect(result.failures).toEqual([])
+  })
+
+  // retrieval.md → Q4 and piggyback.md → Parse strategy both state this exception,
+  // because it reads like an inconsistency someone will later "fix": every other
+  // nested-tag field here throws when content resolves to no entries, which fires a
+  // full extra structured call. Spending one to recover an optional retrieval hint
+  // inverts the cost of the recovery it triggers, so this parser must never raise.
+  describe('<retrieval_queries> — total by contract', () => {
+    const block = (inner: string) => `prose\n<state>\n${inner}\n</state>`
+
+    it('extracts the emitted queries in order', () => {
+      const { block: parsed, failures } = parseStateBlock(
+        block(
+          '<retrieval_queries><query>House Eldrin sigil</query><query>marsh nobility</query></retrieval_queries>',
+        ),
+      )
+      expect(parsed.retrievalQueries).toEqual(['House Eldrin sigil', 'marsh nobility'])
+      expect(failures).toEqual([])
+    })
+
+    it.each([
+      ['unterminated children', '<retrieval_queries><query>House Eldrin'],
+      ['no children at all', '<retrieval_queries>just prose here</retrieval_queries>'],
+      ['empty children', '<retrieval_queries><query></query><query>  </query></retrieval_queries>'],
+    ])('records no failure for %s', (_label, inner) => {
+      const { failures } = parseStateBlock(block(`<summary>s</summary>${inner}`))
+      expect(failures).toEqual([])
+    })
+
+    it('caps the emission at MAX_RETRIEVAL_QUERIES', () => {
+      const queries = ['a', 'b', 'c', 'd'].map((q) => `<query>${q}</query>`).join('')
+      const { block: parsed } = parseStateBlock(
+        block(`<retrieval_queries>${queries}</retrieval_queries>`),
+      )
+      expect(parsed.retrievalQueries).toEqual(['a', 'b', 'c'])
+    })
+
+    // The cap is stated in two modules that cannot import one another (see
+    // MAX_RETRIEVAL_QUERIES' comment). Drift here means storage and the query
+    // stack disagree about how many asks a turn gets.
+    it('caps at the same number the query stack embeds', () => {
+      expect(MAX_RETRIEVAL_QUERIES).toBe(MAX_EMITTED_QUERIES)
+    })
+
+    // Not cosmetic: parseStateBlock judges an empty block on Object.keys(block).length,
+    // so a key set to undefined would read as a clean parse and suppress the fallback
+    // this turn needs — losing every other field with it.
+    it('leaves a state block carrying only an unusable retrieval_queries reported empty', () => {
+      const { block: parsed, failures } = parseStateBlock(
+        block('<retrieval_queries>nothing parseable</retrieval_queries>'),
+      )
+      expect(parsed.retrievalQueries).toBeUndefined()
+      expect(Object.keys(parsed)).toEqual([])
+      expect(failures).toEqual([
+        { field: 'state', detail: 'block content matched no known field tag' },
+      ])
+    })
   })
 })
 

--- a/lib/piggyback/parse.ts
+++ b/lib/piggyback/parse.ts
@@ -157,8 +157,12 @@ function parseTransfers(segment: string): ParsedTransfers {
 // full extra structured call, and spending one to recover an optional retrieval hint
 // inverts the cost of the recovery it triggers (piggyback.md → Parse strategy). Never
 // calls assertNotTruncated. Returns undefined rather than [] so a block carrying
-// nothing else stays "empty" and the fallback still fires.
+// nothing else stays "empty" and the fallback still fires. Dedupes before capping
+// because emittedSpecs (lib/retrieval/queries.ts) counts distinct queries toward its
+// cap — a cap that counted repeats would spend a stored slot on a duplicate and drop
+// a distinct ask.
 function parseRetrievalQueries(segment: string): string[] | undefined {
+  const seen = new Set<string>()
   const out: string[] = []
   const re = new RegExp(
     `<${RETRIEVAL_QUERY_ITEM_TAG}>([\\s\\S]*?)</${RETRIEVAL_QUERY_ITEM_TAG}>`,
@@ -166,7 +170,8 @@ function parseRetrievalQueries(segment: string): string[] | undefined {
   )
   for (const match of segment.matchAll(re)) {
     const text = match[1]?.trim()
-    if (text === undefined || text === '') continue
+    if (text === undefined || text === '' || seen.has(text)) continue
+    seen.add(text)
     out.push(text)
     if (out.length === MAX_RETRIEVAL_QUERIES) break
   }
@@ -204,16 +209,15 @@ export function parseStateBlock(raw: string): ParseStateBlockResult {
     if (segment === undefined) continue
     try {
       const value = parse(segment)
-      // Only parseRetrievalQueries returns undefined, and only when it read no usable
-      // query. Assigning the key anyway would make Object.keys below non-empty, so a
-      // block carrying nothing else would read as a clean parse and suppress the
-      // fallback it needs.
-      if (value === undefined)
+      // Object.keys below judges the block empty, so assigning an undefined key would
+      // make a block carrying nothing else read as a clean parse and lose its fallback.
+      if (value === undefined) {
         continue
-        // FIELD_PARSERS correlates each `field` with a `parse` producing its
-        // matching value type by construction, but that pairing is erased once
-        // collected into one array — narrower than `any`, still an intentional
-        // escape hatch for a heterogeneous field-descriptor list.
+      }
+      // FIELD_PARSERS correlates each `field` with a `parse` producing its
+      // matching value type by construction, but that pairing is erased once
+      // collected into one array — narrower than `any`, still an intentional
+      // escape hatch for a heterogeneous field-descriptor list.
       ;(block as Record<string, unknown>)[field] = value
     } catch (e) {
       failures.push({ field, detail: e instanceof Error ? e.message : String(e) })

--- a/lib/piggyback/parse.ts
+++ b/lib/piggyback/parse.ts
@@ -153,14 +153,9 @@ function parseTransfers(segment: string): ParsedTransfers {
   return { items, stackables }
 }
 
-// Total by contract, and the ONLY parser here that is: a field-level failure fires a
-// full extra structured call, and spending one to recover an optional retrieval hint
-// inverts the cost of the recovery it triggers (piggyback.md → Parse strategy). Never
-// calls assertNotTruncated. Returns undefined rather than [] so a block carrying
-// nothing else stays "empty" and the fallback still fires. Dedupes before capping
-// because emittedSpecs (lib/retrieval/queries.ts) counts distinct queries toward its
-// cap — a cap that counted repeats would spend a stored slot on a duplicate and drop
-// a distinct ask.
+// Total by contract, the only parser that never raises: recovering an optional hint via a
+// full extra structured call would invert that call's cost — never call assertNotTruncated.
+// Returns undefined, not [], so an otherwise-empty block reads empty and the fallback fires.
 function parseRetrievalQueries(segment: string): string[] | undefined {
   const seen = new Set<string>()
   const out: string[] = []

--- a/lib/piggyback/parse.ts
+++ b/lib/piggyback/parse.ts
@@ -3,13 +3,14 @@ import { jsonrepair } from 'jsonrepair'
 import type { StoryEntry } from '@/lib/db'
 
 import {
+  RETRIEVAL_QUERY_ITEM_TAG,
   STATE_ROOT_TAG,
   STATE_TAGS,
   SUGGESTION_ITEM_TAG,
   SUGGESTIONS_ROOT_TAG,
   TRAILING_ROOT_TAGS,
 } from './tags'
-import { VISUAL_CHANGE_TYPES } from './types'
+import { MAX_RETRIEVAL_QUERIES, VISUAL_CHANGE_TYPES } from './types'
 import type {
   ItemTransfer,
   SuggestionRef,
@@ -152,6 +153,26 @@ function parseTransfers(segment: string): ParsedTransfers {
   return { items, stackables }
 }
 
+// Total by contract, and the ONLY parser here that is: a field-level failure fires a
+// full extra structured call, and spending one to recover an optional retrieval hint
+// inverts the cost of the recovery it triggers (piggyback.md → Parse strategy). Never
+// calls assertNotTruncated. Returns undefined rather than [] so a block carrying
+// nothing else stays "empty" and the fallback still fires.
+function parseRetrievalQueries(segment: string): string[] | undefined {
+  const out: string[] = []
+  const re = new RegExp(
+    `<${RETRIEVAL_QUERY_ITEM_TAG}>([\\s\\S]*?)</${RETRIEVAL_QUERY_ITEM_TAG}>`,
+    'g',
+  )
+  for (const match of segment.matchAll(re)) {
+    const text = match[1]?.trim()
+    if (text === undefined || text === '') continue
+    out.push(text)
+    if (out.length === MAX_RETRIEVAL_QUERIES) break
+  }
+  return out.length === 0 ? undefined : out
+}
+
 type FieldParser = {
   field: keyof ParsedStateBlock
   tag: string
@@ -165,6 +186,7 @@ const FIELD_PARSERS: readonly FieldParser[] = [
   { field: 'visualChanges', tag: STATE_TAGS.visualChanges, parse: parseVisualChanges },
   { field: 'transfers', tag: STATE_TAGS.transfers, parse: parseTransfers },
   { field: 'summary', tag: STATE_TAGS.summary, parse: (s) => s.trim() },
+  { field: 'retrievalQueries', tag: STATE_TAGS.retrievalQueries, parse: parseRetrievalQueries },
 ]
 
 // Segment isolation + per-field best-effort parse: one failing top-level tag
@@ -182,10 +204,16 @@ export function parseStateBlock(raw: string): ParseStateBlockResult {
     if (segment === undefined) continue
     try {
       const value = parse(segment)
-      // FIELD_PARSERS correlates each `field` with a `parse` producing its
-      // matching value type by construction, but that pairing is erased once
-      // collected into one array — narrower than `any`, still an intentional
-      // escape hatch for a heterogeneous field-descriptor list.
+      // Only parseRetrievalQueries returns undefined, and only when it read no usable
+      // query. Assigning the key anyway would make Object.keys below non-empty, so a
+      // block carrying nothing else would read as a clean parse and suppress the
+      // fallback it needs.
+      if (value === undefined)
+        continue
+        // FIELD_PARSERS correlates each `field` with a `parse` producing its
+        // matching value type by construction, but that pairing is erased once
+        // collected into one array — narrower than `any`, still an intentional
+        // escape hatch for a heterogeneous field-descriptor list.
       ;(block as Record<string, unknown>)[field] = value
     } catch (e) {
       failures.push({ field, detail: e instanceof Error ? e.message : String(e) })

--- a/lib/piggyback/report.test.ts
+++ b/lib/piggyback/report.test.ts
@@ -134,10 +134,8 @@ describe('buildStateReport', () => {
     expect(report).not.toHaveProperty('summary')
   })
 
-  // Pins the full allowlisted shape, not absence: `not.toHaveProperty('retrievalQueries')`
-  // would pass before any change is made — vacuous under this repo's green-is-not-covered
-  // rule. Asserting the whole object is what fails the moment someone converts the return
-  // to `...block`.
+  // Pins the full allowlisted shape, not absence: `not.toHaveProperty(...)` would pass before
+  // any change (vacuous). Asserting the whole object fails once the return becomes `...block`.
   it('reports exactly the allowlisted keys, excluding summary and retrievalQueries', () => {
     const report = buildStateReport({
       layer: 'piggyback_tagged_block',
@@ -147,9 +145,8 @@ describe('buildStateReport', () => {
     expect(report).toEqual({ layer: 'piggyback_tagged_block', sceneEntities: ['char_a'] })
   })
 
-  // Judged on the block as emitted: a block carrying only retrieval asks reported
-  // state, and suppressing its report would badge the turn as one where piggyback
-  // never ran.
+  // Judged on the block as emitted: a block carrying only retrieval asks still reports state —
+  // suppressing it would badge the turn as one where piggyback never ran.
   it('still reports a block that carried only retrieval asks', () => {
     const report = buildStateReport({
       layer: 'piggyback_tagged_block',

--- a/lib/piggyback/report.test.ts
+++ b/lib/piggyback/report.test.ts
@@ -134,17 +134,17 @@ describe('buildStateReport', () => {
     expect(report).not.toHaveProperty('summary')
   })
 
-  // Pins the ALLOWLIST, not absence. buildStateReport returns an explicit key list, so
-  // `not.toHaveProperty('retrievalQueries')` passes before any change is made — vacuous
-  // under this repo's green-is-not-covered rule. Asserting the exact key set is what
-  // fails the moment someone converts the return to `...reported`.
+  // Pins the full allowlisted shape, not absence: `not.toHaveProperty('retrievalQueries')`
+  // would pass before any change is made — vacuous under this repo's green-is-not-covered
+  // rule. Asserting the whole object is what fails the moment someone converts the return
+  // to `...block`.
   it('reports exactly the allowlisted keys, excluding summary and retrievalQueries', () => {
     const report = buildStateReport({
       layer: 'piggyback_tagged_block',
       block: { sceneEntities: ['char_a'], summary: 's', retrievalQueries: ['q'] },
       failures: [],
     })
-    expect(Object.keys(report!)).toEqual(['layer', 'sceneEntities'])
+    expect(report).toEqual({ layer: 'piggyback_tagged_block', sceneEntities: ['char_a'] })
   })
 
   // Judged on the block as emitted: a block carrying only retrieval asks reported

--- a/lib/piggyback/report.test.ts
+++ b/lib/piggyback/report.test.ts
@@ -134,6 +134,31 @@ describe('buildStateReport', () => {
     expect(report).not.toHaveProperty('summary')
   })
 
+  // Pins the ALLOWLIST, not absence. buildStateReport returns an explicit key list, so
+  // `not.toHaveProperty('retrievalQueries')` passes before any change is made — vacuous
+  // under this repo's green-is-not-covered rule. Asserting the exact key set is what
+  // fails the moment someone converts the return to `...reported`.
+  it('reports exactly the allowlisted keys, excluding summary and retrievalQueries', () => {
+    const report = buildStateReport({
+      layer: 'piggyback_tagged_block',
+      block: { sceneEntities: ['char_a'], summary: 's', retrievalQueries: ['q'] },
+      failures: [],
+    })
+    expect(Object.keys(report!)).toEqual(['layer', 'sceneEntities'])
+  })
+
+  // Judged on the block as emitted: a block carrying only retrieval asks reported
+  // state, and suppressing its report would badge the turn as one where piggyback
+  // never ran.
+  it('still reports a block that carried only retrieval asks', () => {
+    const report = buildStateReport({
+      layer: 'piggyback_tagged_block',
+      block: { retrievalQueries: ['q'] },
+      failures: [],
+    })
+    expect(report?.layer).toBe('piggyback_tagged_block')
+  })
+
   it('carries the full transfer and visual-change shapes through', () => {
     const report = buildStateReport({
       layer: 'piggyback_tagged_block',

--- a/lib/piggyback/report.ts
+++ b/lib/piggyback/report.ts
@@ -20,8 +20,9 @@ type BuildReportArgs = {
 /**
  * What the model EMITTED plus what `apply.ts` did with it — several causes collapse onto
  * the same emitted-vs-current difference (docs/ui/patterns/entry-card.md → Emitted vs.
- * applied). `summary` is not copied: it has a top-level home on EntryMetadata, and a
- * second copy would give the reader two sources for one sentence.
+ * applied). The return below is an explicit allowlist, so `summary` and `retrievalQueries`
+ * are excluded by omission: both have top-level homes on EntryMetadata, and a second copy
+ * would give the reader two sources for one value.
  */
 export function buildStateReport(args: BuildReportArgs): EntryMetadata['stateReport'] {
   const { layer, block, failures, raw, applied } = args

--- a/lib/piggyback/report.ts
+++ b/lib/piggyback/report.ts
@@ -20,13 +20,11 @@ type BuildReportArgs = {
 /**
  * What the model EMITTED plus what `apply.ts` did with it — several causes collapse onto
  * the same emitted-vs-current difference (docs/ui/patterns/entry-card.md → Emitted vs.
- * applied). The return below is an explicit allowlist, so `summary` and `retrievalQueries`
- * are excluded by omission: both have top-level homes on EntryMetadata, and a second copy
- * would give the reader two sources for one value.
+ * applied). `summary` and `retrievalQueries` are excluded by omission: both have top-level
+ * homes on EntryMetadata, and a second copy would give the reader two sources for one value.
  */
 export function buildStateReport(args: BuildReportArgs): EntryMetadata['stateReport'] {
   const { layer, block, failures, raw, applied } = args
-  const { summary: _summary, ...reported } = block
   // Emptiness is judged on the block as emitted, summary included: a block carrying only
   // a summary reported state, and suppressing its report would badge the turn as one
   // where piggyback never ran.
@@ -34,19 +32,17 @@ export function buildStateReport(args: BuildReportArgs): EntryMetadata['stateRep
 
   return {
     layer,
-    ...(reported.sceneEntities !== undefined ? { sceneEntities: reported.sceneEntities } : {}),
-    ...(reported.currentLocation !== undefined
-      ? { currentLocation: reported.currentLocation }
-      : {}),
-    ...(reported.worldTimeDelta !== undefined ? { worldTimeDelta: reported.worldTimeDelta } : {}),
-    ...(reported.worldTimeDelta !== undefined && applied !== undefined
+    ...(block.sceneEntities !== undefined ? { sceneEntities: block.sceneEntities } : {}),
+    ...(block.currentLocation !== undefined ? { currentLocation: block.currentLocation } : {}),
+    ...(block.worldTimeDelta !== undefined ? { worldTimeDelta: block.worldTimeDelta } : {}),
+    ...(block.worldTimeDelta !== undefined && applied !== undefined
       ? { worldTimeDeltaApplied: applied.worldTimeDelta }
       : {}),
     ...(applied?.currentLocationRejected === true
       ? { currentLocationRejected: true as const }
       : {}),
-    ...(reported.visualChanges !== undefined ? { visualChanges: reported.visualChanges } : {}),
-    ...(reported.transfers !== undefined ? { transfers: reported.transfers } : {}),
+    ...(block.visualChanges !== undefined ? { visualChanges: block.visualChanges } : {}),
+    ...(block.transfers !== undefined ? { transfers: block.transfers } : {}),
     ...(failures.length > 0
       ? { failedFields: failures.map((f) => ({ field: f.field, detail: f.detail })) }
       : {}),

--- a/lib/piggyback/report.ts
+++ b/lib/piggyback/report.ts
@@ -18,10 +18,8 @@ type BuildReportArgs = {
 }
 
 /**
- * What the model EMITTED plus what `apply.ts` did with it — several causes collapse onto
- * the same emitted-vs-current difference (docs/ui/patterns/entry-card.md → Emitted vs.
- * applied). `summary` and `retrievalQueries` are excluded by omission: both have top-level
- * homes on EntryMetadata, and a second copy would give the reader two sources for one value.
+ * Emitted vs. applied causes collapse onto one diff (entry-card.md → Emitted vs. applied).
+ * `summary`/`retrievalQueries` omitted: they already live top-level on EntryMetadata.
  */
 export function buildStateReport(args: BuildReportArgs): EntryMetadata['stateReport'] {
   const { layer, block, failures, raw, applied } = args

--- a/lib/piggyback/tags.ts
+++ b/lib/piggyback/tags.ts
@@ -6,7 +6,11 @@ export const STATE_TAGS = {
   visualChanges: 'visual_changes',
   transfers: 'transfers',
   summary: 'summary',
+  retrievalQueries: 'retrieval_queries',
 } as const
+
+/** The `<query>` children `<retrieval_queries>` nests. */
+export const RETRIEVAL_QUERY_ITEM_TAG = 'query'
 
 export const SUGGESTIONS_ROOT_TAG = 'suggestions'
 export const SUGGESTION_ITEM_TAG = 'item'

--- a/lib/piggyback/types.ts
+++ b/lib/piggyback/types.ts
@@ -27,9 +27,8 @@ type _VisualCategoriesMatch = [VisualChangeType] extends [(typeof VISUAL_CATEGOR
 const _visualChecks: [_VisualCategoriesMatch] = [true]
 void _visualChecks
 
-// retrieval.md → Q4. Stated a second time in lib/retrieval's MAX_EMITTED_QUERIES,
-// which lib/piggyback cannot import: scripts/mock-llm loads this module under plain
-// Node, so a value import would drag the retrieval barrel in. parse.test.ts pins them equal.
+// retrieval.md → Q4. Restated from lib/retrieval's MAX_EMITTED_QUERIES, which this module
+// cannot value-import for the reason above; parse.test.ts pins them equal.
 export const MAX_RETRIEVAL_QUERIES = 3
 
 export type VisualChangeNote = { id: string; type: VisualChangeType; text: string }

--- a/lib/piggyback/types.ts
+++ b/lib/piggyback/types.ts
@@ -27,6 +27,11 @@ type _VisualCategoriesMatch = [VisualChangeType] extends [(typeof VISUAL_CATEGOR
 const _visualChecks: [_VisualCategoriesMatch] = [true]
 void _visualChecks
 
+// retrieval.md → Q4. Stated a second time in lib/retrieval's MAX_EMITTED_QUERIES,
+// which lib/piggyback cannot import: scripts/mock-llm loads this module under plain
+// Node, so a value import would drag the retrieval barrel in. parse.test.ts pins them equal.
+export const MAX_RETRIEVAL_QUERIES = 3
+
 export type VisualChangeNote = { id: string; type: VisualChangeType; text: string }
 export type ItemTransfer = {
   id: string
@@ -44,6 +49,7 @@ export type ParsedStateBlock = {
   visualChanges?: VisualChangeNote[]
   transfers?: ParsedTransfers
   summary?: string
+  retrievalQueries?: string[]
 }
 
 // `'state'` is the block-level failure: a <state> that parsed into no field at all.

--- a/lib/piggyback/types.ts
+++ b/lib/piggyback/types.ts
@@ -15,8 +15,9 @@ export const VISUAL_CHANGE_TYPES = [
 export type VisualChangeType = (typeof VISUAL_CHANGE_TYPES)[number]
 
 // Drift guard, both directions: the two lists must stay identical, since the parser
-// validates against this one and entryMetadataSchema validates against lib/db's. A
-// divergence would let a parsed block fail schema validation at write time.
+// validates against this one and entryMetadataSchema's stateReport enum validates
+// against lib/db's own list directly. The type check below is what actually catches a
+// divergence — entryMetadataSchema.parse() never runs on piggyback-authored data.
 // Type-only on purpose — scripts/mock-llm reaches this module under plain Node, and a
 // value import would drag the whole db barrel in behind it.
 type _VisualCategoriesMatch = [VisualChangeType] extends [(typeof VISUAL_CATEGORIES)[number]]

--- a/lib/piggyback/types.ts
+++ b/lib/piggyback/types.ts
@@ -14,12 +14,9 @@ export const VISUAL_CHANGE_TYPES = [
 ] as const
 export type VisualChangeType = (typeof VISUAL_CHANGE_TYPES)[number]
 
-// Drift guard, both directions: the two lists must stay identical, since the parser
-// validates against this one and entryMetadataSchema's stateReport enum validates
-// against lib/db's own list directly. The type check below is what actually catches a
-// divergence — entryMetadataSchema.parse() never runs on piggyback-authored data.
-// Type-only on purpose — scripts/mock-llm reaches this module under plain Node, and a
-// value import would drag the whole db barrel in behind it.
+// Drift guard: must match entryMetadataSchema's stateReport enum (lib/db) — that schema
+// never validates piggyback data, so the type check below is what actually catches drift.
+// Type-only: a value import would drag the whole db barrel into scripts/mock-llm's plain Node.
 type _VisualCategoriesMatch = [VisualChangeType] extends [(typeof VISUAL_CATEGORIES)[number]]
   ? [(typeof VISUAL_CATEGORIES)[number]] extends [VisualChangeType]
     ? true

--- a/lib/pipeline/definitions/per-turn-piggyback.test.ts
+++ b/lib/pipeline/definitions/per-turn-piggyback.test.ts
@@ -668,6 +668,84 @@ describe('per-turn-piggyback', () => {
       })
     })
 
+    // Canon carries Q4 on BOTH per-turn implementations, and this is the one the default
+    // piggybackMode: 'off' story actually runs (docs/memory/retrieval.md → Q4).
+    it("carries the fallback classifier's emitted queries onto the entry metadata", async () => {
+      currentStoryStore.set({
+        storyId: 's1',
+        branchId: 'b1',
+        definition,
+        settings: baseSettings({ models: {} }),
+      })
+      hydrateEntries(phaseDb, 'b1', [
+        {
+          id: 'entry-1',
+          branchId: 'b1',
+          position: 1,
+          content: 'Starting point',
+          metadata: { sceneEntities: [], currentLocationId: null, worldTime: 100 },
+        } as never,
+        {
+          id: 'entry-2',
+          branchId: 'b1',
+          position: 2,
+          content: 'Next step in forest',
+          metadata: { sceneEntities: [], currentLocationId: null, worldTime: 100 },
+        } as never,
+      ])
+      entitiesStore.hydrate('b1', [])
+
+      // Routed through the real schema's .parse(), not a hand-built literal — a real
+      // classifier call validates its JSON reply the same way, and this is what makes
+      // the mutation check meaningful: dropping the field from the schema strips it
+      // here too (zod's default unknown-key behavior), rather than the mock smuggling
+      // it straight past a schema that no longer declares it.
+      const value = fallbackClassifierSchema.parse({
+        sceneEntities: [],
+        currentLocation: undefined,
+        worldTimeDelta: 0,
+        visualChanges: [],
+        transfers: { items: [], stackables: [] },
+        retrievalQueries: ['House Eldrin sigil'],
+      })
+      generateStructuredMock.mockResolvedValueOnce({ status: 'ok', value })
+
+      const ctx = {
+        actionId: 'act_1',
+        abortSignal: new AbortController().signal,
+        intermediates: { idMap: new IdBiMap() },
+        log: makeLogger('act_1'),
+        db: phaseDb.db,
+        runInTransaction: async () => undefined,
+        storyId: 's1',
+        branchId: 'b1',
+      }
+
+      const gen = piggybackFallbackClassifierPhase(ctx)
+      const events = []
+      let result = await gen.next()
+      while (!result.done) {
+        events.push(result.value)
+        result = await gen.next()
+      }
+
+      expect(result.value).toEqual({ status: 'completed' })
+      expect(events[0]).toEqual({
+        type: 'delta_emitted',
+        action: expect.objectContaining({
+          kind: 'updateStoryEntryMetadata',
+          source: 'per_turn_classifier',
+          payload: expect.objectContaining({
+            branchId: 'b1',
+            id: 'entry-2',
+            metadata: expect.objectContaining({
+              retrievalQueries: ['House Eldrin sigil'],
+            }),
+          }),
+        }),
+      })
+    })
+
     it('prompts with a bracketed-ID list of active/staged entities and resolves the returned placeholder back to the real id', async () => {
       const heroId = 'char_00000000-0000-4000-8000-000000000001'
       currentStoryStore.set({

--- a/lib/pipeline/definitions/per-turn-piggyback.test.ts
+++ b/lib/pipeline/definitions/per-turn-piggyback.test.ts
@@ -695,11 +695,9 @@ describe('per-turn-piggyback', () => {
       ])
       entitiesStore.hydrate('b1', [])
 
-      // Routed through the real schema's .parse(), not a hand-built literal — a real
-      // classifier call validates its JSON reply the same way, and this is what makes
-      // the mutation check meaningful: dropping the field from the schema strips it
-      // here too (zod's default unknown-key behavior), rather than the mock smuggling
-      // it straight past a schema that no longer declares it.
+      // Routed through the real schema's .parse() rather than a hand-built literal: the mock
+      // would otherwise smuggle the field past a schema that no longer declares it, and the
+      // mutation check would stop discriminating.
       const value = fallbackClassifierSchema.parse({
         sceneEntities: [],
         currentLocation: undefined,
@@ -1954,6 +1952,30 @@ describe('per-turn-piggyback', () => {
 
       expect(typeof summary === 'object' ? summary.description : undefined).toBeTruthy()
     })
+
+    it('describes the retrievalQueries field so the description survives into the emitted JSON schema', () => {
+      const jsonSchema = z.toJSONSchema(fallbackClassifierSchema)
+      const retrievalQueries = jsonSchema.properties?.retrievalQueries
+
+      expect(
+        typeof retrievalQueries === 'object' ? retrievalQueries.description : undefined,
+      ).toBeTruthy()
+    })
+
+    // retrieval.md → Q4: the emission is malformed-tolerant. Structured output validates
+    // the object in one shot, so a raise here would cost a full extra provider call and,
+    // on a second over-emission, take the mandatory summary down with the optional hint.
+    it('drops an over-long retrievalQueries without failing the sibling fields', () => {
+      const parsed = fallbackClassifierSchema.parse({
+        sceneEntities: ['char_a'],
+        worldTimeDelta: 0,
+        summary: 'Kael drew.',
+        retrievalQueries: ['a', 'b', 'c', 'd'],
+      })
+      expect(parsed.retrievalQueries).toBeUndefined()
+      expect(parsed.summary).toBe('Kael drew.')
+      expect(parsed.sceneEntities).toEqual(['char_a'])
+    })
   })
 
   describe('fallbackClassifierWithSuggestionsSchema', () => {
@@ -1992,6 +2014,23 @@ describe('per-turn-piggyback', () => {
       })
 
       expect(result.success).toBe(false)
+    })
+
+    // Coverage for the schema every real story runs (buildStorySettings always
+    // populates suggestionCategories): .extend() carries retrievalQueries onto this
+    // schema too, but nothing else pins that — a refactor to a standalone z.object
+    // could silently drop Q4 for every real story.
+    it('carries retrievalQueries alongside suggestions', () => {
+      const result = fallbackClassifierWithSuggestionsSchema.safeParse({
+        sceneEntities: [],
+        worldTimeDelta: 5,
+        suggestions: [{ categoryRef: 'cat1', text: 'ok' }],
+        retrievalQueries: ['a query'],
+      })
+
+      expect(result.success).toBe(true)
+      if (!result.success) throw new Error('expected parse to succeed')
+      expect(result.data.retrievalQueries).toEqual(['a query'])
     })
   })
 

--- a/lib/pipeline/definitions/per-turn-piggyback.test.ts
+++ b/lib/pipeline/definitions/per-turn-piggyback.test.ts
@@ -668,8 +668,8 @@ describe('per-turn-piggyback', () => {
       })
     })
 
-    // Canon carries Q4 on BOTH per-turn implementations, and this is the one the default
-    // piggybackMode: 'off' story actually runs (docs/memory/retrieval.md → Q4).
+    // Canon: Q4 on both per-turn implementations; this is the one the default piggybackMode:
+    // 'off' story actually runs (docs/memory/retrieval.md → Q4).
     it("carries the fallback classifier's emitted queries onto the entry metadata", async () => {
       currentStoryStore.set({
         storyId: 's1',
@@ -695,9 +695,8 @@ describe('per-turn-piggyback', () => {
       ])
       entitiesStore.hydrate('b1', [])
 
-      // Routed through the real schema's .parse() rather than a hand-built literal: the mock
-      // would otherwise smuggle the field past a schema that no longer declares it, and the
-      // mutation check would stop discriminating.
+      // Routed through the real schema's .parse(), not a hand-built literal — otherwise the mock
+      // smuggles a field the schema no longer declares, defeating the mutation check.
       const value = fallbackClassifierSchema.parse({
         sceneEntities: [],
         currentLocation: undefined,
@@ -1962,9 +1961,8 @@ describe('per-turn-piggyback', () => {
       ).toBeTruthy()
     })
 
-    // retrieval.md → Q4: the emission is malformed-tolerant. Structured output validates
-    // the object in one shot, so a raise here would cost a full extra provider call and,
-    // on a second over-emission, take the mandatory summary down with the optional hint.
+    // retrieval.md → Q4: emission is malformed-tolerant — raising here costs a full extra
+    // provider call and takes the mandatory summary field down with an over-long hint too.
     it('drops an over-long retrievalQueries without failing the sibling fields', () => {
       const parsed = fallbackClassifierSchema.parse({
         sceneEntities: ['char_a'],
@@ -2016,10 +2014,8 @@ describe('per-turn-piggyback', () => {
       expect(result.success).toBe(false)
     })
 
-    // Coverage for the schema every real story runs (buildStorySettings always
-    // populates suggestionCategories): .extend() carries retrievalQueries onto this
-    // schema too, but nothing else pins that — a refactor to a standalone z.object
-    // could silently drop Q4 for every real story.
+    // This is the schema every real story runs (suggestionCategories is always populated); its
+    // .extend() carries retrievalQueries but nothing else pins that — a refactor could drop Q4.
     it('carries retrievalQueries alongside suggestions', () => {
       const result = fallbackClassifierWithSuggestionsSchema.safeParse({
         sceneEntities: [],

--- a/lib/pipeline/definitions/per-turn-piggyback.ts
+++ b/lib/pipeline/definitions/per-turn-piggyback.ts
@@ -88,11 +88,9 @@ export const fallbackClassifierSchema = z.object({
     .describe(
       'One sentence summarizing what happened in this turn. Used verbatim as a retrieval query next turn, so identify the people, places and things that mattered by name, not ID.',
     ),
-  // retrieval.md → Q4: this field must never raise the parse — an optional retrieval
-  // hint isn't worth the cost of a full extra classifier call (or the mandatory summary).
-  // Over-emission therefore drops all of them rather than truncating as the tagged-block
-  // parser does: truncating needs a .transform(), which makes generateStructured's
-  // z.toJSONSchema throw and fail every call. The two producers diverge here on purpose.
+  // retrieval.md → Q4: must never raise the parse — a raise costs a full extra classifier
+  // call and, on failure, takes the mandatory summary down with it. Drops over-emission rather
+  // than truncating: truncation needs .transform(), which breaks z.toJSONSchema.
   retrievalQueries: z
     .array(z.string())
     .max(MAX_RETRIEVAL_QUERIES)

--- a/lib/pipeline/definitions/per-turn-piggyback.ts
+++ b/lib/pipeline/definitions/per-turn-piggyback.ts
@@ -90,13 +90,16 @@ export const fallbackClassifierSchema = z.object({
     ),
   // retrieval.md → Q4: this field must never raise the parse — an optional retrieval
   // hint isn't worth the cost of a full extra classifier call (or the mandatory summary).
+  // Over-emission therefore drops all of them rather than truncating as the tagged-block
+  // parser does: truncating needs a .transform(), which makes generateStructured's
+  // z.toJSONSchema throw and fail every call. The two producers diverge here on purpose.
   retrievalQueries: z
     .array(z.string())
     .max(MAX_RETRIEVAL_QUERIES)
     .optional()
     .catch(undefined)
     .describe(
-      'Up to three short phrases naming context you want retrieved for the NEXT turn — what you would want looked up, not a recap of this one.',
+      'Up to three short phrases naming context you want retrieved for the NEXT turn — what you would want looked up, not a recap of this one. Used verbatim as a retrieval query next turn, so identify the people, places and things by name, not ID.',
     ),
 })
 

--- a/lib/pipeline/definitions/per-turn-piggyback.ts
+++ b/lib/pipeline/definitions/per-turn-piggyback.ts
@@ -6,6 +6,7 @@ import { inheritedEntryMetadata } from '@/lib/db'
 import {
   buildPiggybackActions,
   buildStateReport,
+  MAX_RETRIEVAL_QUERIES,
   resolveSuggestionEmission,
   resolveSuggestionItems,
   substitutePiggybackIds,
@@ -86,6 +87,13 @@ export const fallbackClassifierSchema = z.object({
     .optional()
     .describe(
       'One sentence summarizing what happened in this turn. Used verbatim as a retrieval query next turn, so identify the people, places and things that mattered by name, not ID.',
+    ),
+  retrievalQueries: z
+    .array(z.string())
+    .max(MAX_RETRIEVAL_QUERIES)
+    .optional()
+    .describe(
+      'Up to three short phrases naming context you want retrieved for the NEXT turn — what you would want looked up, not a recap of this one.',
     ),
 })
 

--- a/lib/pipeline/definitions/per-turn-piggyback.ts
+++ b/lib/pipeline/definitions/per-turn-piggyback.ts
@@ -88,10 +88,13 @@ export const fallbackClassifierSchema = z.object({
     .describe(
       'One sentence summarizing what happened in this turn. Used verbatim as a retrieval query next turn, so identify the people, places and things that mattered by name, not ID.',
     ),
+  // retrieval.md → Q4: this field must never raise the parse — an optional retrieval
+  // hint isn't worth the cost of a full extra classifier call (or the mandatory summary).
   retrievalQueries: z
     .array(z.string())
     .max(MAX_RETRIEVAL_QUERIES)
     .optional()
+    .catch(undefined)
     .describe(
       'Up to three short phrases naming context you want retrieved for the NEXT turn — what you would want looked up, not a recap of this one.',
     ),

--- a/lib/pipeline/definitions/per-turn-retrieval.test.ts
+++ b/lib/pipeline/definitions/per-turn-retrieval.test.ts
@@ -1161,8 +1161,8 @@ describe('retrieval phase — RetrievalParams assembly', () => {
     expect(lastParams().query.emittedQueries).toEqual(['House Eldrin sigil'])
   })
 
-  // Read from the same row Q3 reads (retrieval.md → Q4 Storage). An absent field is
-  // the common case for the whole of PR 2's life on models without the tagged block.
+  // Read from the same row Q3 reads (retrieval.md → Q4 Storage). An absent field is the
+  // pre-Q4 shape, and any turn whose classifier emitted none.
   it('passes an empty emission when the last narrative entry carried none', async () => {
     seedOpenStory({
       entries: [

--- a/lib/pipeline/definitions/per-turn-retrieval.test.ts
+++ b/lib/pipeline/definitions/per-turn-retrieval.test.ts
@@ -1148,6 +1148,34 @@ describe('retrieval phase — RetrievalParams assembly', () => {
     expect(lastParams().query.piggybackSummary).toBeNull()
   })
 
+  it("carries the last narrative entry's emitted queries through to Q4", async () => {
+    seedOpenStory({
+      entries: [
+        entry(1, 'ai_reply', 'Steel sings.', meta({ retrievalQueries: ['House Eldrin sigil'] })),
+        entry(2, 'user_action', 'I press on.', meta()),
+      ],
+    })
+
+    await runRetrievalPhase()
+
+    expect(lastParams().query.emittedQueries).toEqual(['House Eldrin sigil'])
+  })
+
+  // Read from the same row Q3 reads (retrieval.md → Q4 Storage). An absent field is
+  // the common case for the whole of PR 2's life on models without the tagged block.
+  it('passes an empty emission when the last narrative entry carried none', async () => {
+    seedOpenStory({
+      entries: [
+        entry(1, 'ai_reply', 'Steel sings.', meta({ summary: 'Kael drew.' })),
+        entry(2, 'user_action', 'I press on.', meta()),
+      ],
+    })
+
+    await runRetrievalPhase()
+
+    expect(lastParams().query.emittedQueries).toEqual([])
+  })
+
   it('leaves the Q2 era line absent — nothing writes branch_era_flips yet', async () => {
     seedOpenStory()
 

--- a/lib/pipeline/definitions/per-turn-retrieval.ts
+++ b/lib/pipeline/definitions/per-turn-retrieval.ts
@@ -135,6 +135,9 @@ export async function* retrievalPhase(
           // branch_era_flips has no writer wired, so no era can be named yet.
           eraName: null,
           piggybackSummary: lastNarrative?.metadata?.summary ?? null,
+          // Same row Q3 reads (retrieval.md → Q4 Storage). The cap, dedupe and
+          // empty-filter all live in buildQueryStack; this is the whole wiring.
+          emittedQueries: lastNarrative?.metadata?.retrievalQueries ?? [],
         },
         sceneCharacterIds,
         sceneEntityIds: scene.sceneEntities,

--- a/lib/probe/compress.test.ts
+++ b/lib/probe/compress.test.ts
@@ -40,12 +40,26 @@ const capturePayload = (): ProbeCapturePayload => ({
     protectedBuffer: 200,
   },
   queries: [
-    { text: 'What does the party do next?', token_count: 6, source: 'user_action' },
-    { text: 'Summarize recent events.', token_count: 4, source: 'structural_digest' },
+    {
+      text: 'What does the party do next?',
+      token_count: 6,
+      source: 'user_action',
+      redundancy: null,
+      redundancy_k: null,
+    },
+    {
+      text: 'Summarize recent events.',
+      token_count: 4,
+      source: 'structural_digest',
+      redundancy: null,
+      redundancy_k: null,
+    },
     {
       text: 'The bridge fell during the third night of the siege.',
       token_count: 11,
       source: 'piggyback_summary',
+      redundancy: null,
+      redundancy_k: null,
     },
   ],
   scan_text: 'What does the party do next?\nThe bridge fell during the third night of the siege.',

--- a/lib/probe/payload.test.ts
+++ b/lib/probe/payload.test.ts
@@ -302,7 +302,7 @@ describe('buildCapturePayload', () => {
       captured_at: 1_700_000_000_123,
       embedding_model_id: 'Xenova/all-MiniLM-L6-v2',
       capture_mode: 'light',
-      capture_version: 6,
+      capture_version: 7,
     })
   })
 
@@ -404,6 +404,59 @@ describe('buildCapturePayload', () => {
     expect(row).not.toHaveProperty('sim_q1')
   })
 
+  it('carries each Q4 entry its redundancy ratio and the top-K it was measured over', () => {
+    const stack = queryStack({ emittedQueries: ['marsh nobility'] })
+    const payload = buildCapturePayload({
+      ...identity,
+      mode: 'light',
+      settings,
+      params: RANKER_DEFAULTS,
+      outcome: retrievalSuccess({
+        queries: stack,
+        queryRedundancy: [null, null, null, { ratio: 0.25, k: 400 }],
+      }),
+    })
+
+    expect(payload.queries[3]).toMatchObject({
+      source: 'classifier_emitted',
+      redundancy: 0.25,
+      redundancy_k: 400,
+    })
+  })
+
+  it('leaves the fixed slots null on both redundancy fields', () => {
+    const payload = buildCapturePayload({
+      ...identity,
+      mode: 'light',
+      settings,
+      params: RANKER_DEFAULTS,
+      outcome: retrievalSuccess({ queries: queryStack(), queryRedundancy: [null, null, null] }),
+    })
+
+    expect(payload.queries.slice(0, 3).map((q) => [q.redundancy, q.redundancy_k])).toEqual([
+      [null, null],
+      [null, null],
+      [null, null],
+    ])
+  })
+
+  // A pass that failed before KNN carries an empty array while its stack still
+  // has three specs; reading past the end must not produce undefined in the payload.
+  it('nulls redundancy on a failed pass whose stack outlives its measurement', () => {
+    const payload = buildCapturePayload({
+      ...identity,
+      mode: 'light',
+      settings,
+      params: RANKER_DEFAULTS,
+      outcome: retrievalFailure(
+        { reason: 'call', detail: 'KNN blew up', staleCount: null },
+        { queries: queryStack(), queryRedundancy: [] },
+      ),
+    })
+
+    expect(payload.queries.every((q) => q.redundancy === null)).toBe(true)
+  })
+
   it('prices each query with the real tokenizer', () => {
     const payload = buildCapturePayload({
       ...identity,
@@ -417,6 +470,8 @@ describe('buildCapturePayload', () => {
       text: 'Mira opens the ledger and reads the tide marks aloud.',
       token_count: 12,
       source: 'user_action',
+      redundancy: null,
+      redundancy_k: null,
     })
   })
 
@@ -508,9 +563,21 @@ describe('buildCapturePayload', () => {
     })
 
     expect(payload.queries).toEqual([
-      { text: '', token_count: 0, source: 'user_action' },
-      { text: '', token_count: 0, source: 'structural_digest' },
-      { text: '', token_count: 0, source: 'piggyback_summary' },
+      { text: '', token_count: 0, source: 'user_action', redundancy: null, redundancy_k: null },
+      {
+        text: '',
+        token_count: 0,
+        source: 'structural_digest',
+        redundancy: null,
+        redundancy_k: null,
+      },
+      {
+        text: '',
+        token_count: 0,
+        source: 'piggyback_summary',
+        redundancy: null,
+        redundancy_k: null,
+      },
     ])
     expectEmptyPools(payload)
     expect(payload.structural_floor).toEqual([])

--- a/lib/probe/payload.test.ts
+++ b/lib/probe/payload.test.ts
@@ -397,9 +397,8 @@ describe('buildCapturePayload', () => {
     expect(emittedPayload.queries[3].text).toBe('House Eldrin')
   })
 
-  // Literally 0, not null: near-0 is the BEST case (retrieval.md → Redundancy — it
-  // surfaced something the floor did not), so a falsy-collapsing `||` here would
-  // erase exactly the signal the field exists to carry.
+  // 0 is the best case (retrieval.md → Redundancy: it surfaced something the floor
+  // didn't) — a falsy-collapsing `||` here would erase exactly that signal.
   it('keeps a zero redundancy ratio as 0 rather than collapsing it to null', () => {
     expect(emittedPayload.queries[3]).toMatchObject({ redundancy: 0, redundancy_k: 1 })
   })
@@ -447,9 +446,8 @@ describe('buildCapturePayload', () => {
     ])
   })
 
-  // A sync-stage failure reaches no stack at all, so the payload falls back to
-  // ABSENT_QUERY_STACK's three specs beside an empty measurement array; reading
-  // past the end must not produce undefined in the payload.
+  // No stack on a sync-stage failure, so the payload falls back to ABSENT_QUERY_STACK's
+  // three specs beside an empty measurement array — reading past the end must not yield undefined.
   it('nulls redundancy on a failed pass that never built a query stack', () => {
     const payload = buildCapturePayload({
       ...identity,

--- a/lib/probe/payload.test.ts
+++ b/lib/probe/payload.test.ts
@@ -397,6 +397,13 @@ describe('buildCapturePayload', () => {
     expect(emittedPayload.queries[3].text).toBe('House Eldrin')
   })
 
+  // Literally 0, not null: near-0 is the BEST case (retrieval.md → Redundancy — it
+  // surfaced something the floor did not), so a falsy-collapsing `||` here would
+  // erase exactly the signal the field exists to carry.
+  it('keeps a zero redundancy ratio as 0 rather than collapsing it to null', () => {
+    expect(emittedPayload.queries[3]).toMatchObject({ redundancy: 0, redundancy_k: 1 })
+  })
+
   it('stores per-row sims as a list aligned with the query list', () => {
     const row = emittedPayload.pools.lore[0]
     expect(row.sims).toEqual([0.95, 0.9, null, 0.7])
@@ -440,21 +447,22 @@ describe('buildCapturePayload', () => {
     ])
   })
 
-  // A pass that failed before KNN carries an empty array while its stack still
-  // has three specs; reading past the end must not produce undefined in the payload.
-  it('nulls redundancy on a failed pass whose stack outlives its measurement', () => {
+  // A sync-stage failure reaches no stack at all, so the payload falls back to
+  // ABSENT_QUERY_STACK's three specs beside an empty measurement array; reading
+  // past the end must not produce undefined in the payload.
+  it('nulls redundancy on a failed pass that never built a query stack', () => {
     const payload = buildCapturePayload({
       ...identity,
       mode: 'light',
       settings,
       params: RANKER_DEFAULTS,
-      outcome: retrievalFailure(
-        { reason: 'call', detail: 'KNN blew up', staleCount: null },
-        { queries: queryStack(), queryRedundancy: [] },
-      ),
+      outcome: retrievalFailure({ reason: 'call', detail: 'sync blew up', staleCount: null }),
     })
 
-    expect(payload.queries.every((q) => q.redundancy === null)).toBe(true)
+    expect(payload.queries).toHaveLength(3)
+    expect(payload.queries.every((q) => q.redundancy === null && q.redundancy_k === null)).toBe(
+      true,
+    )
   })
 
   it('prices each query with the real tokenizer', () => {

--- a/lib/probe/payload.ts
+++ b/lib/probe/payload.ts
@@ -15,6 +15,7 @@ import {
   type EntityRow,
   type KeywordInjection,
   type LoreRow,
+  type QueryRedundancy,
   type QuerySpec,
   type QueryStack,
   type RankedType,
@@ -109,10 +110,12 @@ const funnelOf = (bundle: RankedType | undefined): ProbeCapturePayload['funnels'
         type_budget: bundle.funnel.typeBudget,
       }
 
-const queryOf = (q: QuerySpec) => ({
+const queryOf = (q: QuerySpec, redundancy: QueryRedundancy | null) => ({
   text: q.text,
   token_count: countTokens(q.text),
   source: q.source,
+  redundancy: redundancy?.ratio ?? null,
+  redundancy_k: redundancy?.k ?? null,
 })
 
 // A pass that failed before building a stack still captures the fixed slots, so
@@ -129,8 +132,14 @@ const ABSENT_QUERY_STACK = buildQueryStack({
 // No query vector in either mode: λ_div — the one thing deep mode exists for —
 // needs candidate-vs-candidate cosines, and every other simulation re-blends
 // the per-row `sims` (probe.md → Deep mode).
-const queriesOf = (stack: QueryStack | null): ProbeCapturePayload['queries'] =>
-  (stack ?? ABSENT_QUERY_STACK).specs.map(queryOf)
+//
+// `redundancy` is indexed defensively: a pass that failed before KNN carries an
+// empty array beside a three-slot stack.
+const queriesOf = (
+  stack: QueryStack | null,
+  redundancy: readonly (QueryRedundancy | null)[],
+): ProbeCapturePayload['queries'] =>
+  (stack ?? ABSENT_QUERY_STACK).specs.map((q, i) => queryOf(q, redundancy[i] ?? null))
 
 const nameWithDescription = (name: string, description: string | null): string =>
   description ? `${name}: ${description}` : name
@@ -189,6 +198,7 @@ export function buildCapturePayload(input: CapturePayloadInput): ProbeCapturePay
     floor,
     bundles,
     keywordInjections,
+    queryRedundancy,
   } = outcome.ok ? outcome : outcome.partial
 
   return {
@@ -205,7 +215,7 @@ export function buildCapturePayload(input: CapturePayloadInput): ProbeCapturePay
       ...input.settings,
       retrievalBudgets: { ...input.settings.retrievalBudgets },
     },
-    queries: queriesOf(stack),
+    queries: queriesOf(stack, queryRedundancy),
     scan_text: input.scanText,
     pools: {
       entities: poolOf(bundles.entities, mode),

--- a/lib/probe/payload.ts
+++ b/lib/probe/payload.ts
@@ -133,8 +133,8 @@ const ABSENT_QUERY_STACK = buildQueryStack({
 // needs candidate-vs-candidate cosines, and every other simulation re-blends
 // the per-row `sims` (probe.md → Deep mode).
 //
-// `redundancy` is indexed defensively: a pass that failed before KNN carries an
-// empty array beside a three-slot stack.
+// `redundancy` is indexed defensively: a partial with no stack of its own carries
+// an empty array beside ABSENT_QUERY_STACK's three specs.
 const queriesOf = (
   stack: QueryStack | null,
   redundancy: readonly (QueryRedundancy | null)[],

--- a/lib/probe/read.test.ts
+++ b/lib/probe/read.test.ts
@@ -219,6 +219,33 @@ describe('decodeCapture', () => {
     expect(decodeCapture(['pc_1', 'br_a', 1000, 'light', null, 100, bytes]).id).toBe('pc_1')
   })
 
+  it.each<[string, unknown, RegExp]>([
+    ['a string', '0.5', /queries\[0\]\.redundancy must be a finite number or null/i],
+    ['a boolean', true, /queries\[0\]\.redundancy must be a finite number or null/i],
+  ])('rejects a capture whose first query has redundancy %s', (_label, redundancy, message) => {
+    const payload = buildCapturePayload(captureInput())
+    const [first, ...rest] = payload.queries
+    const { bytes } = compressPayload({
+      ...payload,
+      queries: [{ ...first, redundancy }, ...rest] as ProbeCapturePayload['queries'],
+    })
+
+    expect(() => decodeCapture(['pc_1', 'br_a', 1000, 'light', null, 100, bytes])).toThrow(message)
+  })
+
+  it('rejects a capture whose first query has a non-numeric redundancy_k', () => {
+    const payload = buildCapturePayload(captureInput())
+    const [first, ...rest] = payload.queries
+    const { bytes } = compressPayload({
+      ...payload,
+      queries: [{ ...first, redundancy_k: '400' }, ...rest] as ProbeCapturePayload['queries'],
+    })
+
+    expect(() => decodeCapture(['pc_1', 'br_a', 1000, 'light', null, 100, bytes])).toThrow(
+      /queries\[0\]\.redundancy_k must be a finite number or null/i,
+    )
+  })
+
   it('rejects a payload that decodes to something other than an object', () => {
     const { bytes } = compressPayload('not a capture' as unknown as ProbeCapturePayload)
 

--- a/lib/probe/read.ts
+++ b/lib/probe/read.ts
@@ -37,10 +37,8 @@ export function capturesForStoryQuery(storyId: string): RowQuery {
 // throw into `corrupt`, so the row stays listed and deletable rather than decoding
 // into a shape that lies about itself.
 //
-// Takes the raw decode so it can run ahead of the shape guard — an older capture is
-// missing whatever fields the shape rules have gained since, and reporting one of
-// those by name buries the real cause. A non-object isn't a version problem, so that
-// diagnostic is left to assertCaptureShape.
+// Runs ahead of the shape guard — an older capture's newly-added fields would otherwise
+// bury the real cause. A non-object isn't a version problem; that's assertCaptureShape's job.
 function assertCaptureVersion(id: string, payload: unknown): void {
   if (typeof payload !== 'object' || payload === null) return
   const version = (payload as Partial<ProbeCapturePayload>).capture_version

--- a/lib/probe/read.ts
+++ b/lib/probe/read.ts
@@ -37,14 +37,21 @@ export function capturesForStoryQuery(storyId: string): RowQuery {
 // throw into `corrupt`, so the row stays listed and deletable rather than decoding
 // into a shape that lies about itself.
 //
+// Takes the raw decode so it can run ahead of the shape guard — an older capture is
+// missing whatever fields the shape rules have gained since, and reporting one of
+// those by name buries the real cause. A non-object isn't a version problem, so that
+// diagnostic is left to assertCaptureShape.
+function assertCaptureVersion(id: string, payload: unknown): void {
+  if (typeof payload !== 'object' || payload === null) return
+  const version = (payload as Partial<ProbeCapturePayload>).capture_version
+  if (version !== CAPTURE_VERSION) {
+    throw new Error(`capture ${id} is format version ${version}, expected ${CAPTURE_VERSION}`)
+  }
+}
+
 // Tokenizer drift only warns — it makes tokens_estimated a count from a different
 // vocabulary, which only a re-price would notice, and invalidates nothing.
-function assertCaptureVersion(id: string, payload: ProbeCapturePayload): void {
-  if (payload.capture_version !== CAPTURE_VERSION) {
-    throw new Error(
-      `capture ${id} is format version ${payload.capture_version}, expected ${CAPTURE_VERSION}`,
-    )
-  }
+function warnOnTokenizerDrift(id: string, payload: ProbeCapturePayload): void {
   const tokenizer = payload.tokenizer
   const stored =
     tokenizer === undefined || tokenizer === null
@@ -74,10 +81,11 @@ export function decodeCapture(row: readonly unknown[]): StoredCapture {
     Uint8Array,
   ]
   const decoded = decompressPayload(payloadBytes)
-  assertCaptureShape(decoded)
-  // Before the params guard: a stale capture reports as stale, not as the
-  // malformed ranker params a since-renamed tunable leaves it holding.
+  // First of the three guards: a stale capture reports as stale, not as a missing
+  // field or as the malformed ranker params a since-renamed tunable leaves it holding.
   assertCaptureVersion(id, decoded)
+  assertCaptureShape(decoded)
+  warnOnTokenizerDrift(id, decoded)
   assertRankerParams(decoded.params.ranker)
   return { id, branchId, capturedAt, captureMode, failureReason, payloadSize, payload: decoded }
 }

--- a/lib/probe/validate.ts
+++ b/lib/probe/validate.ts
@@ -56,6 +56,13 @@ const eachNonNegative = (field: string, record: Readonly<Record<RetrievalType, n
 const typeOf = (value: unknown): string =>
   value === null ? 'null' : Array.isArray(value) ? 'array' : typeof value
 
+// isFinite guards a format change only — JSON flattens NaN/Infinity to null before
+// a capture is ever stored, so no non-finite value can reach here today.
+const requireFiniteOrNull = (field: string, value: unknown): void => {
+  if (value !== null && !(typeof value === 'number' && Number.isFinite(value)))
+    throw new CaptureShapeError(field, `must be a finite number or null, got ${typeOf(value)}`)
+}
+
 const requirePlainObject = (field: string, value: unknown): void => {
   if (value === null || typeof value !== 'object' || Array.isArray(value))
     throw new CaptureShapeError(field, `must be an object, got ${typeOf(value)}`)
@@ -98,10 +105,16 @@ export function assertCaptureShape(decoded: unknown): asserts decoded is ProbeCa
     const source = (query as Record<string, unknown>).source
     if (typeof source !== 'string')
       throw new CaptureShapeError(`queries[${i}].source`, `must be a string, got ${typeOf(source)}`)
+    // Q4-only in practice, but validated on every entry: this module proves shapes,
+    // not which source may carry which field.
+    requireFiniteOrNull(`queries[${i}].redundancy`, (query as Record<string, unknown>).redundancy)
+    requireFiniteOrNull(
+      `queries[${i}].redundancy_k`,
+      (query as Record<string, unknown>).redundancy_k,
+    )
   })
   // blendSims indexes sims positionally against queries, so a non-array dies at
   // replay's `[...r.sims]` spread and a non-number blends to NaN unmarked.
-  // isFinite guards a format change only — JSON flattens NaN/Infinity to null.
   const queryCount = payload.queries.length
   for (const type of RETRIEVAL_TYPES) {
     ;(pools[type] as unknown[]).forEach((candidate, i) => {
@@ -115,13 +128,7 @@ export function assertCaptureShape(decoded: unknown): asserts decoded is ProbeCa
           `${field}.sims`,
           `must carry one value per query, got ${sims.length} for ${queryCount}`,
         )
-      sims.forEach((sim, j) => {
-        if (sim !== null && !(typeof sim === 'number' && Number.isFinite(sim)))
-          throw new CaptureShapeError(
-            `${field}.sims[${j}]`,
-            `must be a finite number or null, got ${typeOf(sim)}`,
-          )
-      })
+      sims.forEach((sim, j) => requireFiniteOrNull(`${field}.sims[${j}]`, sim))
     })
   }
   // Required-and-nullable, so `undefined` is rejected rather than defaulted:

--- a/lib/prompts/bundled/__snapshots__/per-turn.test.ts.snap
+++ b/lib/prompts/bundled/__snapshots__/per-turn.test.ts.snap
@@ -28,6 +28,9 @@ After your narrative prose, append exactly one <state> block (never inside the p
     <stackable key="lowercase name, e.g. gold" amount="quantity moved" to="ID" from="ID" />
   </transfers>
   <summary>one sentence summarizing what happened in this reply — identify the people, places and things that mattered by name, not ID</summary>
+  <retrieval_queries>
+    <query>up to three short phrases naming context you want retrieved for the NEXT turn — what you would want looked up, not a recap of this one</query>
+  </retrieval_queries>
 </state>
 
 Omit any inner tag you have nothing to report for. Use only the IDs shown to you above, without brackets — never invent one. Only reference items and locations that already have an ID; if something is genuinely new, describe it in prose only and leave it out of the structured block. \`to\` or \`from\` may be omitted on a transfer when there's no specific known other party (e.g. found loose, spent on someone off-scene)."
@@ -83,6 +86,9 @@ After your narrative prose, append exactly one <state> block (never inside the p
     <stackable key="lowercase name, e.g. gold" amount="quantity moved" to="ID" from="ID" />
   </transfers>
   <summary>one sentence summarizing what happened in this reply — identify the people, places and things that mattered by name, not ID</summary>
+  <retrieval_queries>
+    <query>up to three short phrases naming context you want retrieved for the NEXT turn — what you would want looked up, not a recap of this one</query>
+  </retrieval_queries>
 </state>
 
 Omit any inner tag you have nothing to report for. Use only the IDs shown to you above, without brackets — never invent one. Only reference items and locations that already have an ID; if something is genuinely new, describe it in prose only and leave it out of the structured block. \`to\` or \`from\` may be omitted on a transfer when there's no specific known other party (e.g. found loose, spent on someone off-scene)."

--- a/lib/prompts/bundled/__snapshots__/per-turn.test.ts.snap
+++ b/lib/prompts/bundled/__snapshots__/per-turn.test.ts.snap
@@ -29,7 +29,7 @@ After your narrative prose, append exactly one <state> block (never inside the p
   </transfers>
   <summary>one sentence summarizing what happened in this reply — identify the people, places and things that mattered by name, not ID</summary>
   <retrieval_queries>
-    <query>up to three short phrases naming context you want retrieved for the NEXT turn — what you would want looked up, not a recap of this one</query>
+    <query>up to three short phrases naming context you want retrieved for the NEXT turn — what you would want looked up, not a recap of this one; identify the people, places and things by name, not ID</query>
   </retrieval_queries>
 </state>
 
@@ -87,7 +87,7 @@ After your narrative prose, append exactly one <state> block (never inside the p
   </transfers>
   <summary>one sentence summarizing what happened in this reply — identify the people, places and things that mattered by name, not ID</summary>
   <retrieval_queries>
-    <query>up to three short phrases naming context you want retrieved for the NEXT turn — what you would want looked up, not a recap of this one</query>
+    <query>up to three short phrases naming context you want retrieved for the NEXT turn — what you would want looked up, not a recap of this one; identify the people, places and things by name, not ID</query>
   </retrieval_queries>
 </state>
 

--- a/lib/prompts/bundled/bundled-pack.test.ts
+++ b/lib/prompts/bundled/bundled-pack.test.ts
@@ -77,4 +77,12 @@ describe('bundled pack', () => {
 
     expect(classifier).toMatch(/one[- ]sentence summary/i)
   })
+
+  it('asks the fallback classifier for the retrieval queries Q4 needs', () => {
+    const context = { entities: [], lastTurns: [{ content: 'The gate groaned open.' }] }
+    const classifier = renderTemplate(TEMPLATE_IDS.piggybackFallbackClassifier, context)
+
+    expect(classifier).toMatch(/up to three/i)
+    expect(classifier).toMatch(/next turn/i)
+  })
 })

--- a/lib/prompts/bundled/piggyback-fallback-classifier.ts
+++ b/lib/prompts/bundled/piggyback-fallback-classifier.ts
@@ -9,7 +9,7 @@ export const PIGGYBACK_FALLBACK_CLASSIFIER = `Known entities, referenced only by
 {%- endfor %}
 {% if referenceable.size == 0 and stagedEntities.size == 0 %}(none){% endif %}
 
-Extract scene state and a one-sentence summary of this turn:
+Extract scene state, a one-sentence summary of this turn, and up to three retrieval queries naming context you want looked up for the next turn:
 
 {% for entry in lastTurns %}
 {{ entry.content }}

--- a/lib/prompts/bundled/state-emission.ts
+++ b/lib/prompts/bundled/state-emission.ts
@@ -12,6 +12,9 @@ export const STATE_EMISSION = `After your narrative prose, append exactly one <s
     <stackable key="lowercase name, e.g. gold" amount="quantity moved" to="ID" from="ID" />
   </transfers>
   <summary>one sentence summarizing what happened in this reply — identify the people, places and things that mattered by name, not ID</summary>
+  <retrieval_queries>
+    <query>up to three short phrases naming context you want retrieved for the NEXT turn — what you would want looked up, not a recap of this one</query>
+  </retrieval_queries>
 </state>
 
 Omit any inner tag you have nothing to report for. Use only the IDs shown to you above, without brackets — never invent one. Only reference items and locations that already have an ID; if something is genuinely new, describe it in prose only and leave it out of the structured block. \`to\` or \`from\` may be omitted on a transfer when there's no specific known other party (e.g. found loose, spent on someone off-scene).`

--- a/lib/prompts/bundled/state-emission.ts
+++ b/lib/prompts/bundled/state-emission.ts
@@ -13,7 +13,7 @@ export const STATE_EMISSION = `After your narrative prose, append exactly one <s
   </transfers>
   <summary>one sentence summarizing what happened in this reply — identify the people, places and things that mattered by name, not ID</summary>
   <retrieval_queries>
-    <query>up to three short phrases naming context you want retrieved for the NEXT turn — what you would want looked up, not a recap of this one</query>
+    <query>up to three short phrases naming context you want retrieved for the NEXT turn — what you would want looked up, not a recap of this one; identify the people, places and things by name, not ID</query>
   </retrieval_queries>
 </state>
 

--- a/lib/prompts/bundled/structural-floor.test.ts
+++ b/lib/prompts/bundled/structural-floor.test.ts
@@ -132,3 +132,14 @@ describe('non-structural rows reach the prompt only by winning budget', () => {
     expect(out).toContain('Mira (available to introduce): A courier who owes the guild.')
   })
 })
+
+describe('state emission includes retrieval query instructions', () => {
+  // A schema field with no instruction is a field the model never fills. The
+  // cap and the next-turn framing both have to reach the model, not just the parser.
+  it('asks for retrieval queries by tag, capped, framed as next-turn context', () => {
+    expect(STATE_EMISSION).toContain('<retrieval_queries>')
+    expect(STATE_EMISSION).toContain('<query>')
+    expect(STATE_EMISSION).toMatch(/up to three/i)
+    expect(STATE_EMISSION).toMatch(/next turn/i)
+  })
+})

--- a/lib/retrieval/__tests__/outcome.ts
+++ b/lib/retrieval/__tests__/outcome.ts
@@ -118,8 +118,11 @@ export function retrievalSuccess(over: RetrievalSuccessOverrides = {}): Retrieva
     queries,
     keywordInjections: over.keywordInjections ?? [],
     // Aligned with `specs` rather than defaulted to []: a pass emitting no Q4
-    // still reports one null per fixed slot.
-    queryRedundancy: over.queryRedundancy ?? queries.specs.map(() => null),
+    // still reports one null per fixed slot. Non-null on a 'direct' slot so an
+    // emitted-stack fixture exercises the rendering path by default.
+    queryRedundancy:
+      over.queryRedundancy ??
+      queries.slots.map((s) => (s === 'direct' ? { ratio: 0, k: 1 } : null)),
     staleCounts: { ...perType(() => 0), ...over.staleCounts },
     injectedAwareness: over.injectedAwareness ?? [],
     selectedLocationIds: over.selectedLocationIds ?? [],

--- a/lib/retrieval/__tests__/outcome.ts
+++ b/lib/retrieval/__tests__/outcome.ts
@@ -2,6 +2,7 @@ import type { StructuralFloor } from '../pools'
 import { buildQueryStack, type QueryStack } from '../queries'
 import type {
   InjectedAwareness,
+  QueryRedundancy,
   RetrievalFailure,
   RetrievalOutcome,
   RetrievalPartial,
@@ -86,6 +87,7 @@ export type RetrievalSuccessOverrides = {
   bundles?: Partial<Record<RetrievalType, RankedType>>
   queries?: QueryStack
   keywordInjections?: readonly KeywordInjection[]
+  queryRedundancy?: readonly (QueryRedundancy | null)[]
   staleCounts?: Partial<Record<RetrievalType, number>>
   injectedAwareness?: InjectedAwareness[]
   selectedLocationIds?: string[]
@@ -99,6 +101,7 @@ export type RetrievalSuccessOverrides = {
  * shared empty bundle is one `.push` away from leaking across tests.
  */
 export function retrievalSuccess(over: RetrievalSuccessOverrides = {}): RetrievalSuccess {
+  const queries = over.queries ?? emptyQueryStack()
   return {
     ok: true,
     floor: {
@@ -112,8 +115,11 @@ export function retrievalSuccess(over: RetrievalSuccessOverrides = {}): Retrieva
       ...over.floor,
     },
     bundles: perType((type) => over.bundles?.[type] ?? rankedBundle(over.selected?.[type] ?? [])),
-    queries: over.queries ?? emptyQueryStack(),
+    queries,
     keywordInjections: over.keywordInjections ?? [],
+    // Aligned with `specs` rather than defaulted to []: a pass emitting no Q4
+    // still reports one null per fixed slot.
+    queryRedundancy: over.queryRedundancy ?? queries.specs.map(() => null),
     staleCounts: { ...perType(() => 0), ...over.staleCounts },
     injectedAwareness: over.injectedAwareness ?? [],
     selectedLocationIds: over.selectedLocationIds ?? [],
@@ -133,6 +139,13 @@ export function retrievalFailure(
   return {
     ok: false,
     failure,
-    partial: { queries: null, floor: null, bundles: {}, keywordInjections: [], ...partial },
+    partial: {
+      queries: null,
+      floor: null,
+      bundles: {},
+      keywordInjections: [],
+      queryRedundancy: [],
+      ...partial,
+    },
   }
 }

--- a/lib/retrieval/__tests__/outcome.ts
+++ b/lib/retrieval/__tests__/outcome.ts
@@ -117,9 +117,9 @@ export function retrievalSuccess(over: RetrievalSuccessOverrides = {}): Retrieva
     bundles: perType((type) => over.bundles?.[type] ?? rankedBundle(over.selected?.[type] ?? [])),
     queries,
     keywordInjections: over.keywordInjections ?? [],
-    // Aligned with `specs` rather than defaulted to []: a pass emitting no Q4
-    // still reports one null per fixed slot. Non-null on a 'direct' slot so an
-    // emitted-stack fixture exercises the rendering path by default.
+    // Slot-aligned, not []: null on fixed slots, real value on 'direct' ones —
+    // so a fixture that skips this override still exercises the non-null path,
+    // and the falsy `ratio: 0` catches a `??`-vs-`||` truthiness bug.
     queryRedundancy:
       over.queryRedundancy ??
       queries.slots.map((s) => (s === 'direct' ? { ratio: 0, k: 1 } : null)),

--- a/lib/retrieval/constants.ts
+++ b/lib/retrieval/constants.ts
@@ -34,3 +34,10 @@ export const RANKER_DEFAULTS = {
  * `runRetrievalPass`, which admits chapter-range happenings separately.
  */
 export const KNN_K = 200
+
+/**
+ * The cut the redundancy metric measures over, deliberately far shallower than
+ * `KNN_K`: over the full pass the floor's ~12 ids cannot move a 600-row
+ * denominator, so every query — degenerate or novel — scores near zero.
+ */
+export const REDUNDANCY_K = 10

--- a/lib/retrieval/index.ts
+++ b/lib/retrieval/index.ts
@@ -13,7 +13,12 @@ export { entityNameIndexFrom, matchTerms, normalizeTerm } from './name-index'
 export type { EntityNameIndex } from './name-index'
 export { buildStructuralFloor, filterEntityPool, filterLorePool, filterThreadPool } from './pools'
 export type { EntityRow, LoreRow, StructuralFloor, ThreadRow } from './pools'
-export { buildQueryStack, distributeQueryVectors, QUERY_SLOT_OF_SOURCE } from './queries'
+export {
+  buildQueryStack,
+  distributeQueryVectors,
+  MAX_EMITTED_QUERIES,
+  QUERY_SLOT_OF_SOURCE,
+} from './queries'
 export type { QuerySource, QuerySpec, QueryStack, QueryStackInput } from './queries'
 export { rankAll, rankPerType, tokenCost } from './ranker'
 export type { RankTypeInput } from './ranker'

--- a/lib/retrieval/index.ts
+++ b/lib/retrieval/index.ts
@@ -26,6 +26,7 @@ export { ENTITY_FRAMING, entityRenderedText, lines, loreRenderedText } from './r
 export { runRetrieval } from './run'
 export type {
   InjectedAwareness,
+  QueryRedundancy,
   RetrievalDeps,
   RetrievalFailure,
   RetrievalOutcome,

--- a/lib/retrieval/pools.ts
+++ b/lib/retrieval/pools.ts
@@ -74,9 +74,8 @@ const narrowThread = (t: ThreadRow): Required<ThreadRow> => ({
   description: t.description,
 })
 
-// The only kinds `buildStructuralFloor` below can seat. Counting a chapter or
-// happening top-K in the redundancy denominator would deflate every ratio by
-// construction, since neither can ever intersect the floor.
+// Only kinds `buildStructuralFloor` can seat; chapters/happenings never intersect
+// the floor, so counting them would deflate every ratio by construction.
 export const FLOOR_SEATABLE_KINDS = new Set<VecTargetKind>(['entity', 'lore', 'thread'])
 
 /**
@@ -213,10 +212,9 @@ export function filterThreadPool(
 }
 
 /**
- * One KNN row reduced to what pool assembly and the redundancy cut need. Nothing
- * SCORES on `distance` — the ranker computes cosine over the returned vectors
- * instead — but it orders, and it does so ACROSS kinds: every vector is
- * unit-norm, so L2 order is cosine order (db/embeddings/knn.ts).
+ * Reduced KNN row for pool assembly + the redundancy cut. `distance` isn't a
+ * score (the ranker recomputes cosine) but it orders — across kinds too, since
+ * unit-norm vectors make L2 order equal cosine order (db/embeddings/knn.ts).
  */
 export type KnnHit = readonly [id: string, distance: number]
 

--- a/lib/retrieval/pools.ts
+++ b/lib/retrieval/pools.ts
@@ -1,4 +1,4 @@
-import type { Entity, EntityKind, InjectionMode, Thread } from '@/lib/db'
+import type { Entity, EntityKind, InjectionMode, Thread, VecTargetKind } from '@/lib/db'
 
 import { matchTerms, normalizeTerm } from './name-index'
 
@@ -73,6 +73,11 @@ const narrowThread = (t: ThreadRow): Required<ThreadRow> => ({
   title: t.title,
   description: t.description,
 })
+
+// The only kinds `buildStructuralFloor` below can seat. Counting a chapter or
+// happening top-K in the redundancy denominator would deflate every ratio by
+// construction, since neither can ever intersect the floor.
+export const FLOOR_SEATABLE_KINDS = new Set<VecTargetKind>(['entity', 'lore', 'thread'])
 
 /**
  * retrieval.md → Structural floor. These bypass the ranker and consume budget
@@ -208,8 +213,10 @@ export function filterThreadPool(
 }
 
 /**
- * One KNN row reduced to what pool assembly needs. Nothing scores on
- * `distance`; the ranker computes cosine over the returned vectors instead.
+ * One KNN row reduced to what pool assembly and the redundancy cut need. Nothing
+ * SCORES on `distance` — the ranker computes cosine over the returned vectors
+ * instead — but it orders, and it does so ACROSS kinds: every vector is
+ * unit-norm, so L2 order is cosine order (db/embeddings/knn.ts).
  */
 export type KnnHit = readonly [id: string, distance: number]
 

--- a/lib/retrieval/queries.ts
+++ b/lib/retrieval/queries.ts
@@ -30,7 +30,7 @@ export const QUERY_SLOT_OF_SOURCE = {
 } as const satisfies Record<QuerySource, QuerySlot>
 
 /** retrieval.md → Q4: capped at three, and the cap is a cost decision. */
-const MAX_EMITTED_QUERIES = 3
+export const MAX_EMITTED_QUERIES = 3
 /** retrieval.md → Q4. A retrieval ask is phrase-shaped, far under any embedder input window. */
 const MAX_EMITTED_QUERY_CHARS = 200
 

--- a/lib/retrieval/run.test.ts
+++ b/lib/retrieval/run.test.ts
@@ -563,10 +563,8 @@ describe('runRetrieval — query embed failure', () => {
     expect(partial.bundles).toEqual({})
   })
 
-  // partial.queries is written as soon as the stack is built; queryRedundancy has to be
-  // written in the same spot, not just initialised to `[]` up front, or a partial with an
-  // emitted Q4 ends up with a 4-spec stack beside a shorter redundancy array. One emitted
-  // query is enough to make specs.length 4, so a hardcoded 3-element array would be caught.
+  // queryRedundancy must be written alongside partial.queries, not initialised to `[]` up
+  // front, or an emitted Q4 leaves a 4-spec stack beside a shorter redundancy array.
   it('keeps queryRedundancy aligned with the query stack when the query embed fails', async () => {
     const out = await runRetrieval(
       deps({
@@ -579,10 +577,9 @@ describe('runRetrieval — query embed failure', () => {
     )
 
     const { partial } = expectBlocking(out)
-    // The embed stage fails AFTER the query stack is built, so a partial can carry specs
-    // with no measurement. queryRedundancy must still be positionally aligned — with
-    // noUncheckedIndexedAccess off, a short array types as (QueryRedundancy | null)[] and
-    // hands back undefined at runtime, which is a type lie rather than a guarded case.
+    // Embed fails AFTER the query stack is built, so partial specs can carry no measurement, but
+    // queryRedundancy must stay positionally aligned — noUncheckedIndexedAccess is off, so a
+    // short array types as (QueryRedundancy | null)[] yet returns undefined at runtime.
     expect(partial.queryRedundancy).toHaveLength(partial.queries!.specs.length)
     expect(partial.queryRedundancy.every((r) => r === null)).toBe(true)
   })
@@ -1001,10 +998,8 @@ describe('runRetrieval — query stack', () => {
   })
 })
 
-// retrieval.md → Redundancy. `char_a` is the scene entity, so buildStructuralFloor
-// seats it; `lo_x` is unseated lore. Measured over the query's own PRE-filter top-K,
-// so both are still in it — filterEntityPool removes the floor rows afterwards, which
-// is why a ratio taken after filtering reads 0 for every query by construction.
+// retrieval.md → Redundancy. `char_a` (seated by the floor) and `lo_x` (unseated) fixture the
+// PRE-filter top-K: filterEntityPool removes floor rows afterward, so a post-filter ratio reads 0.
 describe('runRetrieval — per-Q4 redundancy', () => {
   const SEATED = entityRow('char_a', 'Kara Vex')
   const UNSEATED = loreRow('lo_x', 'Marsh law')
@@ -1014,11 +1009,8 @@ describe('runRetrieval — per-Q4 redundancy', () => {
     expectOk(await runRetrieval(deps({ queryAll: makeQueryAll(fixture) }), params(ASK)))
 
   /**
-   * makeQueryAll answers every kind's MATCH from ONE list, but a real id lives in
-   * exactly one kind's vec table (ids carry disjoint kind prefixes) — so a shared
-   * list puts `char_a` in the entity, lore AND thread top-K at once, which the
-   * global merge counts three times. Routing by table keeps these fixtures inside
-   * the disjointness the merge relies on.
+   * makeQueryAll answers every kind's MATCH from one list, but each id lives in only one kind's
+   * vec table; passByKind routes fixtures per table so they don't triple-count in the merge.
    */
   const passByKind = async (
     fixture: Parameters<typeof makeQueryAll>[0],
@@ -1052,11 +1044,9 @@ describe('runRetrieval — per-Q4 redundancy', () => {
     expect(out.queryRedundancy[3]).toEqual({ ratio: 0, k: 1 })
   })
 
-  // Chapters and happenings can never be in floor.seatedIds (pools.ts →
-  // buildStructuralFloor seats entity, lore and thread ids only), so counting their
-  // top-K in the denominator would deflate every ratio by construction. Chapters
-  // return an id NO other kind returns, which moves k from 2 to 3 the moment they
-  // are counted.
+  // Chapters/happenings can never be in floor.seatedIds (pools.ts seats entity/lore/thread
+  // only), so counting their top-K would deflate every ratio; chapters return an id no other
+  // kind does, which moves k from 2 to 3 the moment they're counted.
   it('measures over the entity, lore and thread top-Ks only', async () => {
     const out = await passByKind(
       { entities: [SEATED], lore: [UNSEATED] },
@@ -1065,13 +1055,9 @@ describe('runRetrieval — per-Q4 redundancy', () => {
     expect(out.queryRedundancy[3]).toEqual({ ratio: 0.5, k: 2 })
   })
 
-  // The cut is REDUNDANCY_K nearest GLOBALLY across the seatable kinds, not each
-  // kind's own cut and not the whole KNN pass. Twelve hits: ten floor-seated
-  // entities at distance 0.5-1.4 and two unseated lore rows nearer than all of
-  // them. The ten nearest are both lore plus the eight closest entities.
-  //   global top-10 (correct) → { ratio: 0.8, k: 10 }
-  //   per-kind top-10 unioned → { ratio: 10/12, k: 12 }
-  //   no cut at all           → { ratio: 10/12, k: 12 }
+  // REDUNDANCY_K cuts the 10 nearest GLOBALLY across seatable kinds — not a per-kind cut, not
+  // the full KNN pass. Fixture forces both wrong approaches to read { ratio: 10/12, k: 12 }
+  // while the correct global cut reads { ratio: 0.8, k: 10 }, so the assertion distinguishes them.
   it('measures the REDUNDANCY_K nearest rows across kinds, not one cut per kind', async () => {
     const sceneIds = Array.from({ length: 10 }, (_, i) => `char_s${i}`)
     const out = await passByKind(
@@ -1090,9 +1076,8 @@ describe('runRetrieval — per-Q4 redundancy', () => {
     expect(out.queryRedundancy[3]).toEqual({ ratio: 0.8, k: 10 })
   })
 
-  // A cold start: no dim family exists, so runKnn returns null and the query has no
-  // top-K to measure. 0/0 is not 0 — an unmeasurable query must not read as a
-  // perfectly novel one.
+  // Cold start: no dim family exists, so runKnn returns null and there's no top-K to measure.
+  // 0/0 is not 0 — an unmeasurable query must not read as a perfectly novel one.
   it('reports null for a Q4 whose top-K came back empty', async () => {
     const out = await passWith({ entities: [SEATED], vecTables: [] })
     expect(out.queryRedundancy[3]).toBeNull()

--- a/lib/retrieval/run.test.ts
+++ b/lib/retrieval/run.test.ts
@@ -989,38 +989,81 @@ describe('runRetrieval — per-Q4 redundancy', () => {
   const passWith = async (fixture: Parameters<typeof makeQueryAll>[0]) =>
     expectOk(await runRetrieval(deps({ queryAll: makeQueryAll(fixture) }), params(ASK)))
 
+  /**
+   * makeQueryAll answers every kind's MATCH from ONE list, but a real id lives in
+   * exactly one kind's vec table (ids carry disjoint kind prefixes) — so a shared
+   * list puts `char_a` in the entity, lore AND thread top-K at once, which the
+   * global merge counts three times. Routing by table keeps these fixtures inside
+   * the disjointness the merge relies on.
+   */
+  const passByKind = async (
+    fixture: Parameters<typeof makeQueryAll>[0],
+    knn: { entity?: Row[]; lore?: Row[]; thread?: Row[]; chapter?: Row[] },
+    over: Parameters<typeof params>[0] = {},
+  ) => {
+    const base = makeQueryAll(fixture)
+    const queryAll = vi.fn(async (sql: string, p: unknown[]) => {
+      if (!sql.includes('MATCH')) return base(sql, p)
+      if (sql.includes('entities_vec_')) return knn.entity ?? []
+      if (sql.includes('lore_vec_')) return knn.lore ?? []
+      if (sql.includes('threads_vec_')) return knn.thread ?? []
+      if (sql.includes('chapter_summaries_vec_')) return knn.chapter ?? []
+      return []
+    })
+    return expectOk(await runRetrieval(deps({ queryAll }), params({ ...ASK, ...over })))
+  }
+
   it('reports null on the three fixed slots', async () => {
     const out = await passWith({ entities: [SEATED], knn: [hit('char_a')] })
     expect(out.queryRedundancy.slice(0, 3)).toEqual([null, null, null])
   })
 
   it('scores 1.0 when the floor had already seated the whole top-K', async () => {
-    const out = await passWith({ entities: [SEATED], knn: [hit('char_a')] })
+    const out = await passByKind({ entities: [SEATED] }, { entity: [hit('char_a')] })
     expect(out.queryRedundancy[3]).toEqual({ ratio: 1, k: 1 })
   })
 
   it('scores 0 when the floor seated none of the top-K', async () => {
-    const out = await passWith({ entities: [SEATED], lore: [UNSEATED], knn: [hit('lo_x')] })
+    const out = await passByKind({ entities: [SEATED], lore: [UNSEATED] }, { lore: [hit('lo_x')] })
     expect(out.queryRedundancy[3]).toEqual({ ratio: 0, k: 1 })
   })
 
   // Chapters and happenings can never be in floor.seatedIds (pools.ts →
   // buildStructuralFloor seats entity, lore and thread ids only), so counting their
-  // top-K in the denominator would deflate every ratio by construction. makeQueryAll
-  // answers every kind's KNN from one list, so proving the exclusion needs a
-  // kind-aware arm: chapters return an id NO other kind returns, which moves k from
-  // 2 to 3 the moment they are counted.
+  // top-K in the denominator would deflate every ratio by construction. Chapters
+  // return an id NO other kind returns, which moves k from 2 to 3 the moment they
+  // are counted.
   it('measures over the entity, lore and thread top-Ks only', async () => {
-    const base = makeQueryAll({ entities: [SEATED], lore: [UNSEATED] })
-    const queryAll = vi.fn(async (sql: string, p: unknown[]) => {
-      if (!sql.includes('MATCH')) return base(sql, p)
-      if (sql.includes('entities_vec_')) return [hit('char_a')]
-      if (sql.includes('lore_vec_')) return [hit('lo_x')]
-      if (sql.includes('chapter_summaries_vec_')) return [hit('ch_only')]
-      return []
-    })
-    const out = expectOk(await runRetrieval(deps({ queryAll }), params(ASK)))
+    const out = await passByKind(
+      { entities: [SEATED], lore: [UNSEATED] },
+      { entity: [hit('char_a')], lore: [hit('lo_x')], chapter: [hit('ch_only')] },
+    )
     expect(out.queryRedundancy[3]).toEqual({ ratio: 0.5, k: 2 })
+  })
+
+  // The cut is REDUNDANCY_K nearest GLOBALLY across the seatable kinds, not each
+  // kind's own cut and not the whole KNN pass. Twelve hits: ten floor-seated
+  // entities at distance 0.5-1.4 and two unseated lore rows nearer than all of
+  // them. The ten nearest are both lore plus the eight closest entities.
+  //   global top-10 (correct) → { ratio: 0.8, k: 10 }
+  //   per-kind top-10 unioned → { ratio: 10/12, k: 12 }
+  //   no cut at all           → { ratio: 10/12, k: 12 }
+  it('measures the REDUNDANCY_K nearest rows across kinds, not one cut per kind', async () => {
+    const sceneIds = Array.from({ length: 10 }, (_, i) => `char_s${i}`)
+    const out = await passByKind(
+      {
+        entities: sceneIds.map((id, i) => entityRow(id, `Scene ${i}`)),
+        lore: [loreRow('lo_far', 'Marsh law'), loreRow('lo_near', 'Tide law')],
+      },
+      {
+        entity: sceneIds.map((id, i) => hit(id, 0.5 + i * 0.1)),
+        lore: [hit('lo_near', 0.1), hit('lo_far', 0.2)],
+      },
+      { sceneEntityIds: sceneIds, sceneCharacterIds: sceneIds },
+    )
+
+    expect(out.floor.seatedIds.size).toBe(10)
+    expect(out.queryRedundancy[3]).toEqual({ ratio: 0.8, k: 10 })
   })
 
   // A cold start: no dim family exists, so runKnn returns null and the query has no

--- a/lib/retrieval/run.test.ts
+++ b/lib/retrieval/run.test.ts
@@ -563,6 +563,30 @@ describe('runRetrieval — query embed failure', () => {
     expect(partial.bundles).toEqual({})
   })
 
+  // partial.queries is written as soon as the stack is built; queryRedundancy has to be
+  // written in the same spot, not just initialised to `[]` up front, or a partial with an
+  // emitted Q4 ends up with a 4-spec stack beside a shorter redundancy array. One emitted
+  // query is enough to make specs.length 4, so a hardcoded 3-element array would be caught.
+  it('keeps queryRedundancy aligned with the query stack when the query embed fails', async () => {
+    const out = await runRetrieval(
+      deps({
+        queryAll: makeQueryAll({ entities: [entityRow('char_a', 'Kara Vex')] }),
+        embedTexts: async () => {
+          throw new EmbedderInitError('no local model')
+        },
+      }),
+      params({ query: { emittedQueries: ['marsh nobility'] } }),
+    )
+
+    const { partial } = expectBlocking(out)
+    // The embed stage fails AFTER the query stack is built, so a partial can carry specs
+    // with no measurement. queryRedundancy must still be positionally aligned — with
+    // noUncheckedIndexedAccess off, a short array types as (QueryRedundancy | null)[] and
+    // hands back undefined at runtime, which is a type lie rather than a guarded case.
+    expect(partial.queryRedundancy).toHaveLength(partial.queries!.specs.length)
+    expect(partial.queryRedundancy.every((r) => r === null)).toBe(true)
+  })
+
   // The sync stage already carries a cancel on its own arm; the query embed is the
   // other place the shared abortSignal can land, and 'Switch embedder' is the wrong
   // fix to offer for a user stop.

--- a/lib/retrieval/run.test.ts
+++ b/lib/retrieval/run.test.ts
@@ -350,7 +350,13 @@ describe('runRetrieval — sync ordering', () => {
   it('carries no partial state when the sync stage fails', async () => {
     const { partial } = await withSyncFailure()
 
-    expect(partial).toEqual({ queries: null, floor: null, bundles: {}, keywordInjections: [] })
+    expect(partial).toEqual({
+      queries: null,
+      floor: null,
+      bundles: {},
+      keywordInjections: [],
+      queryRedundancy: [],
+    })
   })
 
   it('reads the source rows AFTER the sync commits, not before', async () => {
@@ -968,6 +974,61 @@ describe('runRetrieval — query stack', () => {
     // The floor never consults a vector, so it survives a fully absent query stack.
     expect(ok.floor.alwaysLore.map((l) => l.id)).toEqual(['lore_1'])
     expect(Object.values(ok.bundles).every((b) => b.selected.length === 0)).toBe(true)
+  })
+})
+
+// retrieval.md → Redundancy. `char_a` is the scene entity, so buildStructuralFloor
+// seats it; `lo_x` is unseated lore. Measured over the query's own PRE-filter top-K,
+// so both are still in it — filterEntityPool removes the floor rows afterwards, which
+// is why a ratio taken after filtering reads 0 for every query by construction.
+describe('runRetrieval — per-Q4 redundancy', () => {
+  const SEATED = entityRow('char_a', 'Kara Vex')
+  const UNSEATED = loreRow('lo_x', 'Marsh law')
+  const ASK = { query: { emittedQueries: ['marsh nobility'] } }
+
+  const passWith = async (fixture: Parameters<typeof makeQueryAll>[0]) =>
+    expectOk(await runRetrieval(deps({ queryAll: makeQueryAll(fixture) }), params(ASK)))
+
+  it('reports null on the three fixed slots', async () => {
+    const out = await passWith({ entities: [SEATED], knn: [hit('char_a')] })
+    expect(out.queryRedundancy.slice(0, 3)).toEqual([null, null, null])
+  })
+
+  it('scores 1.0 when the floor had already seated the whole top-K', async () => {
+    const out = await passWith({ entities: [SEATED], knn: [hit('char_a')] })
+    expect(out.queryRedundancy[3]).toEqual({ ratio: 1, k: 1 })
+  })
+
+  it('scores 0 when the floor seated none of the top-K', async () => {
+    const out = await passWith({ entities: [SEATED], lore: [UNSEATED], knn: [hit('lo_x')] })
+    expect(out.queryRedundancy[3]).toEqual({ ratio: 0, k: 1 })
+  })
+
+  // Chapters and happenings can never be in floor.seatedIds (pools.ts →
+  // buildStructuralFloor seats entity, lore and thread ids only), so counting their
+  // top-K in the denominator would deflate every ratio by construction. makeQueryAll
+  // answers every kind's KNN from one list, so proving the exclusion needs a
+  // kind-aware arm: chapters return an id NO other kind returns, which moves k from
+  // 2 to 3 the moment they are counted.
+  it('measures over the entity, lore and thread top-Ks only', async () => {
+    const base = makeQueryAll({ entities: [SEATED], lore: [UNSEATED] })
+    const queryAll = vi.fn(async (sql: string, p: unknown[]) => {
+      if (!sql.includes('MATCH')) return base(sql, p)
+      if (sql.includes('entities_vec_')) return [hit('char_a')]
+      if (sql.includes('lore_vec_')) return [hit('lo_x')]
+      if (sql.includes('chapter_summaries_vec_')) return [hit('ch_only')]
+      return []
+    })
+    const out = expectOk(await runRetrieval(deps({ queryAll }), params(ASK)))
+    expect(out.queryRedundancy[3]).toEqual({ ratio: 0.5, k: 2 })
+  })
+
+  // A cold start: no dim family exists, so runKnn returns null and the query has no
+  // top-K to measure. 0/0 is not 0 — an unmeasurable query must not read as a
+  // perfectly novel one.
+  it('reports null for a Q4 whose top-K came back empty', async () => {
+    const out = await passWith({ entities: [SEATED], vecTables: [] })
+    expect(out.queryRedundancy[3]).toBeNull()
   })
 })
 

--- a/lib/retrieval/run.ts
+++ b/lib/retrieval/run.ts
@@ -138,9 +138,12 @@ export type InjectedAwareness = { id: string; retrievalCount: number }
 
 /**
  * retrieval.md → Redundancy. `ratio` is |topK ∩ floor.seatedIds| / |topK| for one
- * emitted Q4; `k` is that top-K's size. `k` is captured because KNN_K is per kind —
- * below 200 rows per kind the top-K IS the whole corpus, so every query reports the
- * same ratio and nothing else in the capture disproves it.
+ * emitted Q4, where topK is that query's KNN cut UNIONED over the three kinds
+ * floor.seatedIds can hold (entity, lore, thread). `k` is not derivable from
+ * KNN_K: three per-kind cuts put its ceiling at 3 × KNN_K, and any kind holding
+ * fewer than KNN_K rows returns its whole corpus to every query alike — so at
+ * small `k` the ratio describes the corpus, not the query, and nothing else in
+ * the capture says so.
  */
 export type QueryRedundancy = { ratio: number; k: number }
 
@@ -376,9 +379,9 @@ async function runRetrievalPass(
   let knnMs = performance.now() - knnStartedAt
   for (const [kind, pool] of built) pools[TYPE_OF_KIND[kind]] = pool.candidates
 
-  // Taken here, before the pool filters below remove the floor rows: after them the
-  // intersection is empty by construction and every query would report 0
-  // (retrieval.md → Redundancy).
+  // Off perQueryIds — runKnn's raw rows — not off pool.candidates: assembleCandidates has
+  // already run filterEntityPool/LorePool/ThreadPool over those, so a ratio taken there
+  // intersects an empty set and reports 0 for every query (retrieval.md → Redundancy).
   const topKByQuery = queries.specs.map(() => new Set<string>())
   for (const [kind, pool] of built) {
     if (!FLOOR_SEATABLE_KINDS.has(kind)) continue

--- a/lib/retrieval/run.ts
+++ b/lib/retrieval/run.ts
@@ -137,6 +137,14 @@ export type RetrievalFailure = {
 export type InjectedAwareness = { id: string; retrievalCount: number }
 
 /**
+ * retrieval.md → Redundancy. `ratio` is |topK ∩ floor.seatedIds| / |topK| for one
+ * emitted Q4; `k` is that top-K's size. `k` is captured because KNN_K is per kind —
+ * below 200 rows per kind the top-K IS the whole corpus, so every query reports the
+ * same ratio and nothing else in the capture disproves it.
+ */
+export type QueryRedundancy = { ratio: number; k: number }
+
+/**
  * Whatever the pass reached before it failed. The probe captures failed passes
  * too (probe.md → Failed captures) and a capture with no queries is evidence of
  * nothing; a sync-stage failure genuinely reached none of it, hence the nulls.
@@ -150,6 +158,9 @@ export type RetrievalPartial = {
    * under `mode='boost'`, and on a pass that failed before ranking started.
    */
   keywordInjections: readonly KeywordInjection[]
+  /** Positionally aligned with `queries.specs`; null on a fixed slot and on an
+   *  empty top-K. Empty on a pass that failed before KNN. */
+  queryRedundancy: readonly (QueryRedundancy | null)[]
 }
 
 export type RetrievalOutcome =
@@ -163,6 +174,9 @@ export type RetrievalOutcome =
        * Empty under `keywordRetrieval.mode='boost'`.
        */
       keywordInjections: readonly KeywordInjection[]
+      /** Positionally aligned with `queries.specs`; null on a fixed slot and on an
+       *  empty top-K. */
+      queryRedundancy: readonly (QueryRedundancy | null)[]
       /**
        * A tripwire, not a report. The sync stage is blocking and clears the flag
        * on every row it embeds, so each count here is structurally 0 — a
@@ -217,6 +231,11 @@ async function loadExistingVecTables(
   return new Set(rows.map((row) => String(row[0])))
 }
 
+// The only kinds floor.seatedIds can hold (pools.ts → buildStructuralFloor). Counting
+// a chapter or happening top-K in the denominator would deflate every ratio by
+// construction, since neither can ever intersect the floor.
+const FLOOR_SEATABLE_KINDS = new Set<VecTargetKind>(['entity', 'lore', 'thread'])
+
 export async function runRetrieval(
   deps: RetrievalDeps,
   params: RetrievalParams,
@@ -228,6 +247,7 @@ export async function runRetrieval(
     floor: null,
     bundles: {},
     keywordInjections: [],
+    queryRedundancy: [],
   }
   try {
     return await runRetrievalPass(deps, params, partial)
@@ -354,7 +374,29 @@ async function runRetrievalPass(
     ),
   )
   let knnMs = performance.now() - knnStartedAt
-  for (const [kind, candidates] of built) pools[TYPE_OF_KIND[kind]] = candidates
+  for (const [kind, pool] of built) pools[TYPE_OF_KIND[kind]] = pool.candidates
+
+  // Taken here, before the pool filters below remove the floor rows: after them the
+  // intersection is empty by construction and every query would report 0
+  // (retrieval.md → Redundancy).
+  const topKByQuery = queries.specs.map(() => new Set<string>())
+  for (const [kind, pool] of built) {
+    if (!FLOOR_SEATABLE_KINDS.has(kind)) continue
+    pool.perQueryIds.forEach((ids, i) => {
+      for (const id of ids) topKByQuery[i]?.add(id)
+    })
+  }
+  const queryRedundancy = queries.slots.map((slot, i) => {
+    // 'direct' is the slot every classifier_emitted query maps to
+    // (QUERY_SLOT_OF_SOURCE) — the fixed three carry no redundancy.
+    if (slot !== 'direct') return null
+    const topK = topKByQuery[i]
+    if (topK === undefined || topK.size === 0) return null
+    let matched = 0
+    for (const id of topK) if (floor.seatedIds.has(id)) matched += 1
+    return { ratio: matched / topK.size, k: topK.size }
+  })
+  partial.queryRedundancy = queryRedundancy
 
   const rankTypeInput = {
     params: RANKER_DEFAULTS,
@@ -431,6 +473,7 @@ async function runRetrievalPass(
     bundles,
     queries,
     keywordInjections: partial.keywordInjections,
+    queryRedundancy,
     staleCounts: staleCountsOf(sourceRows, happeningsStale),
     injectedAwareness: bundles.happenings.selected
       .filter(isHappeningCandidate)
@@ -559,7 +602,13 @@ async function loadAdmittedVectors(
   }
 }
 
-type KnnResult = { ids: Set<string>; vectorById: Map<string, Float32Array> }
+type KnnResult = {
+  ids: Set<string>
+  vectorById: Map<string, Float32Array>
+  /** Per query, in slot order — the pre-filter top-K the redundancy metric measures
+   *  over. `[]` for a slot that produced no vector. */
+  perQueryIds: readonly (readonly string[])[]
+}
 
 /** Null when the dim family does not exist yet — a cold start, not a fault. */
 async function runKnn(
@@ -598,17 +647,24 @@ async function runKnn(
         }),
   )
 
-  return { ids: poolIdsFromKnn(perQuery), vectorById }
+  return {
+    ids: poolIdsFromKnn(perQuery),
+    vectorById,
+    perQueryIds: perQuery.map((rows) => rows.map(([id]) => id)),
+  }
 }
+
+type BuiltPool = { candidates: Candidate[]; perQueryIds: readonly (readonly string[])[] }
 
 async function buildPool(
   deps: RetrievalDeps,
   params: RetrievalParams,
   ctx: PoolCtx,
-): Promise<Candidate[]> {
+): Promise<BuiltPool> {
   const knn = await runKnn(deps, params, ctx)
-  if (knn === null || knn.ids.size === 0) return []
-  return assembleCandidates(ctx, knn.ids, knn.vectorById)
+  if (knn === null) return { candidates: [], perQueryIds: [] }
+  const candidates = knn.ids.size === 0 ? [] : assembleCandidates(ctx, knn.ids, knn.vectorById)
+  return { candidates, perQueryIds: knn.perQueryIds }
 }
 
 /**

--- a/lib/retrieval/run.ts
+++ b/lib/retrieval/run.ts
@@ -138,11 +138,9 @@ export type RetrievalFailure = {
 export type InjectedAwareness = { id: string; retrievalCount: number }
 
 /**
- * retrieval.md → Redundancy. `ratio` is |topK ∩ floor.seatedIds| / |topK| for one
- * emitted Q4, where topK is the REDUNDANCY_K nearest rows that query wanted across
- * the kinds the floor can seat. `k` is the realised cut size, below REDUNDANCY_K
- * only on a corpus too small to fill it. Positionally aligned with
- * `queries.specs`; null on a fixed slot and on an empty top-K.
+ * retrieval.md → Redundancy: ratio = |topK ∩ floor.seatedIds| / |topK|, k the
+ * realised cut size (below REDUNDANCY_K only on a too-small corpus). Positionally
+ * aligned with `queries.specs`; null on a fixed slot and on an empty top-K.
  */
 export type QueryRedundancy = { ratio: number; k: number }
 
@@ -323,9 +321,8 @@ async function runRetrievalPass(
     activeThreadTitles: floor.activeThreads.map((t) => t.title),
   })
   partial.queries = queries
-  // Set with the stack, not with the measurement: a failure between here and KNN
-  // otherwise leaves a 4-6 spec stack beside a length-0 array, and every consumer
-  // reads the two positionally.
+  // Set with the stack, not the measurement: a failure before KNN would otherwise
+  // leave populated specs beside a length-0 array that consumers read positionally.
   partial.queryRedundancy = queries.specs.map(() => null)
 
   const embedStartedAt = performance.now()
@@ -373,12 +370,9 @@ async function runRetrievalPass(
   let knnMs = performance.now() - knnStartedAt
   for (const [kind, pool] of built) pools[TYPE_OF_KIND[kind]] = pool.candidates
 
-  // Off perQueryHits — runKnn's raw rows — not off pool.candidates: assembleCandidates has
-  // already run filterEntityPool/LorePool/ThreadPool over those, so a ratio taken there
-  // intersects an empty set and reports 0 for every query (retrieval.md → Redundancy).
-  // The cut is global across the seatable kinds rather than per kind: a per-kind cut
-  // unioned dilutes by the kinds that rarely reach the floor, and lore reaches it only
-  // through a user-marked `always`.
+  // Off perQueryHits (KNN's raw rows), not pool.candidates — assembleCandidates already
+  // filtered those, so the ratio would intersect an empty set and report 0 throughout.
+  // Cut is global across seatable kinds — per-kind dilutes by kinds that rarely reach the floor.
   const hitsByQuery: KnnHit[][] = queries.specs.map(() => [])
   for (const [kind, pool] of built) {
     if (!FLOOR_SEATABLE_KINDS.has(kind)) continue
@@ -661,9 +655,8 @@ async function buildPool(
   ctx: PoolCtx,
 ): Promise<BuiltPool> {
   const knn = await runKnn(deps, params, ctx)
-  // One empty entry per query, not one empty outer array: every other consumer reads
-  // `perQueryHits[i]` positionally, and a length-0 outer array is the sole shape where
-  // that alignment would not hold.
+  // One empty entry per query, not an empty outer array: consumers read `perQueryHits[i]`
+  // positionally, and length-0 is the only shape that breaks that alignment.
   if (knn === null) return { candidates: [], perQueryHits: ctx.queryVectors.map(() => []) }
   const candidates = knn.ids.size === 0 ? [] : assembleCandidates(ctx, knn.ids, knn.vectorById)
   return { candidates, perQueryHits: knn.perQueryHits }

--- a/lib/retrieval/run.ts
+++ b/lib/retrieval/run.ts
@@ -10,7 +10,7 @@ import { logger } from '@/lib/diagnostics'
 import { EmbedderCancelledError, type EmbedderErrorKind } from '@/lib/embedder'
 
 import { loadAwarenessForScene, type AwarenessRow } from './awareness'
-import { KNN_K, RANKER_DEFAULTS } from './constants'
+import { KNN_K, RANKER_DEFAULTS, REDUNDANCY_K } from './constants'
 import { buildKeywordInjections, type KeywordRetrievalSettings } from './injection'
 import { entityNameIndexFrom, matchTerms, normalizeTerm, type EntityNameIndex } from './name-index'
 import {
@@ -18,6 +18,7 @@ import {
   filterEntityPool,
   filterLorePool,
   filterThreadPool,
+  FLOOR_SEATABLE_KINDS,
   poolIdsFromKnn,
   type KnnHit,
   type StructuralFloor,
@@ -138,12 +139,10 @@ export type InjectedAwareness = { id: string; retrievalCount: number }
 
 /**
  * retrieval.md → Redundancy. `ratio` is |topK ∩ floor.seatedIds| / |topK| for one
- * emitted Q4, where topK is that query's KNN cut UNIONED over the three kinds
- * floor.seatedIds can hold (entity, lore, thread). `k` is not derivable from
- * KNN_K: three per-kind cuts put its ceiling at 3 × KNN_K, and any kind holding
- * fewer than KNN_K rows returns its whole corpus to every query alike — so at
- * small `k` the ratio describes the corpus, not the query, and nothing else in
- * the capture says so.
+ * emitted Q4, where topK is the REDUNDANCY_K nearest rows that query wanted across
+ * the kinds the floor can seat. `k` is the realised cut size, below REDUNDANCY_K
+ * only on a corpus too small to fill it. Positionally aligned with
+ * `queries.specs`; null on a fixed slot and on an empty top-K.
  */
 export type QueryRedundancy = { ratio: number; k: number }
 
@@ -161,8 +160,6 @@ export type RetrievalPartial = {
    * under `mode='boost'`, and on a pass that failed before ranking started.
    */
   keywordInjections: readonly KeywordInjection[]
-  /** Positionally aligned with `queries.specs`; null on a fixed slot and on an
-   *  empty top-K. Empty on a pass that failed before KNN. */
   queryRedundancy: readonly (QueryRedundancy | null)[]
 }
 
@@ -177,8 +174,6 @@ export type RetrievalOutcome =
        * Empty under `keywordRetrieval.mode='boost'`.
        */
       keywordInjections: readonly KeywordInjection[]
-      /** Positionally aligned with `queries.specs`; null on a fixed slot and on an
-       *  empty top-K. */
       queryRedundancy: readonly (QueryRedundancy | null)[]
       /**
        * A tripwire, not a report. The sync stage is blocking and clears the flag
@@ -233,11 +228,6 @@ async function loadExistingVecTables(
   )
   return new Set(rows.map((row) => String(row[0])))
 }
-
-// The only kinds floor.seatedIds can hold (pools.ts → buildStructuralFloor). Counting
-// a chapter or happening top-K in the denominator would deflate every ratio by
-// construction, since neither can ever intersect the floor.
-const FLOOR_SEATABLE_KINDS = new Set<VecTargetKind>(['entity', 'lore', 'thread'])
 
 export async function runRetrieval(
   deps: RetrievalDeps,
@@ -333,6 +323,10 @@ async function runRetrievalPass(
     activeThreadTitles: floor.activeThreads.map((t) => t.title),
   })
   partial.queries = queries
+  // Set with the stack, not with the measurement: a failure between here and KNN
+  // otherwise leaves a 4-6 spec stack beside a length-0 array, and every consumer
+  // reads the two positionally.
+  partial.queryRedundancy = queries.specs.map(() => null)
 
   const embedStartedAt = performance.now()
   const embed = await embedQueries(deps, params, queries.embedTexts)
@@ -379,25 +373,27 @@ async function runRetrievalPass(
   let knnMs = performance.now() - knnStartedAt
   for (const [kind, pool] of built) pools[TYPE_OF_KIND[kind]] = pool.candidates
 
-  // Off perQueryIds — runKnn's raw rows — not off pool.candidates: assembleCandidates has
+  // Off perQueryHits — runKnn's raw rows — not off pool.candidates: assembleCandidates has
   // already run filterEntityPool/LorePool/ThreadPool over those, so a ratio taken there
   // intersects an empty set and reports 0 for every query (retrieval.md → Redundancy).
-  const topKByQuery = queries.specs.map(() => new Set<string>())
+  // The cut is global across the seatable kinds rather than per kind: a per-kind cut
+  // unioned dilutes by the kinds that rarely reach the floor, and lore reaches it only
+  // through a user-marked `always`.
+  const hitsByQuery: KnnHit[][] = queries.specs.map(() => [])
   for (const [kind, pool] of built) {
     if (!FLOOR_SEATABLE_KINDS.has(kind)) continue
-    pool.perQueryIds.forEach((ids, i) => {
-      for (const id of ids) topKByQuery[i]?.add(id)
-    })
+    pool.perQueryHits.forEach((hits, i) => hitsByQuery[i]?.push(...hits))
   }
   const queryRedundancy = queries.slots.map((slot, i) => {
     // 'direct' is the slot every classifier_emitted query maps to
     // (QUERY_SLOT_OF_SOURCE) — the fixed three carry no redundancy.
     if (slot !== 'direct') return null
-    const topK = topKByQuery[i]
-    if (topK === undefined || topK.size === 0) return null
+    const hits = hitsByQuery[i]
+    if (hits === undefined || hits.length === 0) return null
+    const topK = [...hits].sort((a, b) => a[1] - b[1]).slice(0, REDUNDANCY_K)
     let matched = 0
-    for (const id of topK) if (floor.seatedIds.has(id)) matched += 1
-    return { ratio: matched / topK.size, k: topK.size }
+    for (const [id] of topK) if (floor.seatedIds.has(id)) matched += 1
+    return { ratio: matched / topK.length, k: topK.length }
   })
   partial.queryRedundancy = queryRedundancy
 
@@ -608,9 +604,9 @@ async function loadAdmittedVectors(
 type KnnResult = {
   ids: Set<string>
   vectorById: Map<string, Float32Array>
-  /** Per query, in slot order — the pre-filter top-K the redundancy metric measures
-   *  over. `[]` for a slot that produced no vector. */
-  perQueryIds: readonly (readonly string[])[]
+  /** Per query, in slot order — the pre-filter matches the redundancy metric cuts
+   *  into its top-K. `[]` for a slot that produced no vector. */
+  perQueryHits: readonly (readonly KnnHit[])[]
 }
 
 /** Null when the dim family does not exist yet — a cold start, not a fault. */
@@ -653,11 +649,11 @@ async function runKnn(
   return {
     ids: poolIdsFromKnn(perQuery),
     vectorById,
-    perQueryIds: perQuery.map((rows) => rows.map(([id]) => id)),
+    perQueryHits: perQuery,
   }
 }
 
-type BuiltPool = { candidates: Candidate[]; perQueryIds: readonly (readonly string[])[] }
+type BuiltPool = { candidates: Candidate[]; perQueryHits: readonly (readonly KnnHit[])[] }
 
 async function buildPool(
   deps: RetrievalDeps,
@@ -665,9 +661,12 @@ async function buildPool(
   ctx: PoolCtx,
 ): Promise<BuiltPool> {
   const knn = await runKnn(deps, params, ctx)
-  if (knn === null) return { candidates: [], perQueryIds: [] }
+  // One empty entry per query, not one empty outer array: every other consumer reads
+  // `perQueryHits[i]` positionally, and a length-0 outer array is the sole shape where
+  // that alignment would not hold.
+  if (knn === null) return { candidates: [], perQueryHits: ctx.queryVectors.map(() => []) }
   const candidates = knn.ids.size === 0 ? [] : assembleCandidates(ctx, knn.ids, knn.vectorById)
-  return { candidates, perQueryIds: knn.perQueryIds }
+  return { candidates, perQueryHits: knn.perQueryHits }
 }
 
 /**

--- a/locales/en/reader.json
+++ b/locales/en/reader.json
@@ -74,6 +74,7 @@
     "stateChanges": "Changes this turn",
     "stateDelta": "Reported delta",
     "stateSummary": "Summary",
+    "stateRetrievalAsks": "Retrieval asks",
     "stateDeltaSeconds": "{{n}}s",
     "stateDeltaClamped": "(clamped to {{n}}s)",
     "stateLocationRejected": "(emitted id was not a location — previous kept)",


### PR DESCRIPTION
**PR 2 of the query-stack stack. Stacked on #490 — review that first.**

PR 1 landed the whole consumption side: `buildQueryStack` already accepted an `emittedQueries` input and capped, deduped and filtered it. Nothing produced that input, so `w_direct` has been a dead weight since it shipped. This sources it, and adds the one thing PR 1 could not — a per-Q4 redundancy metric computed from the per-query KNN top-K that pool assembly was discarding.

## Summary

- **Both per-turn implementations carry the field.** The tagged block gains `<retrieval_queries>`, and so does the fallback classifier's structured-output schema. Canon requires both, and `piggybackMode` defaults to `'off'` — so the fallback is what a default-configured story actually runs. This half was missing from the original plan and was found in review.
- **Redundancy** is `|topK ∩ floor.seatedIds| / |topK|` per emitted Q4, measured over the `REDUNDANCY_K = 10` nearest rows merged globally across entity/lore/thread, taken off `runKnn`'s raw rows rather than the filtered pool. Stored at capture version 7 alongside `redundancy_k`. Observability only — nothing drops a query on it.
- **The reader's world-state panel** gains a *Retrieval asks* row.
- **The cost budget is re-measured.** `bench/fixture.ts` put all three query vectors on centroid 0 (`t` was never read), so their top-200 sets largely coincided and every published figure was optimistic.

## Decisions worth carrying forward

- **The cut is 10 nearest, merged globally — not the full KNN pass.** As originally specified, `k` ran to ~600 against a ~12-id floor, bounding the ratio at ~0.02: canon's "near 1.0" was unreachable and the probe's warn threshold could never fire. Per-kind-then-union was rejected as the same dilution 20× smaller. Cross-kind distance comparability is verified, not assumed — every vector is unit-norm, so L2 order is cosine order.
- **The Q4-saturated pass at dim 768 measures ~319ms against canon's ~250ms ceiling.** Recorded in `retrieval.md` and filed in `triage.md`; the three options (move the ceiling, tighten the cap, drop dim 768 as a desktop default) are unresolved. dim 384 at the same scale is ~182ms.
- **`w_direct` becomes real on merge.** The live effective blend moves from action 0.40 / digest 0.33 / summary 0.27 to the nominal 0.30 / 0.25 / 0.20 / 0.25. Ranking will shift — that is the calibration moment, not a regression.
- **The `<retrieval_queries>` parser is total by contract** — the only parser in `lib/piggyback` that never raises. A field-level failure fires a full extra structured call, and spending one to recover an optional retrieval hint inverts the cost of the recovery it triggers. Canon states this twice on purpose; please don't "fix" the inconsistency.

## Test plan

- [x] `pnpm typecheck`, `pnpm lint`, `pnpm lint:docs` — clean
- [x] `pnpm test:run` — 444 files / 4719 tests
- [x] `pnpm test:e2e -- e2e/tests/retrieval-q4.spec.ts` — two-turn seam, 13 clean runs
- [x] `pnpm bench:retrieval` — 24 cases, re-measured on a quiet machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The app can now identify up to three context items to retrieve on the next turn.
  * Retrieval asks are saved with story entries and used in subsequent retrieval.
  * Entry state details display retrieval asks when available.
  * Diagnostics now include per-query retrieval redundancy metrics.

* **Bug Fixes**
  * Improved handling and validation of retrieval-query data, including duplicate, blank, malformed, and outdated diagnostic data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->