### PR TITLE
feat: fallback parity — give the classifier the context Q4 needs (3/3)

### DIFF
--- a/components/story-settings/memory-panel.stories.tsx
+++ b/components/story-settings/memory-panel.stories.tsx
@@ -28,6 +28,7 @@ const GEMMA = 'onnx-community/embeddinggemma-300m-ONNX'
 function buildSettings(overrides: Partial<StorySettings> = {}): StorySettings {
   return storySettingsSchema.parse({
     classifierCadence: 4,
+    classifierContextEntries: 4,
     piggybackMode: 'on',
     embeddingBackend: 'local',
     embedding_model_id: MINILM,

--- a/docs/implementation/roadmap.md
+++ b/docs/implementation/roadmap.md
@@ -857,6 +857,20 @@ moved; resolve with the slice it names.
   designed, and an M7.5 simulator that wants to re-run a whole captured
   pass at once will need `RankAllInput` widened. Surfaced by the Slice
   3.5 Task 2 review (2026-08-08).
+- **M7.5 — The query panel has no rendering rule for a redundancy value
+  outside its own range.** `assertCaptureShape` proves `redundancy` and
+  `redundancy_k` finite-or-null and no further, deliberately: the module is
+  structural, and a capture it refuses is also one the list cannot delete.
+  That leaves the panel to meet a ratio above 1, a zero or fractional
+  `redundancy_k`, or a `redundancy_k` sitting beside a null `redundancy`.
+  None of these can crash it — `redundancy_k` is a display denominator, not
+  an index — but each renders a nonsense line such as "12 of 0 top-K already
+  seated", under a ⚠ lit for the wrong reason. Decide it alongside the warn
+  threshold that
+  [`memory-probe.md → Queries tab`](../ui/screens/memory-probe/memory-probe.md#queries-tab)
+  also leaves unset; the likely answer is to render the raw value and mark it
+  out of range, since a producer bug is precisely what the screen exists to
+  expose. Surfaced by the query-stack Q4 review (2026-09-08).
 - **M7.3 — A non-embedder retrieval fault writes no capture, which is the
   case the probe most wants.** `runRetrieval` converts only
   `VectorInvariantError` into a captured failure and rethrows

--- a/docs/implementation/triage.md
+++ b/docs/implementation/triage.md
@@ -120,16 +120,16 @@ true` (`lib/embedder/local/runtime.native.ts`) at a length nobody
   pattern). Unowned: it guards the schema layer on behalf of every
   future slice, not any one of them.
 
-- **Four hand-rolled copies of the same settings-hardening guard.**
-  `Number.isFinite(v) ? Math.max(floor, Math.floor(v)) : floor` appears
-  in `lib/retrieval/buffer.ts` (`toCount`), `scan-surface.ts` (`toTake`),
-  `injection.ts` (`toDepth`) and now `lib/pipeline/definitions/
-entry-reads.ts`. Each guards a `stories.settings` number that reaches a
-  read site without having gone through `storySettingsSchema` — a real
-  and recurring need, since the schema deliberately avoids `.int()` so a
-  hand-edited blob degrades instead of refusing to open the story. A
-  shared helper is the obvious move; what stops it being mechanical is
-  that each caller's floor and units differ, and two live in `lib/
-retrieval` while the fourth does not, so the helper has no obvious
-  home under the `lib/*` public-API rule. Unowned: it is a cross-module
-  utility question, not any one slice's work.
+- **Four hand-rolled copies of the same settings-hardening guard.** The
+  shape `Number.isFinite(v) ? Math.max(floor, Math.floor(v)) : floor`
+  appears in `buffer.ts` (`toCount`), `scan-surface.ts` (`toTake`) and
+  `injection.ts` (`toDepth`), all under `lib/retrieval`, and now in
+  `entry-reads.ts` under `lib/pipeline/definitions`. Each guards a
+  `stories.settings` number that reaches a read site without having gone
+  through `storySettingsSchema` — a real and recurring need, since the
+  schema deliberately avoids `.int()` so a hand-edited blob degrades
+  instead of refusing to open the story. A shared helper is the obvious
+  move; what stops it being mechanical is that each caller's floor and
+  units differ, and three live in one module while the fourth does not,
+  so the helper has no obvious home under the `lib/*` public-API rule.
+  Unowned: a cross-module utility question, not any one slice's work.

--- a/docs/implementation/triage.md
+++ b/docs/implementation/triage.md
@@ -119,3 +119,17 @@ true` (`lib/embedder/local/runtime.native.ts`) at a length nobody
   are legitimately required-and-unmigrated because they predate the
   pattern). Unowned: it guards the schema layer on behalf of every
   future slice, not any one of them.
+
+- **Four hand-rolled copies of the same settings-hardening guard.**
+  `Number.isFinite(v) ? Math.max(floor, Math.floor(v)) : floor` appears
+  in `lib/retrieval/buffer.ts` (`toCount`), `scan-surface.ts` (`toTake`),
+  `injection.ts` (`toDepth`) and now `lib/pipeline/definitions/
+entry-reads.ts`. Each guards a `stories.settings` number that reaches a
+  read site without having gone through `storySettingsSchema` — a real
+  and recurring need, since the schema deliberately avoids `.int()` so a
+  hand-edited blob degrades instead of refusing to open the story. A
+  shared helper is the obvious move; what stops it being mechanical is
+  that each caller's floor and units differ, and two live in `lib/
+retrieval` while the fourth does not, so the helper has no obvious
+  home under the `lib/*` public-API rule. Unowned: it is a cross-module
+  utility question, not any one slice's work.

--- a/docs/implementation/triage.md
+++ b/docs/implementation/triage.md
@@ -89,3 +89,18 @@ slice-planning gate forces its resolution before that slice is planned.
   projected cost once this branch measured it — but that left the
   decision living only as canon prose, with no queue entry to route it
   to an owner.
+
+- **Q1 and Q2 carry no length cap, and Q1 is the slot a user can blow
+  up on purpose.**
+  [`retrieval.md → Q3`](../memory/retrieval.md#q3-piggyback-summary) and
+  [`Q4`](../memory/retrieval.md#q4-classifier-emitted-queries) now share
+  one 200-char cap, applied at query build. Q1 is `userAction` trimmed
+  and nothing more, with no length limit on the composer that produces
+  it; Q2's structural digest grows with scene-entity and thread count.
+  Both are therefore still cut by the local tokenizer's `truncation:
+true` (`lib/embedder/local/runtime.native.ts`) at a length nobody
+  chose — the same silent limit the Q3 cap was added to replace. Q1 is
+  the highest-weighted slot, so a pasted wall of text degrades the turn
+  it was meant to steer. Unowned: capping user input is a composer
+  decision, capping the digest is a retrieval one, and neither has a
+  slice.

--- a/docs/implementation/triage.md
+++ b/docs/implementation/triage.md
@@ -133,3 +133,16 @@ true` (`lib/embedder/local/runtime.native.ts`) at a length nobody
   units differ, and three live in one module while the fourth does not,
   so the helper has no obvious home under the `lib/*` public-API rule.
   Unowned: a cross-module utility question, not any one slice's work.
+
+- **No bundled template exercises the scene-read gate's false branch.**
+  `buildGenerationContext` skips the scene query when a template names
+  none of `SCENE_VARIABLES`, and that gate is what keeps a prompt from
+  paying for reads it never renders. As of the fallback-parity work all
+  three bundled `generationContext` templates name `sceneEntities`, so
+  nothing covers the skip. It is not dead code — a user-authored pack
+  template can name no scene variable — but the only honest test needs a
+  registered template that production does not ship, so covering it
+  means deciding whether a test-only template belongs in the registry.
+  The sibling gates for `entries` and `lastTurns` are still covered.
+  Unowned: it guards the context builder on behalf of custom packs, not
+  any one slice.

--- a/docs/implementation/triage.md
+++ b/docs/implementation/triage.md
@@ -104,3 +104,18 @@ true` (`lib/embedder/local/runtime.native.ts`) at a length nobody
   it was meant to steer. Unowned: capping user input is a composer
   decision, capping the digest is a retrieval one, and neither has a
   slice.
+
+- **Nothing links a new required settings key to its backfill
+  migration.** Settings writes are key-scoped `json_set`
+  (`lib/db/stories/settings-ops.ts`), so a key added to
+  `storySettingsSchema` without a `.default()` needs a migration or every
+  upgraded story fails `storySettingsSchema.parse` and will not open.
+  Migrations 0007, 0011 and 0013 all follow the pattern by hand, and
+  nothing enforces it — `story-config-schema.test.ts` counts the
+  _defaulted_ keys, which is the opposite half. A guard test walking
+  `storySettingsSchema.shape` for keys with no `ZodDefault` wrapper and
+  diffing them against a checked-in allowlist would close it in ~15
+  lines, but choosing that allowlist is a real decision (several keys
+  are legitimately required-and-unmigrated because they predate the
+  pattern). Unowned: it guards the schema layer on behalf of every
+  future slice, not any one of them.

--- a/docs/memory/piggyback.md
+++ b/docs/memory/piggyback.md
@@ -289,8 +289,8 @@ in `sceneEntities` that neither set contains. The two contexts are not
 symmetric in both directions.
 
 **Marking the extraction target is mandatory, not stylistic.**
-`lastTurns` is a fixed pair — the last two non-system entries, bounded
-so neither the buffer knobs nor a template can narrow them, because the
+`lastTurns` has a fixed floor — the last two non-system entries — that
+neither the buffer knobs nor a template can narrow below, because the
 user's action can itself carry state changes ("I put the sword away").
 Extraction targets the last of that pair. Everything else in the prompt
 is background and must be marked as such — including the memory blocks,

--- a/docs/memory/retrieval.md
+++ b/docs/memory/retrieval.md
@@ -781,6 +781,15 @@ reliability difference visible to the blend.
 Absent on parse failure or restart is fine — presence is derived, and
 the blend re-normalizes.
 
+**Capped at 200 characters, the same cap and the same constant as
+[Q4](#q4-classifier-emitted-queries).** Applied at query build, not at parse or
+persist: `metadata.summary` is a reader surface and reaches templates as
+`sceneMetadata.summary`, so truncating it there would cut what the user reads.
+One sentence is the instruction; the cap is what stops a model that writes a
+paragraph from getting a paragraph averaged into one vector. It binds on a long
+compound sentence as well as on a runaway one — a deliberate trade for a single
+shared constant over two that could drift.
+
 ### Q4: Classifier-emitted queries
 
 Up to **three** query strings the per-turn classifier emits directly,

--- a/docs/memory/retrieval.md
+++ b/docs/memory/retrieval.md
@@ -766,6 +766,15 @@ piggyback did not fire or its block failed to parse — so it is
 available in either mode
 ([`piggyback.md → Capability gate`](./piggyback.md#capability-gate)).
 
+**Capped at 200 characters, the same cap and the same constant as
+[Q4](#q4-classifier-emitted-queries).** Applied at query build, not at parse or
+persist: `metadata.summary` is a reader surface and reaches templates as
+`sceneMetadata.summary`, so truncating it there would cut what the user reads.
+One sentence is the instruction; the cap is what stops a model that writes a
+paragraph from getting a paragraph averaged into one vector. It binds on a long
+compound sentence as well as on a runaway one — a deliberate trade for a single
+shared constant over two that could drift.
+
 **Why it is not part of Q2.** It used to be the digest's last line, one
 natural-language sentence averaged into a single vector with a
 comma-separated proper-noun list. The two carry different shapes and
@@ -780,15 +789,6 @@ reliability difference visible to the blend.
 
 Absent on parse failure or restart is fine — presence is derived, and
 the blend re-normalizes.
-
-**Capped at 200 characters, the same cap and the same constant as
-[Q4](#q4-classifier-emitted-queries).** Applied at query build, not at parse or
-persist: `metadata.summary` is a reader surface and reaches templates as
-`sceneMetadata.summary`, so truncating it there would cut what the user reads.
-One sentence is the instruction; the cap is what stops a model that writes a
-paragraph from getting a paragraph averaged into one vector. It binds on a long
-compound sentence as well as on a runaway one — a deliberate trade for a single
-shared constant over two that could drift.
 
 ### Q4: Classifier-emitted queries
 

--- a/docs/memory/retrieval.md
+++ b/docs/memory/retrieval.md
@@ -829,7 +829,9 @@ Three degenerate emissions are closed before embedding: identical
 strings are deduplicated (three copies would split the pooled weight
 evenly and cost triple the KNN for one signal), empty strings are
 filtered, and an oversized string is capped at 200 characters rather
-than left to the [truncation contract](#truncation-contract).
+than left to the [truncation contract](#truncation-contract) — the same
+constant as [Q3](#q3-piggyback-summary), which is the slot that shares
+it.
 
 **Storage.** `story_entries.metadata.retrievalQueries`, capped at
 three, excluded from `stateReport`, and **not inherited** — a query

--- a/e2e/harness/db.ts
+++ b/e2e/harness/db.ts
@@ -1,6 +1,9 @@
 import { DatabaseSync } from 'node:sqlite'
 
 import type { Page } from '@playwright/test'
+import { gunzipSync } from 'fflate'
+
+import type { EntryMetadata, ProbeCapturePayload } from '@/lib/db'
 
 // Query the running app's own DB connection through the preload bridge
 // (window.aventurasDb). The faithful way to assert an in-app write: it reads
@@ -37,6 +40,38 @@ const BRANCH_STALE_TOTAL_SQL = `SELECT (SELECT count(*) FROM entities WHERE bran
 export async function branchStaleTotal(page: Page, branchId: string): Promise<number> {
   const [[total]] = await queryApp(page, BRANCH_STALE_TOTAL_SQL, Array<string>(5).fill(branchId))
   return Number(total)
+}
+
+export async function currentBranchId(page: Page, storyId: string): Promise<string> {
+  const rows = await queryApp(page, `SELECT current_branch_id FROM stories WHERE id = ?`, [storyId])
+  return rows[0]?.[0] as string
+}
+
+const TAIL_METADATA_SQL = `SELECT metadata FROM story_entries WHERE branch_id = ? AND kind = 'ai_reply'
+   ORDER BY position DESC LIMIT 1`
+
+// queryApp is a raw SQL bridge, not drizzle's typed select, so the column's
+// `mode: 'json'` transform never runs — parse it here instead.
+export async function tailMetadata(page: Page, branchId: string): Promise<EntryMetadata | null> {
+  const rows = await queryApp(page, TAIL_METADATA_SQL, [branchId])
+  const raw = rows[0]?.[0] as string | null | undefined
+  return raw ? (JSON.parse(raw) as EntryMetadata) : null
+}
+
+const LATEST_CAPTURE_SQL = `SELECT payload FROM probe_captures
+   WHERE branch_id = ? ORDER BY captured_at DESC, id DESC LIMIT 1`
+
+// Payload is a gzipped blob; queryApp's evaluate bridge returns the BLOB column as a real
+// Uint8Array (Playwright has serialized typed arrays since 1.44), so it gunzips directly.
+export async function latestCapture(
+  page: Page,
+  branchId: string,
+): Promise<ProbeCapturePayload | null> {
+  const rows = await queryApp(page, LATEST_CAPTURE_SQL, [branchId])
+  const blob = rows[0]?.[0] as Uint8Array | undefined
+  if (blob === undefined) return null
+  const json = new TextDecoder().decode(gunzipSync(blob))
+  return JSON.parse(json) as ProbeCapturePayload
 }
 
 // Read-only assertion handle over the fixture DB file. E2E drives the app

--- a/e2e/harness/seed.ts
+++ b/e2e/harness/seed.ts
@@ -213,10 +213,8 @@ export function setClassifierCadence(dbPath: string, storyId: string, cadence: n
   }
 }
 
-// Set a story's piggybackMode. The fixture seeds 'on'; 'off' is what
-// story-settings-defaults.ts gives a real story, and the only gate that turns
-// the fold off without also lying about the model's capabilities (unlike
-// disablePiggybackCapability). Runs before launch.
+// The fixture seeds 'on'; 'off' is what story-settings-defaults.ts gives a real story — and
+// unlike disablePiggybackCapability it doesn't lie about the model. Runs before launch.
 export function setPiggybackMode(dbPath: string, storyId: string, mode: 'on' | 'off'): void {
   const db = new DatabaseSync(dbPath)
   try {

--- a/e2e/harness/seed.ts
+++ b/e2e/harness/seed.ts
@@ -213,6 +213,27 @@ export function setClassifierCadence(dbPath: string, storyId: string, cadence: n
   }
 }
 
+// Set a story's piggybackMode. The fixture seeds 'on'; 'off' is what
+// story-settings-defaults.ts gives a real story, and the only gate that turns
+// the fold off without also lying about the model's capabilities (unlike
+// disablePiggybackCapability). Runs before launch.
+export function setPiggybackMode(dbPath: string, storyId: string, mode: 'on' | 'off'): void {
+  const db = new DatabaseSync(dbPath)
+  try {
+    const row = db.prepare(`SELECT settings FROM stories WHERE id = ?`).get(storyId) as {
+      settings: string
+    }
+    const settings = JSON.parse(row.settings) as Record<string, unknown>
+    settings.piggybackMode = mode
+    db.prepare(`UPDATE stories SET settings = ? WHERE id = ?`).run(
+      JSON.stringify(settings),
+      storyId,
+    )
+  } finally {
+    db.close()
+  }
+}
+
 // Arm the story half of the probe's two gates (the app half is enableDiagnostics).
 // Both must be on before a turn writes a capture. Runs before launch.
 export function enableStoryProbeMode(dbPath: string, storyId: string): void {

--- a/e2e/tests/retrieval-q4-fallback.spec.ts
+++ b/e2e/tests/retrieval-q4-fallback.spec.ts
@@ -1,0 +1,187 @@
+import { expect, test, type Page } from '@playwright/test'
+import { gunzipSync } from 'fflate'
+
+import type { EntryMetadata, ProbeCapturePayload } from '@/lib/db'
+
+import { queryApp } from '../harness/db'
+import { installEmbedderModel } from '../harness/embedder'
+import { launchApp, type LaunchedApp } from '../harness/launch'
+import { startMockLlm, type MockLlm } from '../harness/mock-llm'
+import {
+  createSeededUserDataDir,
+  enableDiagnostics,
+  enableStoryProbeMode,
+  removeUserDataDir,
+  setPiggybackMode,
+  setProviderEndpoint,
+} from '../harness/seed'
+import { home } from '../locators/home'
+import { reader } from '../locators/reader'
+
+// Q4 on the FALLBACK path (docs/memory/retrieval.md#q4-classifier-emitted-queries), the
+// one a default-configured story runs: piggybackMode defaults to 'off', so the asks come
+// from the fallback classifier's own structured call — generateStructured →
+// substitutePiggybackIds → buildPiggybackActions → metadata — not from a tagged <state>
+// block folded out of the narrative. retrieval-q4.spec.ts covers the fold; this covers the
+// seam it cannot reach.
+
+const HERO_TITLE = 'The Veilstone Courier'
+const HERO_STORY_ID = 'story_hero'
+
+const ASK_A = 'E2E-Q4F-ASK House Eldrin sigil provenance'
+const ASK_B = 'E2E-Q4F-ASK marsh territory exile customs'
+const ASK_C = 'E2E-Q4F-ASK ferry schedules along the reed channels'
+const ASK_D = 'E2E-Q4F-ASK who last carried the courier seal'
+
+// No <state> block anywhere in the prose: with the fold off nothing else can write these
+// fields, so a value in metadata came from the fallback's structured call or from nowhere.
+const narrative = (marker: string) => `${marker} The storm bends the reeds flat.`
+
+// The seeded story has suggestion categories enabled and the fold is off, so no chips are
+// in hand when the phase runs — it takes the `-suggestions` schema branch. Both shapes are
+// set anyway: which one fires is a property of the fixture's settings, not of Q4.
+function setAsks(mock: MockLlm, askOne: string, askTwo: string): void {
+  const reply = {
+    sceneEntities: [],
+    worldTimeDelta: 0,
+    summary: 'The courier crossed the marsh under storm light.',
+    retrievalQueries: [askOne, askTwo],
+  }
+  mock.setStructured('per-turn-classifier', reply)
+  mock.setStructured('per-turn-classifier-suggestions', { ...reply, suggestions: [] })
+}
+
+async function currentBranchId(page: Page): Promise<string> {
+  const rows = await queryApp(page, `SELECT current_branch_id FROM stories WHERE id = ?`, [
+    HERO_STORY_ID,
+  ])
+  return rows[0]?.[0] as string
+}
+
+// queryApp is a raw SQL bridge, not drizzle's typed select, so the column's
+// `mode: 'json'` transform never runs — parse it here instead.
+async function tailMetadata(page: Page, branchId: string): Promise<EntryMetadata | null> {
+  const rows = await queryApp(
+    page,
+    `SELECT metadata FROM story_entries WHERE branch_id = ? AND kind = 'ai_reply'
+     ORDER BY position DESC LIMIT 1`,
+    [branchId],
+  )
+  const raw = rows[0]?.[0] as string | null | undefined
+  return raw ? (JSON.parse(raw) as EntryMetadata) : null
+}
+
+const LATEST_CAPTURE_SQL = `SELECT payload FROM probe_captures
+   WHERE branch_id = ? ORDER BY captured_at DESC, id DESC LIMIT 1`
+
+// Payload is a gzipped blob; queryApp's evaluate bridge returns the BLOB column as a real
+// Uint8Array (Playwright has serialized typed arrays since 1.44), so it gunzips directly.
+async function latestCapture(page: Page, branchId: string): Promise<ProbeCapturePayload | null> {
+  const rows = await queryApp(page, LATEST_CAPTURE_SQL, [branchId])
+  const blob = rows[0]?.[0] as Uint8Array | undefined
+  if (blob === undefined) return null
+  const json = new TextDecoder().decode(gunzipSync(blob))
+  return JSON.parse(json) as ProbeCapturePayload
+}
+
+test.describe('retrieval Q4 — fallback classifier across a turn boundary', () => {
+  let app: LaunchedApp
+  let mock: MockLlm
+  let userDataDir: string | undefined
+
+  test.beforeAll(async () => {
+    // Embed failure blocks the reply (model-management.md → Embed failure is blocking); cold
+    // cache pulls ~24 MB from Hugging Face before launch, hence the long timeout.
+    test.setTimeout(180_000)
+    const seeded = createSeededUserDataDir()
+    userDataDir = seeded.userDataDir
+    await installEmbedderModel(userDataDir)
+    mock = await startMockLlm()
+    mock.setNarrative(narrative('E2E-Q4F-TURN'))
+    setAsks(mock, ASK_A, ASK_B)
+    setProviderEndpoint(seeded.dbPath, mock.url)
+    // The whole point of this spec: the fixture seeds 'on', a real story defaults to 'off'.
+    setPiggybackMode(seeded.dbPath, HERO_STORY_ID, 'off')
+    // Both probe gates: app half (diagnostics) and story half (probe_mode_active).
+    enableDiagnostics(seeded.dbPath)
+    enableStoryProbeMode(seeded.dbPath, HERO_STORY_ID)
+    app = await launchApp({ userDataDir, cleanupUserData: true })
+  })
+
+  test.afterAll(async () => {
+    await app?.close()
+    await mock?.close()
+    removeUserDataDir(userDataDir)
+  })
+
+  test('the fallback classifier emits Q4 and the next turn embeds it', async () => {
+    test.setTimeout(120_000)
+
+    let branchId = ''
+
+    await test.step('turn 1 — the fallback writes the asks', async () => {
+      await home.openStory(app.window, HERO_TITLE).click()
+      await expect(reader.composer(app.window)).toBeVisible({ timeout: 20_000 })
+      await reader.composer(app.window).fill('E2E-Q4F-USER-1 I press toward the ridge.')
+      await reader.send(app.window).click()
+      await expect(app.window.getByText('E2E-Q4F-TURN', { exact: false })).toBeVisible({
+        timeout: 30_000,
+      })
+
+      branchId = await currentBranchId(app.window)
+
+      await expect
+        .poll(async () => (await tailMetadata(app.window, branchId))?.retrievalQueries, {
+          timeout: 30_000,
+        })
+        .toEqual([ASK_A, ASK_B])
+
+      // Provenance, not inference: with the fold off it never builds a report, so
+      // 'per_turn_classifier' can only have come from this phase. 'piggyback_tagged_block'
+      // here would mean the fold ran after all and the rest of this spec proves nothing.
+      expect((await tailMetadata(app.window, branchId))?.stateReport?.layer).toBe(
+        'per_turn_classifier',
+      )
+
+      // The five-slot poll in step 2 only distinguishes turn 2's capture from turn 1's
+      // because turn 1 had no prior row to read: three fixed slots, no Q4.
+      expect((await latestCapture(app.window, branchId))?.queries.length).toBe(3)
+    })
+
+    await test.step('turn 2 — retrieval embeds turn 1 asks, not its own', async () => {
+      // Turn 2 emits different asks so the capture below distinguishes "read the previous
+      // turn's row" (correct) from "read my own" — the regression this test catches.
+      setAsks(mock, ASK_C, ASK_D)
+      mock.setNarrative(narrative('E2E-Q4F-TURN-2'))
+      await reader.composer(app.window).fill('E2E-Q4F-USER-2 I ask what the sigil means.')
+      await reader.send(app.window).click()
+
+      // Turn 1 wrote its own capture with three slots (Q1-Q3, no emitted Q4 yet), so
+      // polling for five is what waits for turn 2's row specifically.
+      await expect
+        .poll(async () => (await latestCapture(app.window, branchId))?.queries.length, {
+          timeout: 30_000,
+        })
+        .toBe(5)
+
+      const capture = (await latestCapture(app.window, branchId))!
+      expect(capture.queries.map((q) => q.source)).toEqual([
+        'user_action',
+        'structural_digest',
+        'piggyback_summary',
+        'classifier_emitted',
+        'classifier_emitted',
+      ])
+      expect(capture.queries.slice(3).map((q) => q.text)).toEqual([ASK_A, ASK_B])
+
+      // Without this the line above would also pass if the ASK_C/ASK_D override never
+      // reached the model — the assertion would be reading a stale mock, not a fresh
+      // previous-turn read. Turn 2's own row carries the new asks for turn 3.
+      await expect
+        .poll(async () => (await tailMetadata(app.window, branchId))?.retrievalQueries, {
+          timeout: 30_000,
+        })
+        .toEqual([ASK_C, ASK_D])
+    })
+  })
+})

--- a/e2e/tests/retrieval-q4-fallback.spec.ts
+++ b/e2e/tests/retrieval-q4-fallback.spec.ts
@@ -1,9 +1,6 @@
-import { expect, test, type Page } from '@playwright/test'
-import { gunzipSync } from 'fflate'
+import { expect, test } from '@playwright/test'
 
-import type { EntryMetadata, ProbeCapturePayload } from '@/lib/db'
-
-import { queryApp } from '../harness/db'
+import { currentBranchId, latestCapture, queryApp, tailMetadata } from '../harness/db'
 import { installEmbedderModel } from '../harness/embedder'
 import { launchApp, type LaunchedApp } from '../harness/launch'
 import { startMockLlm, type MockLlm } from '../harness/mock-llm'
@@ -18,12 +15,9 @@ import {
 import { home } from '../locators/home'
 import { reader } from '../locators/reader'
 
-// Q4 on the FALLBACK path (docs/memory/retrieval.md#q4-classifier-emitted-queries), the
-// one a default-configured story runs: piggybackMode defaults to 'off', so the asks come
-// from the fallback classifier's own structured call — generateStructured →
-// substitutePiggybackIds → buildPiggybackActions → metadata — not from a tagged <state>
-// block folded out of the narrative. retrieval-q4.spec.ts covers the fold; this covers the
-// seam it cannot reach.
+// Q4 on the FALLBACK path (docs/memory/retrieval.md#q4-classifier-emitted-queries), the one a
+// default-configured story runs: piggybackMode defaults to 'off', so the asks come from the
+// fallback classifier's own structured call. retrieval-q4.spec.ts covers the fold instead.
 
 const HERO_TITLE = 'The Veilstone Courier'
 const HERO_STORY_ID = 'story_hero'
@@ -37,9 +31,8 @@ const ASK_D = 'E2E-Q4F-ASK who last carried the courier seal'
 // fields, so a value in metadata came from the fallback's structured call or from nowhere.
 const narrative = (marker: string) => `${marker} The storm bends the reeds flat.`
 
-// The seeded story has suggestion categories enabled and the fold is off, so no chips are
-// in hand when the phase runs — it takes the `-suggestions` schema branch. Both shapes are
-// set anyway: which one fires is a property of the fixture's settings, not of Q4.
+// The seeded story has suggestion categories enabled and the fold is off, so the phase takes
+// the `-suggestions` branch. Both are set anyway: which fires is fixture settings, not Q4.
 function setAsks(mock: MockLlm, askOne: string, askTwo: string): void {
   const reply = {
     sceneEntities: [],
@@ -49,39 +42,6 @@ function setAsks(mock: MockLlm, askOne: string, askTwo: string): void {
   }
   mock.setStructured('per-turn-classifier', reply)
   mock.setStructured('per-turn-classifier-suggestions', { ...reply, suggestions: [] })
-}
-
-async function currentBranchId(page: Page): Promise<string> {
-  const rows = await queryApp(page, `SELECT current_branch_id FROM stories WHERE id = ?`, [
-    HERO_STORY_ID,
-  ])
-  return rows[0]?.[0] as string
-}
-
-// queryApp is a raw SQL bridge, not drizzle's typed select, so the column's
-// `mode: 'json'` transform never runs — parse it here instead.
-async function tailMetadata(page: Page, branchId: string): Promise<EntryMetadata | null> {
-  const rows = await queryApp(
-    page,
-    `SELECT metadata FROM story_entries WHERE branch_id = ? AND kind = 'ai_reply'
-     ORDER BY position DESC LIMIT 1`,
-    [branchId],
-  )
-  const raw = rows[0]?.[0] as string | null | undefined
-  return raw ? (JSON.parse(raw) as EntryMetadata) : null
-}
-
-const LATEST_CAPTURE_SQL = `SELECT payload FROM probe_captures
-   WHERE branch_id = ? ORDER BY captured_at DESC, id DESC LIMIT 1`
-
-// Payload is a gzipped blob; queryApp's evaluate bridge returns the BLOB column as a real
-// Uint8Array (Playwright has serialized typed arrays since 1.44), so it gunzips directly.
-async function latestCapture(page: Page, branchId: string): Promise<ProbeCapturePayload | null> {
-  const rows = await queryApp(page, LATEST_CAPTURE_SQL, [branchId])
-  const blob = rows[0]?.[0] as Uint8Array | undefined
-  if (blob === undefined) return null
-  const json = new TextDecoder().decode(gunzipSync(blob))
-  return JSON.parse(json) as ProbeCapturePayload
 }
 
 test.describe('retrieval Q4 — fallback classifier across a turn boundary', () => {
@@ -106,6 +66,12 @@ test.describe('retrieval Q4 — fallback classifier across a turn boundary', () 
     enableDiagnostics(seeded.dbPath)
     enableStoryProbeMode(seeded.dbPath, HERO_STORY_ID)
     app = await launchApp({ userDataDir, cleanupUserData: true })
+    // Tripwire: proves the seed landed, not that the app read it. Without it, deleting the
+    // call above still reads layer === 'per_turn_classifier' — a failed fold ends there too.
+    const [[raw]] = await queryApp(app.window, `SELECT settings FROM stories WHERE id = ?`, [
+      HERO_STORY_ID,
+    ])
+    expect((JSON.parse(raw as string) as { piggybackMode: string }).piggybackMode).toBe('off')
   })
 
   test.afterAll(async () => {
@@ -128,7 +94,7 @@ test.describe('retrieval Q4 — fallback classifier across a turn boundary', () 
         timeout: 30_000,
       })
 
-      branchId = await currentBranchId(app.window)
+      branchId = await currentBranchId(app.window, HERO_STORY_ID)
 
       await expect
         .poll(async () => (await tailMetadata(app.window, branchId))?.retrievalQueries, {
@@ -136,9 +102,8 @@ test.describe('retrieval Q4 — fallback classifier across a turn boundary', () 
         })
         .toEqual([ASK_A, ASK_B])
 
-      // Provenance, not inference: with the fold off it never builds a report, so
-      // 'per_turn_classifier' can only have come from this phase. 'piggyback_tagged_block'
-      // here would mean the fold ran after all and the rest of this spec proves nothing.
+      // Provenance: only this phase writes 'per_turn_classifier'. It does NOT prove the fold
+      // was off — a fold that fired and failed lands here too; the beforeAll tripwire covers that.
       expect((await tailMetadata(app.window, branchId))?.stateReport?.layer).toBe(
         'per_turn_classifier',
       )
@@ -174,9 +139,8 @@ test.describe('retrieval Q4 — fallback classifier across a turn boundary', () 
       ])
       expect(capture.queries.slice(3).map((q) => q.text)).toEqual([ASK_A, ASK_B])
 
-      // Without this the line above would also pass if the ASK_C/ASK_D override never
-      // reached the model — the assertion would be reading a stale mock, not a fresh
-      // previous-turn read. Turn 2's own row carries the new asks for turn 3.
+      // Without this, the line above passes even if the ASK_C/ASK_D override never reached the
+      // model — the mock's override Map persists, so turn 2 would re-serve turn 1's asks.
       await expect
         .poll(async () => (await tailMetadata(app.window, branchId))?.retrievalQueries, {
           timeout: 30_000,

--- a/e2e/tests/retrieval-q4-fallback.spec.ts
+++ b/e2e/tests/retrieval-q4-fallback.spec.ts
@@ -149,8 +149,8 @@ test.describe('retrieval Q4 — fallback classifier across a turn boundary', () 
     })
 
     await test.step('turn 2 — retrieval embeds turn 1 asks, not its own', async () => {
-      // Turn 2 emits different asks so the capture below distinguishes "read the previous
-      // turn's row" (correct) from "read my own" — the regression this test catches.
+      // Turn 2 emits different asks, so the capture below pins Q4 to the COMMITTED previous
+      // row — not a stale store copy, a re-read, or a shifted readSceneSource anchor.
       setAsks(mock, ASK_C, ASK_D)
       mock.setNarrative(narrative('E2E-Q4F-TURN-2'))
       await reader.composer(app.window).fill('E2E-Q4F-USER-2 I ask what the sigil means.')

--- a/e2e/tests/retrieval-q4-fallback.spec.ts
+++ b/e2e/tests/retrieval-q4-fallback.spec.ts
@@ -15,9 +15,8 @@ import {
 import { home } from '../locators/home'
 import { reader } from '../locators/reader'
 
-// Q4 on the FALLBACK path (docs/memory/retrieval.md#q4-classifier-emitted-queries), the one a
-// default-configured story runs: piggybackMode defaults to 'off', so the asks come from the
-// fallback classifier's own structured call. retrieval-q4.spec.ts covers the fold instead.
+// Q4 on the FALLBACK path (docs/memory/retrieval.md#q4-classifier-emitted-queries): a default
+// story's piggybackMode is 'off', so asks come from the classifier call — see retrieval-q4.spec.ts.
 
 const HERO_TITLE = 'The Veilstone Courier'
 const HERO_STORY_ID = 'story_hero'

--- a/e2e/tests/retrieval-q4.spec.ts
+++ b/e2e/tests/retrieval-q4.spec.ts
@@ -1,9 +1,6 @@
 import { expect, test, type Page } from '@playwright/test'
-import { gunzipSync } from 'fflate'
 
-import type { EntryMetadata, ProbeCapturePayload } from '@/lib/db'
-
-import { queryApp } from '../harness/db'
+import { currentBranchId, latestCapture, queryApp, tailMetadata } from '../harness/db'
 import { installEmbedderModel } from '../harness/embedder'
 import { launchApp, type LaunchedApp } from '../harness/launch'
 import { startMockLlm, type MockLlm } from '../harness/mock-llm'
@@ -44,26 +41,6 @@ const narrative = (
   </retrieval_queries>
 </state>`
 
-async function currentBranchId(page: Page): Promise<string> {
-  const rows = await queryApp(page, `SELECT current_branch_id FROM stories WHERE id = ?`, [
-    HERO_STORY_ID,
-  ])
-  return rows[0]?.[0] as string
-}
-
-// queryApp is a raw SQL bridge, not drizzle's typed select, so the column's
-// `mode: 'json'` transform never runs — parse it here instead.
-async function tailMetadata(page: Page, branchId: string): Promise<EntryMetadata | null> {
-  const rows = await queryApp(
-    page,
-    `SELECT metadata FROM story_entries WHERE branch_id = ? AND kind = 'ai_reply'
-     ORDER BY position DESC LIMIT 1`,
-    [branchId],
-  )
-  const raw = rows[0]?.[0] as string | null | undefined
-  return raw ? (JSON.parse(raw) as EntryMetadata) : null
-}
-
 async function tailEntryId(page: Page, branchId: string): Promise<string> {
   const rows = await queryApp(
     page,
@@ -72,19 +49,6 @@ async function tailEntryId(page: Page, branchId: string): Promise<string> {
     [branchId],
   )
   return rows[0]?.[0] as string
-}
-
-const LATEST_CAPTURE_SQL = `SELECT payload FROM probe_captures
-   WHERE branch_id = ? ORDER BY captured_at DESC, id DESC LIMIT 1`
-
-// Payload is a gzipped blob; queryApp's evaluate bridge returns the BLOB column as a real
-// Uint8Array (Playwright has serialized typed arrays since 1.44), so it gunzips directly.
-async function latestCapture(page: Page, branchId: string): Promise<ProbeCapturePayload | null> {
-  const rows = await queryApp(page, LATEST_CAPTURE_SQL, [branchId])
-  const blob = rows[0]?.[0] as Uint8Array | undefined
-  if (blob === undefined) return null
-  const json = new TextDecoder().decode(gunzipSync(blob))
-  return JSON.parse(json) as ProbeCapturePayload
 }
 
 test.describe('retrieval Q4 — classifier-emitted queries across a turn boundary', () => {
@@ -128,7 +92,7 @@ test.describe('retrieval Q4 — classifier-emitted queries across a turn boundar
         timeout: 30_000,
       })
 
-      branchId = await currentBranchId(app.window)
+      branchId = await currentBranchId(app.window, HERO_STORY_ID)
 
       await expect
         .poll(async () => (await tailMetadata(app.window, branchId))?.retrievalQueries, {

--- a/e2e/tests/retrieval-q4.spec.ts
+++ b/e2e/tests/retrieval-q4.spec.ts
@@ -149,8 +149,8 @@ test.describe('retrieval Q4 — classifier-emitted queries across a turn boundar
     })
 
     await test.step('turn 2 embeds them as direct-slot queries and captures redundancy', async () => {
-      // Turn 2 emits different asks (ASK_C/ASK_D) so the capture below distinguishes "read the
-      // previous turn's row" (correct) from "read my own" — the regression this test catches.
+      // Turn 2 emits different asks (ASK_C/ASK_D), so the capture below pins Q4 to the COMMITTED
+      // previous row — not a stale store copy, a re-read, or a shifted readSceneSource anchor.
       mock.setNarrative(narrative('E2E-Q4-TURN-2', ASK_C, ASK_D))
       await reader.composer(app.window).fill('E2E-Q4-USER-2 I ask what the sigil means.')
       await reader.send(app.window).click()

--- a/lib/actions/classifier/run-now.test.ts
+++ b/lib/actions/classifier/run-now.test.ts
@@ -28,6 +28,7 @@ const DEFINITION = storyDefinitionSchema.parse({
 })
 const SETTINGS = storySettingsSchema.parse({
   classifierCadence: 8,
+  classifierContextEntries: 4,
   piggybackMode: 'off',
   embeddingBackend: 'local',
   embedding_model_id: 'm',

--- a/lib/actions/stories/load-open-story.test.ts
+++ b/lib/actions/stories/load-open-story.test.ts
@@ -33,6 +33,7 @@ const STORY_DEFINITION = storyDefinitionSchema.parse({
 })
 const STORY_SETTINGS = storySettingsSchema.parse({
   classifierCadence: 8,
+  classifierContextEntries: 4,
   piggybackMode: 'off',
   embeddingBackend: 'local',
   embedding_model_id: 'm',

--- a/lib/actions/stories/operational.test.ts
+++ b/lib/actions/stories/operational.test.ts
@@ -44,6 +44,7 @@ const STORY_DEFINITION = storyDefinitionSchema.parse({
 })
 const STORY_SETTINGS = storySettingsSchema.parse({
   classifierCadence: 8,
+  classifierContextEntries: 4,
   piggybackMode: 'off',
   embeddingBackend: 'local',
   embedding_model_id: 'm',

--- a/lib/actions/turns/__tests__/fixtures.ts
+++ b/lib/actions/turns/__tests__/fixtures.ts
@@ -72,6 +72,7 @@ export const STORY_DEFINITION = storyDefinitionSchema.parse({
 
 export const STORY_SETTINGS = storySettingsSchema.parse({
   classifierCadence: 8,
+  classifierContextEntries: 4,
   piggybackMode: 'off',
   embeddingBackend: 'local',
   // A catalog id, not a placeholder: the retrieval phase resolves this story's

--- a/lib/boot/classifier-scheduler.test.ts
+++ b/lib/boot/classifier-scheduler.test.ts
@@ -26,6 +26,7 @@ const DEFINITION = storyDefinitionSchema.parse({
 })
 const SETTINGS = storySettingsSchema.parse({
   classifierCadence: 1,
+  classifierContextEntries: 4,
   piggybackMode: 'off',
   embeddingBackend: 'local',
   embedding_model_id: 'm',

--- a/lib/db/__tests__/migrate-m3-classifier-context.test.ts
+++ b/lib/db/__tests__/migrate-m3-classifier-context.test.ts
@@ -29,6 +29,7 @@ const LEGACY_SETTINGS = {
   chapterTokenThreshold: 24000,
   classifierCadence: 5,
   piggybackMode: 'off',
+  retrievalBudgets: { entities: 1200, lore: 1800, happenings: 1500, threads: 400, chapters: 600 },
   keywordRetrieval: {
     mode: 'boost',
     budgetShare: 0.5,
@@ -71,7 +72,8 @@ describe(TAG, () => {
     expect(migrationTags()).toContain(TAG)
     const runtime = readFileSync(`${MIGRATIONS_DIR}/migrations.js`, 'utf8')
     expect(runtime).toContain(`${TAG}.sql`)
-    expect(runtime).toMatch(/^\s*m0013,\s*$/m)
+    const runtimeKey = `m${TAG.slice(0, 4)}`
+    expect(runtime).toMatch(new RegExp(`^\\s*${runtimeKey},\\s*$`, 'm'))
   })
 
   it('creates the key on a settings blob that predates it', () => {
@@ -130,8 +132,8 @@ describe(TAG, () => {
     expect(bad.settings).toBe(raw)
   })
 
-  // json_valid alone admits these, and json_set then rewrites the column re-serialized,
-  // normalizing a row the migration must not touch. The spacing is the assertion.
+  // json_valid alone admits these, and json_set would rewrite the column
+  // re-serialized. The array's spacing is the assertion; the scalar is parity.
   it.each([
     ['a spaced top-level array', '[1, 2]'],
     ['a quoted scalar', '"already gone"'],

--- a/lib/db/__tests__/migrate-m3-classifier-context.test.ts
+++ b/lib/db/__tests__/migrate-m3-classifier-context.test.ts
@@ -1,0 +1,158 @@
+import { readFileSync } from 'node:fs'
+import { DatabaseSync } from 'node:sqlite'
+
+import { getLoadablePath } from 'sqlite-vec'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { STORY_SETTINGS_DEFAULTS } from '@/lib/db'
+
+const MIGRATIONS_DIR = 'lib/db/migrations'
+const TAG = '0013_classifier_context_entries'
+
+function migrationTags(): string[] {
+  const journal = JSON.parse(readFileSync(`${MIGRATIONS_DIR}/meta/_journal.json`, 'utf8')) as {
+    entries: { idx: number; tag: string }[]
+  }
+  return [...journal.entries].sort((a, b) => a.idx - b.idx).map((e) => e.tag)
+}
+
+function applyMigration(sqlite: DatabaseSync, tag: string): void {
+  const sql = readFileSync(`${MIGRATIONS_DIR}/${tag}.sql`, 'utf8')
+  for (const statement of sql.split('--> statement-breakpoint')) {
+    const trimmed = statement.trim()
+    if (trimmed) sqlite.exec(trimmed)
+  }
+}
+
+// No classifierContextEntries key, plus enough siblings to prove the migration writes one key.
+const LEGACY_SETTINGS = {
+  chapterTokenThreshold: 24000,
+  classifierCadence: 5,
+  piggybackMode: 'off',
+  keywordRetrieval: {
+    mode: 'boost',
+    budgetShare: 0.5,
+    scanEntries: 1,
+    cascade: false,
+    cascadeMaxDepth: 2,
+  },
+  embedding_model_id: 'Xenova/all-MiniLM-L6-v2',
+  packVariables: { tone: 'wry' },
+}
+
+function settingsOf(db: DatabaseSync, storyId: string): Record<string, unknown> | null {
+  const row = db.prepare('select settings from stories where id = ?').get(storyId) as
+    | { settings: string | null }
+    | undefined
+  return row?.settings == null ? null : (JSON.parse(row.settings) as Record<string, unknown>)
+}
+
+function insertStory(db: DatabaseSync, id: string, settings: unknown): void {
+  db.prepare(
+    'insert into stories (id, title, settings, created_at, updated_at) values (?,?,?,?,?)',
+  ).run(id, id, settings === null ? null : JSON.stringify(settings), 1, 1)
+}
+
+describe(TAG, () => {
+  let db: DatabaseSync
+
+  beforeEach(() => {
+    db = new DatabaseSync(':memory:', { allowExtension: true })
+    db.loadExtension(getLoadablePath())
+    for (const tag of migrationTags()) {
+      if (tag === TAG) break
+      applyMigration(db, tag)
+    }
+  })
+
+  // Applying by filename stays green against a migration the app never runs; an
+  // unjournalled 0013 fails storySettingsSchema on every upgraded story. A fresh DB
+  // never needs the migration, so E2E cannot catch it either.
+  it('is wired into the upgrade path, not just present on disk', () => {
+    expect(migrationTags()).toContain(TAG)
+    const runtime = readFileSync(`${MIGRATIONS_DIR}/migrations.js`, 'utf8')
+    expect(runtime).toContain(`${TAG}.sql`)
+  })
+
+  it('creates the key on a settings blob that predates it', () => {
+    insertStory(db, 's1', LEGACY_SETTINGS)
+    expect(settingsOf(db, 's1')?.classifierContextEntries).toBeUndefined()
+
+    applyMigration(db, TAG)
+
+    expect(settingsOf(db, 's1')?.classifierContextEntries).toBe(
+      STORY_SETTINGS_DEFAULTS.classifierContextEntries,
+    )
+  })
+
+  it('leaves every sibling settings key untouched', () => {
+    insertStory(db, 's1', LEGACY_SETTINGS)
+
+    applyMigration(db, TAG)
+
+    expect(settingsOf(db, 's1')).toEqual({
+      ...LEGACY_SETTINGS,
+      classifierContextEntries: STORY_SETTINGS_DEFAULTS.classifierContextEntries,
+    })
+  })
+
+  // A user-chosen depth must survive a re-run, so the statement is idempotent.
+  it('leaves a story that already carries the key alone', () => {
+    insertStory(db, 's1', { ...LEGACY_SETTINGS, classifierContextEntries: 9 })
+
+    applyMigration(db, TAG)
+    applyMigration(db, TAG)
+
+    expect(settingsOf(db, 's1')?.classifierContextEntries).toBe(9)
+  })
+
+  // json_set raises on non-JSON text and aborts the whole UPDATE: without the guard one
+  // unparseable blob leaves every other story unmigrated and the app unable to boot.
+  it.each([
+    ['unparseable text', '{not json'],
+    ['an empty string', ''],
+    ['a top-level array', '[1,2]'],
+    ['a top-level scalar', '42'],
+  ])('migrates good rows beside %s', (_label, raw) => {
+    insertStory(db, 's_good', LEGACY_SETTINGS)
+    db.prepare(
+      'insert into stories (id, title, settings, created_at, updated_at) values (?,?,?,?,?)',
+    ).run('s_bad', 's_bad', raw, 1, 1)
+
+    expect(() => applyMigration(db, TAG)).not.toThrow()
+
+    expect(settingsOf(db, 's_good')?.classifierContextEntries).toBe(
+      STORY_SETTINGS_DEFAULTS.classifierContextEntries,
+    )
+    const bad = db.prepare('select settings from stories where id = ?').get('s_bad') as {
+      settings: string
+    }
+    expect(bad.settings).toBe(raw)
+  })
+
+  // json_valid alone admits these, and json_set then rewrites the column re-serialized,
+  // normalizing a row the migration must not touch. The spacing is the assertion.
+  it.each([
+    ['a spaced top-level array', '[1, 2]'],
+    ['a quoted scalar', '"already gone"'],
+  ])('does not rewrite %s', (_label, raw) => {
+    db.prepare(
+      'insert into stories (id, title, settings, created_at, updated_at) values (?,?,?,?,?)',
+    ).run('s_odd', 's_odd', raw, 1, 1)
+
+    applyMigration(db, TAG)
+
+    const after = db.prepare('select settings from stories where id = ?').get('s_odd') as {
+      settings: string
+    }
+    expect(after.settings).toBe(raw)
+  })
+
+  it('leaves a wizard draft with no settings blob null rather than writing one', () => {
+    insertStory(db, 's1', null)
+
+    applyMigration(db, TAG)
+
+    expect(settingsOf(db, 's1')).toBeNull()
+  })
+})

--- a/lib/db/__tests__/migrate-m3-classifier-context.test.ts
+++ b/lib/db/__tests__/migrate-m3-classifier-context.test.ts
@@ -108,6 +108,18 @@ describe(TAG, () => {
     expect(settingsOf(db, 's1')?.classifierContextEntries).toBe(9)
   })
 
+  // Deliberate — the key is z.number(), so a stored null fails story open as
+  // settings-corrupt; json_extract IS NULL matches it and the backfill repairs it.
+  it('repairs an explicit null rather than preserving it', () => {
+    insertStory(db, 's1', { ...LEGACY_SETTINGS, classifierContextEntries: null })
+
+    applyMigration(db, TAG)
+
+    expect(settingsOf(db, 's1')?.classifierContextEntries).toBe(
+      STORY_SETTINGS_DEFAULTS.classifierContextEntries,
+    )
+  })
+
   // json_set raises on non-JSON text and aborts the whole UPDATE: without the guard one
   // unparseable blob leaves every other story unmigrated and the app unable to boot.
   it.each([

--- a/lib/db/__tests__/migrate-m3-classifier-context.test.ts
+++ b/lib/db/__tests__/migrate-m3-classifier-context.test.ts
@@ -65,13 +65,13 @@ describe(TAG, () => {
     }
   })
 
-  // Applying by filename stays green against a migration the app never runs; an
-  // unjournalled 0013 fails storySettingsSchema on every upgraded story. A fresh DB
-  // never needs the migration, so E2E cannot catch it either.
+  // drizzle-orm looks migrations up by key (m0013), not by filename. Both halves
+  // must be present; an import-only file would boot crash on the missing key.
   it('is wired into the upgrade path, not just present on disk', () => {
     expect(migrationTags()).toContain(TAG)
     const runtime = readFileSync(`${MIGRATIONS_DIR}/migrations.js`, 'utf8')
     expect(runtime).toContain(`${TAG}.sql`)
+    expect(runtime).toMatch(/^\s*m0013,\s*$/m)
   })
 
   it('creates the key on a settings blob that predates it', () => {

--- a/lib/db/devtools/seed-dataset.ts
+++ b/lib/db/devtools/seed-dataset.ts
@@ -146,6 +146,7 @@ function definition(input: {
 function settings(overrides: Partial<StorySettings> = {}): StorySettings {
   return storySettingsSchema.parse({
     classifierCadence: 4,
+    classifierContextEntries: 4,
     piggybackMode: 'on',
     embeddingBackend: 'local',
     embedding_model_id: 'Xenova/all-MiniLM-L6-v2',

--- a/lib/db/migrations/0013_classifier_context_entries.sql
+++ b/lib/db/migrations/0013_classifier_context_entries.sql
@@ -12,7 +12,9 @@ SET settings = json_set(settings, '$.classifierContextEntries', 4)
 -- (lib/actions/stories/operational.ts sets a settings-corrupt open failure), so
 -- skip those rows and leave the rest of the database migratable. json_valid must
 -- stay first: json_type and json_extract raise on a blob nested past SQLite's
--- parser depth, where json_valid merely returns 0.
+-- parser depth, where json_valid merely returns 0. The key test is json_extract
+-- rather than a path-scoped json_type so an explicit null is repaired as well as
+-- an absent key: the schema types it z.number(), so a stored null fails story open.
 WHERE settings IS NOT NULL
 	AND json_valid(settings)
 	AND json_type(settings) = 'object'

--- a/lib/db/migrations/0013_classifier_context_entries.sql
+++ b/lib/db/migrations/0013_classifier_context_entries.sql
@@ -10,7 +10,9 @@ SET settings = json_set(settings, '$.classifierContextEntries', 4)
 -- statement: no story migrates and the app cannot boot past migrate(). A corrupt
 -- settings blob is already a per-story recoverable state elsewhere
 -- (lib/actions/stories/operational.ts sets a settings-corrupt open failure), so
--- skip those rows and leave the rest of the database migratable.
+-- skip those rows and leave the rest of the database migratable. json_valid must
+-- stay first: json_type and json_extract raise on a blob nested past SQLite's
+-- parser depth, where json_valid merely returns 0.
 WHERE settings IS NOT NULL
 	AND json_valid(settings)
 	AND json_type(settings) = 'object'

--- a/lib/db/migrations/0013_classifier_context_entries.sql
+++ b/lib/db/migrations/0013_classifier_context_entries.sql
@@ -1,0 +1,17 @@
+-- stories.settings.classifierContextEntries is new here. Settings writes are
+-- key-scoped json_set (settings-ops.ts), so a Zod-side default would never
+-- materialise in an existing blob: reads would apply it while the stored column
+-- stayed short. Guarded on the key being absent rather than written
+-- unconditionally like 0007, so the statement is idempotent once users can
+-- choose a depth of their own.
+UPDATE stories
+SET settings = json_set(settings, '$.classifierContextEntries', 4)
+-- json_set raises on non-JSON text, and one such row would abort the whole
+-- statement: no story migrates and the app cannot boot past migrate(). A corrupt
+-- settings blob is already a per-story recoverable state elsewhere
+-- (lib/actions/stories/operational.ts sets a settings-corrupt open failure), so
+-- skip those rows and leave the rest of the database migratable.
+WHERE settings IS NOT NULL
+	AND json_valid(settings)
+	AND json_type(settings) = 'object'
+	AND json_extract(settings, '$.classifierContextEntries') IS NULL;

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1788708593734,
       "tag": "0012_entity_keywords_priority",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "6",
+      "when": 1788858116000,
+      "tag": "0013_classifier_context_entries",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/migrations/migrations.js
+++ b/lib/db/migrations/migrations.js
@@ -14,6 +14,7 @@ import m0009 from './0009_blue_pet_avengers.sql'
 import m0010 from './0010_entries_position_idx.sql'
 import m0011 from './0011_keyword_retrieval_settings.sql'
 import m0012 from './0012_entity_keywords_priority.sql'
+import m0013 from './0013_classifier_context_entries.sql'
 
 export default {
   journal,
@@ -31,5 +32,6 @@ export default {
     m0010,
     m0011,
     m0012,
+    m0013,
   },
 }

--- a/lib/db/stories/settings-ops.test.ts
+++ b/lib/db/stories/settings-ops.test.ts
@@ -40,6 +40,7 @@ describe('story settings ops', () => {
       partialChapterBuffer: 10,
       protectedBuffer: 10,
       classifierCadence: 5,
+      classifierContextEntries: 4,
       piggybackMode: 'off',
       embeddingBackend: 'local',
       embedding_model_id: 'old-model',

--- a/lib/db/stories/story-config-schema.test.ts
+++ b/lib/db/stories/story-config-schema.test.ts
@@ -26,6 +26,7 @@ const VALID_SETTINGS = {
   partialChapterBuffer: 10,
   protectedBuffer: 10,
   classifierCadence: 8,
+  classifierContextEntries: 4,
   piggybackMode: 'off' as const,
   embeddingBackend: 'local' as const,
   embedding_model_id: 'bge-small',

--- a/lib/db/stories/story-config-schema.ts
+++ b/lib/db/stories/story-config-schema.ts
@@ -122,9 +122,8 @@ export const storySettingsSchema = z.object({
   partialChapterBuffer: z.number().int().nonnegative().default(10),
   protectedBuffer: z.number().int().nonnegative().default(10),
   classifierCadence: z.number(),
-  // cadence.md → User-tunable knobs: default 4, minimum 2. No `.min(2)` here —
-  // a hand-edited 0 must degrade at the read site, not fail story load. No
-  // `.default()` either, matching classifierCadence: migration 0013 backfills.
+  // cadence.md → User-tunable knobs. No `.min(2)`: a hand-edited 0 degrades at read time rather
+  // than failing story load. No `.default()` either — matches classifierCadence (migration 0013).
   classifierContextEntries: z.number(),
   piggybackMode: z.enum(['on', 'off']),
   embeddingBackend: z.enum(['provider', 'local']),

--- a/lib/db/stories/story-config-schema.ts
+++ b/lib/db/stories/story-config-schema.ts
@@ -122,6 +122,10 @@ export const storySettingsSchema = z.object({
   partialChapterBuffer: z.number().int().nonnegative().default(10),
   protectedBuffer: z.number().int().nonnegative().default(10),
   classifierCadence: z.number(),
+  // cadence.md → User-tunable knobs: default 4, minimum 2. No `.min(2)` here —
+  // a hand-edited 0 must degrade at the read site, not fail story load. No
+  // `.default()` either, matching classifierCadence: migration 0013 backfills.
+  classifierContextEntries: z.number(),
   piggybackMode: z.enum(['on', 'off']),
   embeddingBackend: z.enum(['provider', 'local']),
   embedding_model_id: z.string(),

--- a/lib/db/stories/story-settings-defaults.ts
+++ b/lib/db/stories/story-settings-defaults.ts
@@ -14,6 +14,7 @@ export const STORY_SETTINGS_DEFAULTS: StorySettings = {
   partialChapterBuffer: 10,
   protectedBuffer: 10,
   classifierCadence: 5,
+  classifierContextEntries: 4,
   piggybackMode: 'off',
   embeddingBackend: 'local',
   embedding_model_id: 'Xenova/all-MiniLM-L6-v2',

--- a/lib/pipeline/definitions/entry-reads.ts
+++ b/lib/pipeline/definitions/entry-reads.ts
@@ -25,15 +25,21 @@ export async function readSceneSource(
 }
 
 // Bounded by the query rather than by a caller or a template, so neither the
-// story's buffer knobs nor a pack can narrow it. Whichever phase asks, the
-// classifier needs the action that caused a state change alongside the prose
-// around it; which kinds those two rows are depends on when in the run it asks.
-export async function readLastTurns(db: DbCtx['db'], branchId: string): Promise<StoryEntry[]> {
+// story's buffer knobs nor a pack can narrow it below the pair. Whichever phase
+// asks, the classifier needs the action that caused a state change alongside the
+// prose around it; which kinds those two rows are depends on when in the run it
+// asks. `limit` widens the background above that floor (cadence.md → User-tunable
+// knobs); it can never cut into it.
+export async function readLastTurns(
+  db: DbCtx['db'],
+  branchId: string,
+  limit: number = LAST_TURNS,
+): Promise<StoryEntry[]> {
   const rows = await db
     .select()
     .from(storyEntries)
     .where(and(eq(storyEntries.branchId, branchId), ne(storyEntries.kind, 'system')))
     .orderBy(desc(storyEntries.position), desc(storyEntries.createdAt))
-    .limit(LAST_TURNS)
+    .limit(Math.max(LAST_TURNS, limit))
   return rows.reverse()
 }

--- a/lib/pipeline/definitions/entry-reads.ts
+++ b/lib/pipeline/definitions/entry-reads.ts
@@ -29,17 +29,19 @@ export async function readSceneSource(
 // asks, the classifier needs the action that caused a state change alongside the
 // prose around it; which kinds those two rows are depends on when in the run it
 // asks. `limit` widens the background above that floor (cadence.md → User-tunable
-// knobs); it can never cut into it.
+// knobs); it can never cut into it, and a fractional or non-finite knob degrades
+// to the pair rather than throwing or reading the branch unbounded.
 export async function readLastTurns(
   db: DbCtx['db'],
   branchId: string,
   limit: number = LAST_TURNS,
 ): Promise<StoryEntry[]> {
+  const take = Number.isFinite(limit) ? Math.max(LAST_TURNS, Math.trunc(limit)) : LAST_TURNS
   const rows = await db
     .select()
     .from(storyEntries)
     .where(and(eq(storyEntries.branchId, branchId), ne(storyEntries.kind, 'system')))
     .orderBy(desc(storyEntries.position), desc(storyEntries.createdAt))
-    .limit(Math.max(LAST_TURNS, limit))
+    .limit(take)
   return rows.reverse()
 }

--- a/lib/pipeline/definitions/entry-reads.ts
+++ b/lib/pipeline/definitions/entry-reads.ts
@@ -29,14 +29,13 @@ export async function readSceneSource(
 // asks, the classifier needs the action that caused a state change alongside the
 // prose around it; which kinds those two rows are depends on when in the run it
 // asks. `limit` widens the background above that floor (cadence.md → User-tunable
-// knobs); it can never cut into it, and a fractional or non-finite knob degrades
-// to the pair rather than throwing or reading the branch unbounded.
+// knobs). Hardened against settings that never went through storySettingsSchema.
 export async function readLastTurns(
   db: DbCtx['db'],
   branchId: string,
   limit: number = LAST_TURNS,
 ): Promise<StoryEntry[]> {
-  const take = Number.isFinite(limit) ? Math.max(LAST_TURNS, Math.trunc(limit)) : LAST_TURNS
+  const take = Number.isFinite(limit) ? Math.max(LAST_TURNS, Math.floor(limit)) : LAST_TURNS
   const rows = await db
     .select()
     .from(storyEntries)

--- a/lib/pipeline/definitions/entry-reads.ts
+++ b/lib/pipeline/definitions/entry-reads.ts
@@ -24,12 +24,9 @@ export async function readSceneSource(
   return row
 }
 
-// Bounded by the query rather than by a caller or a template, so neither the
-// story's buffer knobs nor a pack can narrow it below the pair. Whichever phase
-// asks, the classifier needs the action that caused a state change alongside the
-// prose around it; which kinds those two rows are depends on when in the run it
-// asks. `limit` widens the background above that floor (cadence.md → User-tunable
-// knobs). Hardened against settings that never went through storySettingsSchema.
+// Bounded by the query, not the caller or a pack — nothing narrows it below the
+// action-plus-reply pair the classifier needs (cadence.md → User-tunable knobs). A
+// fractional or non-finite limit degrades to that floor instead of throwing or reading unbounded.
 export async function readLastTurns(
   db: DbCtx['db'],
   branchId: string,

--- a/lib/pipeline/definitions/generation-context.test.ts
+++ b/lib/pipeline/definitions/generation-context.test.ts
@@ -899,22 +899,28 @@ describe('buildGenerationContext — data source', () => {
     ])
   })
 
-  it('exposes the last two non-system turns as lastTurns', async () => {
-    // Pinned at the floor: this test is about system-row exclusion, not the
-    // widening knob (covered separately above).
-    openStory({ classifierContextEntries: 2 })
+  it('excludes system rows from lastTurns at the default window', async () => {
+    openStory()
+    // The system row sits mid-stack, inside the top-4-by-position range: a
+    // naive position-only window would pull it in over 'second'. The WHERE
+    // clause excludes it before the window is taken, so 'second' fills the
+    // fourth slot instead.
     await seedEntries([
       dbEntry(1, 'oldest'),
-      dbEntry(2, 'user turn', 'user_action'),
-      dbEntry(3, 'ai turn'),
-      dbEntry(4, 'ERROR', 'system'),
+      dbEntry(2, 'second'),
+      dbEntry(3, 'ERROR', 'system'),
+      dbEntry(4, 'third'),
+      dbEntry(5, 'fourth'),
+      dbEntry(6, 'fifth'),
     ])
 
     const context = await build({}, TEMPLATE_IDS.piggybackFallbackClassifier)
 
     expect((context.lastTurns as { content: string }[]).map((e) => e.content)).toEqual([
-      'user turn',
-      'ai turn',
+      'second',
+      'third',
+      'fourth',
+      'fifth',
     ])
   })
 
@@ -1203,6 +1209,30 @@ describe('buildGenerationContext — classifierContextEntries', () => {
     const ctx = await buildContext({
       entries: sixEntries,
       settings: storySettings({ classifierContextEntries: knob }),
+      templateId: TEMPLATE_IDS.piggybackFallbackClassifier,
+    })
+
+    expect(contentsOf(ctx)).toEqual(['e5 the action', 'e6 the reply'])
+  })
+
+  // z.number() admits a fractional knob from a hand-edited settings blob;
+  // schema-level .int() would refuse to open the story instead of degrading.
+  it('truncates a fractional knob down', async () => {
+    const ctx = await buildContext({
+      entries: sixEntries,
+      settings: storySettings({ classifierContextEntries: 3.5 }),
+      templateId: TEMPLATE_IDS.piggybackFallbackClassifier,
+    })
+
+    expect(contentsOf(ctx)).toEqual(['e4', 'e5 the action', 'e6 the reply'])
+  })
+
+  // A NaN knob must degrade to the pair, not fall through Math.max to an
+  // unbounded read of the whole branch.
+  it('degrades to the pair on a NaN knob', async () => {
+    const ctx = await buildContext({
+      entries: sixEntries,
+      settings: storySettings({ classifierContextEntries: Number.NaN }),
       templateId: TEMPLATE_IDS.piggybackFallbackClassifier,
     })
 

--- a/lib/pipeline/definitions/generation-context.test.ts
+++ b/lib/pipeline/definitions/generation-context.test.ts
@@ -900,9 +900,8 @@ describe('buildGenerationContext — data source', () => {
   })
 
   it('excludes system rows from lastTurns at both the tail and mid-stack', async () => {
-    // A system row can sit mid-stack (defensive) or at the branch tail — a
-    // failed turn's error banner, per classifier-facts.ts — and neither may
-    // consume a slot.
+    // A system row can sit mid-stack (defensive) or at the tail (a failed turn's
+    // error banner, per classifier-facts.ts) — neither may consume a slot.
     openStory({ classifierContextEntries: 4 })
     await seedEntries([
       dbEntry(1, 'oldest'),
@@ -959,8 +958,7 @@ describe('buildGenerationContext — data source', () => {
   // The group's variable set does not shrink; the query behind an unread one does.
   it('skips the reads a template never mentions, leaving the variables empty', async () => {
     openStory()
-    // Real scene state, so a read that fired is distinguishable from one that
-    // was skipped.
+    // Real scene state, so a read that fired is distinguishable from one that was skipped.
     await seedEntries([
       dbEntry(1, 'prose', 'ai_reply', {
         sceneEntities: [CHAR_ID],
@@ -984,9 +982,8 @@ describe('buildGenerationContext — data source', () => {
     expect(narrative.sceneMetadata).toMatchObject({ worldTime: 7, summary: 'a summary' })
     expect(classifier.lastTurns).toHaveLength(2)
     expect(classifier.entries).toEqual([])
-    // Its in-scene and current-location sections name sceneEntities (piggyback.md →
-    // Fallback classifier context), so the scene read fires for it too; the skipped
-    // pair is what this case turns on.
+    // Its in-scene/current-location sections name sceneEntities (piggyback.md → Fallback
+    // classifier context), so that read fires too — the skipped pair is what this case turns on.
     expect(classifier.sceneMetadata).toEqual({
       sceneEntities: ['c1'],
       currentLocationId: 'l1',
@@ -1240,9 +1237,8 @@ describe('buildGenerationContext — classifierContextEntries', () => {
     expect(contentsOf(ctx)).toEqual(['e4', 'e5 the action', 'e6 the reply'])
   })
 
-  // Defense in depth: z.number() itself already rejects NaN and Infinity, so
-  // this guards a value that reached the read site without going through
-  // storySettingsSchema at all, not one a user can produce through the app.
+  // Defense in depth: z.number() already rejects NaN/Infinity, so this guards a value that
+  // reached the read site outside storySettingsSchema — not one a user can produce via the app.
   it('degrades to the pair on a NaN knob', async () => {
     const ctx = await buildContext({
       entries: sixEntries,
@@ -1253,9 +1249,8 @@ describe('buildGenerationContext — classifierContextEntries', () => {
     expect(contentsOf(ctx)).toEqual(['e5 the action', 'e6 the reply'])
   })
 
-  // cadence.md scopes the knob to the fallback classifier. perTurnNarrative reads
-  // worldTimeDeltaBasis off the same query but never lastTurns, so it must stay at
-  // the pair however wide the knob goes.
+  // cadence.md scopes the knob to the fallback classifier; perTurnNarrative reads
+  // worldTimeDeltaBasis off the same query but never lastTurns, so it stays pinned at the pair.
   it('does not widen the narrative path, which reads the basis but not the turns', async () => {
     // A file-hoisted vi.mock (the repo's usual pattern) would cover all 71
     // tests in this file for this one case's benefit.
@@ -1271,9 +1266,8 @@ describe('buildGenerationContext — classifierContextEntries', () => {
     expect(ctx.lastTurns).toEqual([])
     expect(ctx.worldTimeDeltaBasis).toBe('sinceLastAiReply')
     expect(readLastTurnsSpy).toHaveBeenCalledTimes(1)
-    // ctx.lastTurns is gated to [] by exposure regardless of read width (see
-    // the comment on that field in generation-context.ts) — the call itself,
-    // not the exposed value, is what proves the knob stayed off this path.
+    // ctx.lastTurns is gated to [] regardless of read width (see the field comment in
+    // generation-context.ts) — the spy call, not the exposed value, is what this case proves.
     expect(readLastTurnsSpy.mock.calls.at(-1)?.[2]).toBeUndefined()
   })
 })
@@ -1329,9 +1323,8 @@ describe('buildGenerationContext — worldTimeDeltaBasis', () => {
     expect(context.worldTimeDeltaBasis).toBe('sinceLastAiReply')
   })
 
-  // perTurnNarrative's read is pinned to the floor (generation-context.ts), so
-  // only the fallback classifier's read can grow past two rows. resolveWorldTimeDeltaBasis
-  // reads only .at(-1)/.at(-2), so a wide knob on that path must still land here.
+  // perTurnNarrative's read is pinned to the floor (generation-context.ts); only the fallback
+  // classifier's read grows. resolveWorldTimeDeltaBasis reads .at(-1)/.at(-2), so it lands here.
   it('resolves the same basis on the fallback template at a wide knob', async () => {
     const context = await buildContext({
       entries: [

--- a/lib/pipeline/definitions/generation-context.test.ts
+++ b/lib/pipeline/definitions/generation-context.test.ts
@@ -959,8 +959,8 @@ describe('buildGenerationContext — data source', () => {
   // The group's variable set does not shrink; the query behind an unread one does.
   it('skips the reads a template never mentions, leaving the variables empty', async () => {
     openStory()
-    // Real scene state, or skipping the scene read would look the same as
-    // reading a row that has none.
+    // Real scene state, so a read that fired is distinguishable from one that
+    // was skipped.
     await seedEntries([
       dbEntry(1, 'prose', 'ai_reply', {
         sceneEntities: [CHAR_ID],
@@ -979,13 +979,10 @@ describe('buildGenerationContext — data source', () => {
     expect(narrative.sceneMetadata).toMatchObject({ worldTime: 7, summary: 'a summary' })
     expect(classifier.lastTurns).toHaveLength(2)
     expect(classifier.entries).toEqual([])
-    // The classifier reads no scene variable either, so its scene read is skipped.
-    expect(classifier.sceneMetadata).toEqual({
-      sceneEntities: [],
-      currentLocationId: null,
-      worldTime: 0,
-      summary: '',
-    })
+    // Its in-scene section names sceneEntities (piggyback.md → Fallback classifier
+    // context), so the scene read fires for it too; the skipped pair is what this
+    // case turns on.
+    expect(classifier.sceneMetadata).toMatchObject({ worldTime: 7, summary: 'a summary' })
     for (const key of Object.keys(narrative)) expect(classifier).toHaveProperty(key)
   })
 

--- a/lib/pipeline/definitions/generation-context.test.ts
+++ b/lib/pipeline/definitions/generation-context.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { describeCalendarVocabulary, EARTH_GREGORIAN } from '@/lib/calendar'
 import {
@@ -1193,6 +1193,12 @@ describe('buildGenerationContext — classifierContextEntries', () => {
   const contentsOf = (ctx: Record<string, unknown>): string[] =>
     (ctx.lastTurns as { content: string }[]).map((e) => e.content)
 
+  // No global restoreMocks: without this, a thrown assertion in the spy case
+  // below leaks the spy into the describe after it.
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   // cadence.md → User-tunable knobs: the knob widens the background, and the
   // fixed action-plus-reply pair is a floor it can never cut.
   it('reads the knob many trailing entries for the fallback classifier', async () => {
@@ -1244,6 +1250,8 @@ describe('buildGenerationContext — classifierContextEntries', () => {
   // worldTimeDeltaBasis off the same query but never lastTurns, so it must stay at
   // the pair however wide the knob goes.
   it('does not widen the narrative path, which reads the basis but not the turns', async () => {
+    // A file-hoisted vi.mock (the repo's usual pattern) would cover all 71
+    // tests in this file for this one case's benefit.
     const entryReads = await import('./entry-reads')
     const readLastTurnsSpy = vi.spyOn(entryReads, 'readLastTurns')
 
@@ -1255,12 +1263,11 @@ describe('buildGenerationContext — classifierContextEntries', () => {
 
     expect(ctx.lastTurns).toEqual([])
     expect(ctx.worldTimeDeltaBasis).toBe('sinceLastAiReply')
+    expect(readLastTurnsSpy).toHaveBeenCalledTimes(1)
     // ctx.lastTurns is gated to [] by exposure regardless of read width (see
     // the comment on that field in generation-context.ts) — the call itself,
     // not the exposed value, is what proves the knob stayed off this path.
     expect(readLastTurnsSpy.mock.calls.at(-1)?.[2]).toBeUndefined()
-
-    readLastTurnsSpy.mockRestore()
   })
 })
 

--- a/lib/pipeline/definitions/generation-context.test.ts
+++ b/lib/pipeline/definitions/generation-context.test.ts
@@ -900,7 +900,9 @@ describe('buildGenerationContext — data source', () => {
   })
 
   it('exposes the last two non-system turns as lastTurns', async () => {
-    openStory()
+    // Pinned at the floor: this test is about system-row exclusion, not the
+    // widening knob (covered separately above).
+    openStory({ classifierContextEntries: 2 })
     await seedEntries([
       dbEntry(1, 'oldest'),
       dbEntry(2, 'user turn', 'user_action'),
@@ -1169,6 +1171,70 @@ describe('buildGenerationContext — data source', () => {
     if (!load.ok) throw new Error('expected a context')
     expect(load.idMap).toBeInstanceOf(IdBiMap)
     expect(intermediates.idMap).toBe(load.idMap)
+  })
+})
+
+describe('buildGenerationContext — classifierContextEntries', () => {
+  const sixEntries = [
+    entry('e1', 1, 'e1 oldest'),
+    entry('e2', 2, 'e2'),
+    entry('e3', 3, 'e3'),
+    entry('e4', 4, 'e4'),
+    entry('e5', 5, 'e5 the action', 'user_action'),
+    entry('e6', 6, 'e6 the reply'),
+  ] as unknown as StoryEntry[]
+
+  const contentsOf = (ctx: Record<string, unknown>): string[] =>
+    (ctx.lastTurns as { content: string }[]).map((e) => e.content)
+
+  // cadence.md → User-tunable knobs: the knob widens the background, and the
+  // fixed action-plus-reply pair is a floor it can never cut.
+  it('reads the knob many trailing entries for the fallback classifier', async () => {
+    const ctx = await buildContext({
+      entries: sixEntries,
+      settings: storySettings({ classifierContextEntries: 4 }),
+      templateId: TEMPLATE_IDS.piggybackFallbackClassifier,
+    })
+
+    expect(contentsOf(ctx)).toEqual(['e3', 'e4', 'e5 the action', 'e6 the reply'])
+  })
+
+  it.each([0, 1, 2])('never narrows below the fixed pair at %i', async (knob) => {
+    const ctx = await buildContext({
+      entries: sixEntries,
+      settings: storySettings({ classifierContextEntries: knob }),
+      templateId: TEMPLATE_IDS.piggybackFallbackClassifier,
+    })
+
+    expect(contentsOf(ctx)).toEqual(['e5 the action', 'e6 the reply'])
+  })
+
+  function withWorldTime(row: ReturnType<typeof entry>, n: number) {
+    return { ...row, metadata: { ...(row.metadata ?? {}), worldTime: n } }
+  }
+
+  // resolveWorldTimeDeltaBasis reads only .at(-1)/.at(-2), so a wider window
+  // must not change it. perTurnNarrative reads the basis but never lastTurns,
+  // so this is the only thing widening could have broken on that path.
+  it.each([2, 8])('resolves the same worldTimeDeltaBasis at knob %i', async (knob) => {
+    // basis is 'sinceUserAction' only when the tail is a user_action, the row
+    // before it is a narrative kind, and the tail's worldTime exceeds it.
+    const timed = [
+      entry('e1', 1, 'e1'),
+      entry('e2', 2, 'e2'),
+      entry('e3', 3, 'e3'),
+      entry('e4', 4, 'e4'),
+      withWorldTime(entry('e5', 5, 'e5 reply'), 100),
+      withWorldTime(entry('e6', 6, 'e6 action', 'user_action'), 200),
+    ] as unknown as StoryEntry[]
+
+    const ctx = await buildContext({
+      entries: timed,
+      settings: storySettings({ classifierContextEntries: knob }),
+      templateId: TEMPLATE_IDS.piggybackFallbackClassifier,
+    })
+
+    expect(ctx.worldTimeDeltaBasis).toBe('sinceUserAction')
   })
 })
 

--- a/lib/pipeline/definitions/generation-context.test.ts
+++ b/lib/pipeline/definitions/generation-context.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { describeCalendarVocabulary, EARTH_GREGORIAN } from '@/lib/calendar'
 import {
@@ -899,19 +899,19 @@ describe('buildGenerationContext — data source', () => {
     ])
   })
 
-  it('excludes system rows from lastTurns at the default window', async () => {
-    openStory()
-    // The system row sits mid-stack, inside the top-4-by-position range: a
-    // naive position-only window would pull it in over 'second'. The WHERE
-    // clause excludes it before the window is taken, so 'second' fills the
-    // fourth slot instead.
+  it('excludes system rows from lastTurns at both the tail and mid-stack', async () => {
+    // A system row can sit mid-stack (defensive) or at the branch tail — a
+    // failed turn's error banner, per classifier-facts.ts — and neither may
+    // consume a slot.
+    openStory({ classifierContextEntries: 4 })
     await seedEntries([
       dbEntry(1, 'oldest'),
       dbEntry(2, 'second'),
-      dbEntry(3, 'ERROR', 'system'),
+      dbEntry(3, 'ERROR mid-stack', 'system'),
       dbEntry(4, 'third'),
       dbEntry(5, 'fourth'),
       dbEntry(6, 'fifth'),
+      dbEntry(7, 'ERROR tail', 'system'),
     ])
 
     const context = await build({}, TEMPLATE_IDS.piggybackFallbackClassifier)
@@ -1188,7 +1188,7 @@ describe('buildGenerationContext — classifierContextEntries', () => {
     entry('e4', 4, 'e4'),
     entry('e5', 5, 'e5 the action', 'user_action'),
     entry('e6', 6, 'e6 the reply'),
-  ] as unknown as StoryEntry[]
+  ] as never[]
 
   const contentsOf = (ctx: Record<string, unknown>): string[] =>
     (ctx.lastTurns as { content: string }[]).map((e) => e.content)
@@ -1227,8 +1227,9 @@ describe('buildGenerationContext — classifierContextEntries', () => {
     expect(contentsOf(ctx)).toEqual(['e4', 'e5 the action', 'e6 the reply'])
   })
 
-  // A NaN knob must degrade to the pair, not fall through Math.max to an
-  // unbounded read of the whole branch.
+  // Defense in depth: z.number() itself already rejects NaN and Infinity, so
+  // this guards a value that reached the read site without going through
+  // storySettingsSchema at all, not one a user can produce through the app.
   it('degrades to the pair on a NaN knob', async () => {
     const ctx = await buildContext({
       entries: sixEntries,
@@ -1239,32 +1240,27 @@ describe('buildGenerationContext — classifierContextEntries', () => {
     expect(contentsOf(ctx)).toEqual(['e5 the action', 'e6 the reply'])
   })
 
-  function withWorldTime(row: ReturnType<typeof entry>, n: number) {
-    return { ...row, metadata: { ...(row.metadata ?? {}), worldTime: n } }
-  }
-
-  // resolveWorldTimeDeltaBasis reads only .at(-1)/.at(-2), so a wider window
-  // must not change it. perTurnNarrative reads the basis but never lastTurns,
-  // so this is the only thing widening could have broken on that path.
-  it.each([2, 8])('resolves the same worldTimeDeltaBasis at knob %i', async (knob) => {
-    // basis is 'sinceUserAction' only when the tail is a user_action, the row
-    // before it is a narrative kind, and the tail's worldTime exceeds it.
-    const timed = [
-      entry('e1', 1, 'e1'),
-      entry('e2', 2, 'e2'),
-      entry('e3', 3, 'e3'),
-      entry('e4', 4, 'e4'),
-      withWorldTime(entry('e5', 5, 'e5 reply'), 100),
-      withWorldTime(entry('e6', 6, 'e6 action', 'user_action'), 200),
-    ] as unknown as StoryEntry[]
+  // cadence.md scopes the knob to the fallback classifier. perTurnNarrative reads
+  // worldTimeDeltaBasis off the same query but never lastTurns, so it must stay at
+  // the pair however wide the knob goes.
+  it('does not widen the narrative path, which reads the basis but not the turns', async () => {
+    const entryReads = await import('./entry-reads')
+    const readLastTurnsSpy = vi.spyOn(entryReads, 'readLastTurns')
 
     const ctx = await buildContext({
-      entries: timed,
-      settings: storySettings({ classifierContextEntries: knob }),
-      templateId: TEMPLATE_IDS.piggybackFallbackClassifier,
+      entries: sixEntries,
+      settings: storySettings({ classifierContextEntries: 6 }),
+      templateId: TEMPLATE_IDS.perTurnNarrative,
     })
 
-    expect(ctx.worldTimeDeltaBasis).toBe('sinceUserAction')
+    expect(ctx.lastTurns).toEqual([])
+    expect(ctx.worldTimeDeltaBasis).toBe('sinceLastAiReply')
+    // ctx.lastTurns is gated to [] by exposure regardless of read width (see
+    // the comment on that field in generation-context.ts) — the call itself,
+    // not the exposed value, is what proves the knob stayed off this path.
+    expect(readLastTurnsSpy.mock.calls.at(-1)?.[2]).toBeUndefined()
+
+    readLastTurnsSpy.mockRestore()
   })
 })
 
@@ -1317,5 +1313,24 @@ describe('buildGenerationContext — worldTimeDeltaBasis', () => {
       entries: [entry(1, 'ai_reply', 900), entry(2, 'user_action', 300)],
     })
     expect(context.worldTimeDeltaBasis).toBe('sinceLastAiReply')
+  })
+
+  // perTurnNarrative's read is pinned to the floor (generation-context.ts), so
+  // only the fallback classifier's read can grow past two rows. resolveWorldTimeDeltaBasis
+  // reads only .at(-1)/.at(-2), so a wide knob on that path must still land here.
+  it('resolves the same basis on the fallback template at a wide knob', async () => {
+    const context = await buildContext({
+      entries: [
+        entry(1, 'ai_reply', 10),
+        entry(2, 'user_action', 10),
+        entry(3, 'ai_reply', 20),
+        entry(4, 'user_action', 20),
+        entry(5, 'ai_reply', 100),
+        entry(6, 'user_action', 200),
+      ],
+      settings: storySettings({ classifierContextEntries: 6 }),
+      templateId: TEMPLATE_IDS.piggybackFallbackClassifier,
+    })
+    expect(context.worldTimeDeltaBasis).toBe('sinceUserAction')
   })
 })

--- a/lib/pipeline/definitions/generation-context.test.ts
+++ b/lib/pipeline/definitions/generation-context.test.ts
@@ -972,17 +972,27 @@ describe('buildGenerationContext — data source', () => {
     ])
 
     const narrative = await build()
-    const classifier = await build({}, TEMPLATE_IDS.piggybackFallbackClassifier)
+    // Seeded so the scene ids below are pinned placeholders rather than whichever
+    // order substituteIds happened to walk the context keys in.
+    const classifier = await build(
+      { idMap: seededIdMap(CHAR_ID, LOC_A) },
+      TEMPLATE_IDS.piggybackFallbackClassifier,
+    )
 
     expect(narrative.entries).toHaveLength(2)
     expect(narrative.lastTurns).toEqual([])
     expect(narrative.sceneMetadata).toMatchObject({ worldTime: 7, summary: 'a summary' })
     expect(classifier.lastTurns).toHaveLength(2)
     expect(classifier.entries).toEqual([])
-    // Its in-scene section names sceneEntities (piggyback.md → Fallback classifier
-    // context), so the scene read fires for it too; the skipped pair is what this
-    // case turns on.
-    expect(classifier.sceneMetadata).toMatchObject({ worldTime: 7, summary: 'a summary' })
+    // Its in-scene and current-location sections name sceneEntities (piggyback.md →
+    // Fallback classifier context), so the scene read fires for it too; the skipped
+    // pair is what this case turns on.
+    expect(classifier.sceneMetadata).toEqual({
+      sceneEntities: ['c1'],
+      currentLocationId: 'l1',
+      worldTime: 7,
+      summary: 'a summary',
+    })
     for (const key of Object.keys(narrative)) expect(classifier).toHaveProperty(key)
   })
 

--- a/lib/pipeline/definitions/generation-context.ts
+++ b/lib/pipeline/definitions/generation-context.ts
@@ -237,7 +237,11 @@ export async function buildGenerationContext(
   const [buffer, lastTurns, sceneSource] = await Promise.all([
     reads.has('entries') ? readPromptBuffer(ctx.db, branchId, settings) : [],
     reads.has('lastTurns') || reads.has('worldTimeDeltaBasis')
-      ? readLastTurns(ctx.db, branchId, settings.classifierContextEntries)
+      ? readLastTurns(
+          ctx.db,
+          branchId,
+          reads.has('lastTurns') ? settings.classifierContextEntries : undefined,
+        )
       : [],
     readsScene ? readSceneSource(ctx.db, branchId) : undefined,
   ])

--- a/lib/pipeline/definitions/generation-context.ts
+++ b/lib/pipeline/definitions/generation-context.ts
@@ -237,7 +237,7 @@ export async function buildGenerationContext(
   const [buffer, lastTurns, sceneSource] = await Promise.all([
     reads.has('entries') ? readPromptBuffer(ctx.db, branchId, settings) : [],
     reads.has('lastTurns') || reads.has('worldTimeDeltaBasis')
-      ? readLastTurns(ctx.db, branchId)
+      ? readLastTurns(ctx.db, branchId, settings.classifierContextEntries)
       : [],
     readsScene ? readSceneSource(ctx.db, branchId) : undefined,
   ])

--- a/lib/pipeline/definitions/per-turn-piggyback.test.ts
+++ b/lib/pipeline/definitions/per-turn-piggyback.test.ts
@@ -1044,10 +1044,8 @@ describe('per-turn-piggyback', () => {
       })
     })
 
-    // Here rather than in the template's own test file because the gating is the
-    // subject: buildGenerationContext skips the read behind a variable the template
-    // never names, so a mis-typed name yields an empty section instead of an error,
-    // and a direct renderTemplate fixture would hand the template whatever it names.
+    // Here, not the template's own test file: buildGenerationContext gates the read on a
+    // variable the template never names — mistyped, it silently empties instead of erroring.
     describe('fallback classifier context (piggyback.md → Fallback classifier context)', () => {
       const KEEP = 'loc_00000000-0000-4000-8000-0000000000a1'
       const KAEL = 'char_00000000-0000-4000-8000-000000000001'
@@ -1075,9 +1073,8 @@ describe('per-turn-piggyback', () => {
       })
 
       /**
-       * Runs the phase far enough to have rendered its prompt and returns that prompt.
-       * The classifier call is failed rather than ok so the run stops at the report the
-       * failure path yields, which is one `.next()` after the render.
+       * Renders the phase's prompt and returns it. The classifier call is mocked to fail,
+       * so the run stops at the resulting report — one `.next()` past the render.
        */
       async function renderFallbackPrompt(
         over: {

--- a/lib/pipeline/definitions/per-turn-piggyback.test.ts
+++ b/lib/pipeline/definitions/per-turn-piggyback.test.ts
@@ -6,7 +6,7 @@ import { logger, makeLogger } from '@/lib/diagnostics'
 import { IdBiMap } from '@/lib/ids'
 import { runPreflight } from '@/lib/pipeline/runtime/preflight'
 import type { Pipeline, PreflightSnapshot } from '@/lib/pipeline/types'
-import type { Candidate, EntityRow, LoreRow, RetrievalSuccess } from '@/lib/retrieval'
+import type { EntityRow, LoreRow, RetrievalSuccess } from '@/lib/retrieval'
 import { retrievalSuccess } from '@/lib/retrieval/__tests__/outcome'
 import { currentStoryStore, entitiesStore, resetAllStores } from '@/lib/stores'
 
@@ -1039,13 +1039,13 @@ describe('per-turn-piggyback', () => {
       })
     })
 
-    // The template is the drift surface: buildGenerationContext gates each read on
-    // whether the template names the variable, so a mis-typed name yields an empty
-    // section rather than an error — every case here asserts the rendered prompt.
+    // Here rather than in the template's own test file because the gating is the
+    // subject: buildGenerationContext skips the read behind a variable the template
+    // never names, so a mis-typed name yields an empty section instead of an error,
+    // and a direct renderTemplate fixture would hand the template whatever it names.
     describe('fallback classifier context (piggyback.md → Fallback classifier context)', () => {
       const KEEP = 'loc_00000000-0000-4000-8000-0000000000a1'
       const KAEL = 'char_00000000-0000-4000-8000-000000000001'
-      const MORA = 'char_00000000-0000-4000-8000-000000000002'
 
       const entity = (id: string, name: string, description: string | null = null): EntityRow => ({
         id,
@@ -1069,19 +1069,6 @@ describe('per-turn-piggyback', () => {
         priority: 0,
       })
 
-      const ranked = (id: string, displayName: string, renderedText: string): Candidate => ({
-        kind: 'entity',
-        id,
-        displayName,
-        renderedText,
-        sims: [0, 0, 0],
-        vector: new Float32Array([1, 0, 0]),
-        chaptersOld: 0,
-        pinSignal: 0,
-        keywordHits: [],
-        embeddingStale: false,
-      })
-
       /**
        * Runs the phase far enough to have rendered its prompt and returns that prompt.
        * The classifier call is failed rather than ok so the run stops at the report the
@@ -1089,7 +1076,6 @@ describe('per-turn-piggyback', () => {
        */
       async function renderFallbackPrompt(
         over: {
-          definition?: unknown
           settings?: Partial<StorySettings>
           entries?: string[]
           sceneEntities?: string[]
@@ -1100,7 +1086,7 @@ describe('per-turn-piggyback', () => {
         currentStoryStore.set({
           storyId: 's1',
           branchId: 'b1',
-          definition: (over.definition ?? definition) as never,
+          definition,
           settings: baseSettings({ models: {}, ...over.settings }),
         })
         const contents = over.entries ?? ['I put the sword away.', 'The blade slides home.']
@@ -1143,7 +1129,10 @@ describe('per-turn-piggyback', () => {
           branchId: 'b1',
         }).next()
 
-        return generateStructuredMock.mock.calls.at(-1)?.[1] as string
+        // A phase that grew a yield before the render would otherwise surface as a
+        // TypeError inside toContain rather than as a failed expectation.
+        expect(generateStructuredMock).toHaveBeenCalledOnce()
+        return generateStructuredMock.mock.calls[0]![1] as string
       }
 
       it('renders the memory blocks, in-scene and location sections, and the calendar', async () => {
@@ -1166,104 +1155,6 @@ describe('per-turn-piggyback', () => {
         expect(prompt).toContain('# Relevant lore')
         expect(prompt).toContain('An exiled line.')
         expect(prompt).toContain('Calendar')
-      })
-
-      // piggyback.md: Setting, Genre and Tone steer prose style and bias an extraction
-      // call toward narrating. Neither output-format macro either — this call carries
-      // its own structured-output schema.
-      it('never renders Setting, Genre, Tone or an output-format macro', async () => {
-        const prompt = await renderFallbackPrompt({
-          definition: {
-            ...definition,
-            setting: 'SETTING-MARKER a keep on a hill',
-            genre: { label: 'Fantasy', promptBody: 'GENRE-MARKER high fantasy' },
-            tone: { label: 'Wry', promptBody: 'TONE-MARKER dry and clipped' },
-          },
-        })
-
-        expect(prompt).not.toContain('SETTING-MARKER')
-        expect(prompt).not.toContain('GENRE-MARKER')
-        expect(prompt).not.toContain('TONE-MARKER')
-        expect(prompt).not.toContain('# Setting')
-        expect(prompt).not.toContain('# Genre')
-        expect(prompt).not.toContain('# Tone')
-        expect(prompt).not.toContain('Write the next beat of the story as prose')
-        expect(prompt).not.toContain('<state>')
-      })
-
-      // piggybackFires stays false, so macro_memory_blocks brackets no ids and the roster
-      // is the sole ID source; true would also inject per-turn.ts's tagged-block-only lines.
-      it('renders memory blocks without bracketed ids and without tagged-block instructions', async () => {
-        const prompt = await renderFallbackPrompt({
-          retrieval: retrievalSuccess({
-            selected: { entities: [ranked(MORA, 'Mora', 'Mora — elsewhere.')] },
-          }),
-        })
-
-        expect(prompt).toContain('# Elsewhere in the world')
-        // The whole line, not a substring: a bracketed id would prefix it.
-        expect(prompt.split('\n').find((l) => l.includes('Mora'))).toBe('Mora — elsewhere.')
-        expect(prompt).not.toContain('include their ID (without brackets) in the trailing')
-        expect(prompt).not.toContain('Use one of these place IDs')
-      })
-
-      describe('extraction-turn marking (mandatory, not stylistic)', () => {
-        // Newline-anchored: the background sentence quotes "# This turn" by name, so a
-        // bare indexOf would find the pointer to the header rather than the header.
-        const headingAt = (prompt: string, heading: string) => prompt.indexOf(`\n${heading}\n`)
-
-        // The memory blocks are the hazard the marking exists for — older and bulkier than
-        // any tail of entries, and arriving with no framing of their own.
-        it('marks the reference sections as background', async () => {
-          const prompt = await renderFallbackPrompt({
-            retrieval: retrievalSuccess({
-              floor: { alwaysLore: [lore('lore_1', 'House Eldrin', 'An exiled line.')] },
-            }),
-          })
-
-          const backgroundAt = prompt.indexOf('the world as it stands going into that turn')
-          const loreAt = prompt.indexOf('# Relevant lore')
-          expect(backgroundAt).toBeGreaterThan(-1)
-          expect(loreAt).toBeGreaterThan(backgroundAt)
-        })
-
-        it('marks entries above the pair as background and the pair as this turn', async () => {
-          const prompt = await renderFallbackPrompt({
-            settings: { classifierContextEntries: 4 },
-            entries: ['e1 oldest', 'e2 older', 'e3 the action', 'e4 the reply'],
-          })
-
-          const earlierAt = prompt.indexOf('\n# Earlier turns')
-          const thisTurnAt = headingAt(prompt, '# This turn')
-          expect(earlierAt).toBeGreaterThan(-1)
-          expect(prompt.indexOf('e1 oldest')).toBeGreaterThan(earlierAt)
-          expect(prompt.indexOf('e2 older')).toBeGreaterThan(earlierAt)
-          expect(prompt.indexOf('e2 older')).toBeLessThan(thisTurnAt)
-          expect(prompt.indexOf('e3 the action')).toBeGreaterThan(thisTurnAt)
-          expect(prompt.indexOf('e4 the reply')).toBeGreaterThan(thisTurnAt)
-        })
-
-        // The pair is the evidence window — the user's action can carry the state change
-        // ("I put the sword away") — so it is never marked background, target or not.
-        it('omits the earlier-turns header when only the pair is present', async () => {
-          const prompt = await renderFallbackPrompt({
-            settings: { classifierContextEntries: 2 },
-            entries: ['e1 the action', 'e2 the reply'],
-          })
-
-          expect(prompt).not.toContain('# Earlier turns')
-          expect(headingAt(prompt, '# This turn')).toBeGreaterThan(-1)
-          expect(prompt).toContain('e1 the action')
-          expect(prompt).toContain('e2 the reply')
-        })
-
-        it('still marks this turn when the branch holds a single entry', async () => {
-          const prompt = await renderFallbackPrompt({ entries: ['e1 only'] })
-
-          expect(prompt).not.toContain('# Earlier turns')
-          expect(headingAt(prompt, '# This turn')).toBeGreaterThan(-1)
-          expect(prompt).toContain('e1 only')
-        })
       })
     })
   })

--- a/lib/pipeline/definitions/per-turn-piggyback.test.ts
+++ b/lib/pipeline/definitions/per-turn-piggyback.test.ts
@@ -1171,6 +1171,13 @@ describe('per-turn-piggyback', () => {
       // piggyback-fallback-classifier.test.ts. This is the builder half: only a real
       // resolveWorldTimeDeltaBasis call over the seeded pair proves the phase actually
       // supplies the variable rather than the template silently defaulting.
+      //
+      // This shape is unreachable in production: per-turn.ts always sequences narrative
+      // before this phase and awaits its ai_reply entry before resuming (orchestrator.ts),
+      // so the tail readLastTurns sees here is always ai_reply and the basis is always
+      // sinceLastAiReply in practice (generation-context.test.ts encodes the same
+      // assumption). Forcing the tail to a user_action is deliberate: the realistic shape
+      // can't discriminate — it would pass even if the builder dropped worldTimeDeltaBasis.
       it('states the sinceUserAction basis when the tail advanced time on its own action', async () => {
         const prompt = await renderFallbackPrompt({ worldTimes: [100, 200] })
 

--- a/lib/pipeline/definitions/per-turn-piggyback.test.ts
+++ b/lib/pipeline/definitions/per-turn-piggyback.test.ts
@@ -1,7 +1,12 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
 
-import { APP_SETTINGS_DEFAULTS, STORY_SETTINGS_DEFAULTS, type StorySettings } from '@/lib/db'
+import {
+  APP_SETTINGS_DEFAULTS,
+  STORY_SETTINGS_DEFAULTS,
+  type StoryEntry,
+  type StorySettings,
+} from '@/lib/db'
 import { logger, makeLogger } from '@/lib/diagnostics'
 import { IdBiMap } from '@/lib/ids'
 import { runPreflight } from '@/lib/pipeline/runtime/preflight'
@@ -1081,6 +1086,7 @@ describe('per-turn-piggyback', () => {
           sceneEntities?: string[]
           entities?: EntityRow[]
           retrieval?: RetrievalSuccess
+          kinds?: StoryEntry['kind'][]
           worldTimes?: number[]
         } = {},
       ): Promise<string> {
@@ -1091,6 +1097,10 @@ describe('per-turn-piggyback', () => {
           settings: baseSettings({ models: {}, ...over.settings }),
         })
         const contents = over.entries ?? ['I put the sword away.', 'The blade slides home.']
+        if (over.kinds && over.kinds.length !== contents.length)
+          throw new Error('kinds must have one entry per content string')
+        if (over.worldTimes && over.worldTimes.length !== contents.length)
+          throw new Error('worldTimes must have one entry per content string')
         hydrateEntries(
           phaseDb,
           'b1',
@@ -1100,16 +1110,7 @@ describe('per-turn-piggyback', () => {
                 id: `entry-${i + 1}`,
                 branchId: 'b1',
                 position: i + 1,
-                // worldTimes forces the tail to a user_action over a narrative-kind
-                // predecessor — resolveWorldTimeDeltaBasis (generation-context.ts)
-                // requires that shape before it looks at either worldTime value.
-                kind: over.worldTimes
-                  ? i === contents.length - 1
-                    ? 'user_action'
-                    : 'ai_reply'
-                  : i % 2 === 0
-                    ? 'user_action'
-                    : 'ai_reply',
+                kind: over.kinds?.[i] ?? (i % 2 === 0 ? 'user_action' : 'ai_reply'),
                 content,
                 metadata: {
                   sceneEntities: i === contents.length - 1 ? (over.sceneEntities ?? []) : [],
@@ -1167,19 +1168,13 @@ describe('per-turn-piggyback', () => {
         expect(prompt).toContain('Calendar')
       })
 
-      // The template-only half of this contract (both basis values, pure Liquid) lives in
-      // piggyback-fallback-classifier.test.ts. This is the builder half: only a real
-      // resolveWorldTimeDeltaBasis call over the seeded pair proves the phase actually
-      // supplies the variable rather than the template silently defaulting.
-      //
-      // This shape is unreachable in production: per-turn.ts always sequences narrative
-      // before this phase and awaits its ai_reply entry before resuming (orchestrator.ts),
-      // so the tail readLastTurns sees here is always ai_reply and the basis is always
-      // sinceLastAiReply in practice (generation-context.test.ts encodes the same
-      // assumption). Forcing the tail to a user_action is deliberate: the realistic shape
-      // can't discriminate — it would pass even if the builder dropped worldTimeDeltaBasis.
+      // Unreachable in production (narrative always fills the tail with ai_reply first) —
+      // forced here because the realistic shape can't discriminate a dropped variable.
       it('states the sinceUserAction basis when the tail advanced time on its own action', async () => {
-        const prompt = await renderFallbackPrompt({ worldTimes: [100, 200] })
+        const prompt = await renderFallbackPrompt({
+          kinds: ['ai_reply', 'user_action'],
+          worldTimes: [100, 200],
+        })
 
         expect(prompt).toContain("since the end of the user's action")
         expect(prompt).toContain('never negative')
@@ -2095,19 +2090,13 @@ describe('per-turn-piggyback', () => {
   })
 
   describe('fallbackClassifierSchema', () => {
-    /**
-     * Walks a `z.toJSONSchema()` result to one field's own `description`, treating
-     * 'items' as "descend into the array element schema" — so a caller can name
-     * `sceneEntities` and `visualChanges.items.text` the same way. Scoping to the
-     * exact node (rather than `toContain` over the whole serialized blob) is the
-     * point: a marker word landing in an unrelated field's describe would still
-     * pass a blob-wide check.
-     */
+    // Scoped to the exact node, not `toContain` over the blob. '[]' (not 'items') steps into
+    // the array-element schema, since 'items' is itself a real property name on transfers.
     function fieldDescription(schema: unknown, path: readonly string[]): string | undefined {
       let node: unknown = schema
       for (const key of path) {
         if (typeof node !== 'object' || node === null) return undefined
-        if (key === 'items') {
+        if (key === '[]') {
           node = (node as { items?: unknown }).items
           continue
         }
@@ -2118,18 +2107,26 @@ describe('per-turn-piggyback', () => {
       return typeof description === 'string' ? description : undefined
     }
 
-    // A schema field with no describe is a field the model never fills well. The
-    // tagged block spells these out (state-emission.ts); parity means the fallback
-    // must too — piggyback.md → Fallback classifier context.
+    // A field with no describe is one the model never fills well; parity means the
+    // fallback states it too (state-emission.ts; piggyback.md → Fallback classifier context).
     it.each([
       ['sceneEntities', ['sceneEntities'], 'present in this scene'],
       ['currentLocation', ['currentLocation'], 'place this scene happens at'],
       [
         'visualChanges[].text',
-        ['visualChanges', 'items', 'text'],
+        ['visualChanges', '[]', 'text'],
         'replaces whatever was there before',
       ],
-      ['transfers.stackables[].key', ['transfers', 'stackables', 'items', 'key'], 'Lowercase name'],
+      ['transfers.stackables[].key', ['transfers', 'stackables', '[]', 'key'], 'Lowercase name'],
+      [
+        'transfers.stackables[].amount',
+        ['transfers', 'stackables', '[]', 'amount'],
+        'not the resulting total',
+      ],
+      ['transfers.items[].to', ['transfers', 'items', '[]', 'to'], 'no other party'],
+      ['transfers.items[].from', ['transfers', 'items', '[]', 'from'], 'no other party'],
+      ['transfers.stackables[].to', ['transfers', 'stackables', '[]', 'to'], 'no other party'],
+      ['transfers.stackables[].from', ['transfers', 'stackables', '[]', 'from'], 'no other party'],
     ] as const)('describes %s', (_field, path, marker) => {
       const jsonSchema = z.toJSONSchema(fallbackClassifierSchema)
       expect(fieldDescription(jsonSchema, path)).toContain(marker)

--- a/lib/pipeline/definitions/per-turn-piggyback.test.ts
+++ b/lib/pipeline/definitions/per-turn-piggyback.test.ts
@@ -1212,8 +1212,8 @@ describe('per-turn-piggyback', () => {
         // bare indexOf would find the pointer to the header rather than the header.
         const headingAt = (prompt: string, heading: string) => prompt.indexOf(`\n${heading}\n`)
 
-        // Everything but the pair is background, the memory blocks most of all — older
-        // and bulkier than any tail of entries, and arriving with no framing of their own.
+        // The memory blocks are the hazard the marking exists for — older and bulkier than
+        // any tail of entries, and arriving with no framing of their own.
         it('marks the reference sections as background', async () => {
           const prompt = await renderFallbackPrompt({
             retrieval: retrievalSuccess({
@@ -1221,7 +1221,7 @@ describe('per-turn-piggyback', () => {
             }),
           })
 
-          const backgroundAt = prompt.indexOf('never the turn itself')
+          const backgroundAt = prompt.indexOf('the world as it stands going into that turn')
           const loreAt = prompt.indexOf('# Relevant lore')
           expect(backgroundAt).toBeGreaterThan(-1)
           expect(loreAt).toBeGreaterThan(backgroundAt)

--- a/lib/pipeline/definitions/per-turn-piggyback.test.ts
+++ b/lib/pipeline/definitions/per-turn-piggyback.test.ts
@@ -6,9 +6,12 @@ import { logger, makeLogger } from '@/lib/diagnostics'
 import { IdBiMap } from '@/lib/ids'
 import { runPreflight } from '@/lib/pipeline/runtime/preflight'
 import type { Pipeline, PreflightSnapshot } from '@/lib/pipeline/types'
+import type { Candidate, EntityRow, LoreRow, RetrievalSuccess } from '@/lib/retrieval'
+import { retrievalSuccess } from '@/lib/retrieval/__tests__/outcome'
 import { currentStoryStore, entitiesStore, resetAllStores } from '@/lib/stores'
 
 import { createPhaseDb, hydrateEntries, resetPhaseDb, type PhaseDb } from './__tests__/phase-db'
+import { RETRIEVAL_INTERMEDIATE_KEY } from './intermediates'
 import {
   fallbackClassifierSchema,
   fallbackClassifierWithSuggestionsSchema,
@@ -1033,6 +1036,234 @@ describe('per-turn-piggyback', () => {
             metadata: expect.objectContaining({ worldTime: 0 }),
           }),
         }),
+      })
+    })
+
+    // The template is the drift surface: buildGenerationContext gates each read on
+    // whether the template names the variable, so a mis-typed name yields an empty
+    // section rather than an error — every case here asserts the rendered prompt.
+    describe('fallback classifier context (piggyback.md → Fallback classifier context)', () => {
+      const KEEP = 'loc_00000000-0000-4000-8000-0000000000a1'
+      const KAEL = 'char_00000000-0000-4000-8000-000000000001'
+      const MORA = 'char_00000000-0000-4000-8000-000000000002'
+
+      const entity = (id: string, name: string, description: string | null = null): EntityRow => ({
+        id,
+        kind: 'character',
+        status: 'active',
+        injectionMode: 'auto',
+        name,
+        description,
+      })
+
+      const place = (id: string, name: string, description: string): EntityRow => ({
+        ...entity(id, name, description),
+        kind: 'location',
+      })
+
+      const lore = (id: string, title: string, body: string): LoreRow => ({
+        id,
+        title,
+        body,
+        injectionMode: 'always',
+        priority: 0,
+      })
+
+      const ranked = (id: string, displayName: string, renderedText: string): Candidate => ({
+        kind: 'entity',
+        id,
+        displayName,
+        renderedText,
+        sims: [0, 0, 0],
+        vector: new Float32Array([1, 0, 0]),
+        chaptersOld: 0,
+        pinSignal: 0,
+        keywordHits: [],
+        embeddingStale: false,
+      })
+
+      /**
+       * Runs the phase far enough to have rendered its prompt and returns that prompt.
+       * The classifier call is failed rather than ok so the run stops at the report the
+       * failure path yields, which is one `.next()` after the render.
+       */
+      async function renderFallbackPrompt(
+        over: {
+          definition?: unknown
+          settings?: Partial<StorySettings>
+          entries?: string[]
+          sceneEntities?: string[]
+          entities?: EntityRow[]
+          retrieval?: RetrievalSuccess
+        } = {},
+      ): Promise<string> {
+        currentStoryStore.set({
+          storyId: 's1',
+          branchId: 'b1',
+          definition: (over.definition ?? definition) as never,
+          settings: baseSettings({ models: {}, ...over.settings }),
+        })
+        const contents = over.entries ?? ['I put the sword away.', 'The blade slides home.']
+        hydrateEntries(
+          phaseDb,
+          'b1',
+          contents.map(
+            (content, i) =>
+              ({
+                id: `entry-${i + 1}`,
+                branchId: 'b1',
+                position: i + 1,
+                kind: i % 2 === 0 ? 'user_action' : 'ai_reply',
+                content,
+                metadata: {
+                  sceneEntities: i === contents.length - 1 ? (over.sceneEntities ?? []) : [],
+                  currentLocationId: null,
+                  worldTime: 100,
+                },
+              }) as never,
+          ),
+        )
+        entitiesStore.hydrate(
+          'b1',
+          (over.entities ?? []).map((e) => ({ branchId: 'b1', ...e })) as never[],
+        )
+
+        const intermediates: Record<string, unknown> = { idMap: new IdBiMap() }
+        if (over.retrieval) intermediates[RETRIEVAL_INTERMEDIATE_KEY] = over.retrieval
+
+        generateStructuredMock.mockResolvedValueOnce({ status: 'failed', detail: 'LLM error' })
+        await piggybackFallbackClassifierPhase({
+          actionId: 'act_1',
+          abortSignal: new AbortController().signal,
+          intermediates,
+          log: makeLogger('act_1'),
+          db: phaseDb.db,
+          runInTransaction: async () => undefined,
+          storyId: 's1',
+          branchId: 'b1',
+        }).next()
+
+        return generateStructuredMock.mock.calls.at(-1)?.[1] as string
+      }
+
+      it('renders the memory blocks, in-scene and location sections, and the calendar', async () => {
+        const prompt = await renderFallbackPrompt({
+          entities: [entity(KAEL, 'Kael', 'A courier with a stolen sigil.')],
+          sceneEntities: [KAEL],
+          retrieval: retrievalSuccess({
+            floor: {
+              currentLocation: place(KEEP, 'The Drowned Keep', 'Half sunk.'),
+              alwaysLore: [lore('lore_1', 'House Eldrin', 'An exiled line.')],
+            },
+          }),
+        })
+
+        expect(prompt).toContain('# In scene')
+        expect(prompt).toContain('A courier with a stolen sigil.')
+        expect(prompt).toContain('# Current location')
+        expect(prompt).toContain('The Drowned Keep')
+        expect(prompt).toContain('Half sunk.')
+        expect(prompt).toContain('# Relevant lore')
+        expect(prompt).toContain('An exiled line.')
+        expect(prompt).toContain('Calendar')
+      })
+
+      // piggyback.md: Setting, Genre and Tone steer prose style and bias an extraction
+      // call toward narrating. Neither output-format macro either — this call carries
+      // its own structured-output schema.
+      it('never renders Setting, Genre, Tone or an output-format macro', async () => {
+        const prompt = await renderFallbackPrompt({
+          definition: {
+            ...definition,
+            setting: 'SETTING-MARKER a keep on a hill',
+            genre: { label: 'Fantasy', promptBody: 'GENRE-MARKER high fantasy' },
+            tone: { label: 'Wry', promptBody: 'TONE-MARKER dry and clipped' },
+          },
+        })
+
+        expect(prompt).not.toContain('SETTING-MARKER')
+        expect(prompt).not.toContain('GENRE-MARKER')
+        expect(prompt).not.toContain('TONE-MARKER')
+        expect(prompt).not.toContain('# Setting')
+        expect(prompt).not.toContain('# Genre')
+        expect(prompt).not.toContain('# Tone')
+        expect(prompt).not.toContain('Write the next beat of the story as prose')
+        expect(prompt).not.toContain('<state>')
+      })
+
+      // piggybackFires stays false, so macro_memory_blocks brackets no ids and the roster
+      // is the sole ID source; true would also inject per-turn.ts's tagged-block-only lines.
+      it('renders memory blocks without bracketed ids and without tagged-block instructions', async () => {
+        const prompt = await renderFallbackPrompt({
+          retrieval: retrievalSuccess({
+            selected: { entities: [ranked(MORA, 'Mora', 'Mora — elsewhere.')] },
+          }),
+        })
+
+        expect(prompt).toContain('# Elsewhere in the world')
+        // The whole line, not a substring: a bracketed id would prefix it.
+        expect(prompt.split('\n').find((l) => l.includes('Mora'))).toBe('Mora — elsewhere.')
+        expect(prompt).not.toContain('include their ID (without brackets) in the trailing')
+        expect(prompt).not.toContain('Use one of these place IDs')
+      })
+
+      describe('extraction-turn marking (mandatory, not stylistic)', () => {
+        // Newline-anchored: the background sentence quotes "# This turn" by name, so a
+        // bare indexOf would find the pointer to the header rather than the header.
+        const headingAt = (prompt: string, heading: string) => prompt.indexOf(`\n${heading}\n`)
+
+        // Everything but the pair is background, the memory blocks most of all — older
+        // and bulkier than any tail of entries, and arriving with no framing of their own.
+        it('marks the reference sections as background', async () => {
+          const prompt = await renderFallbackPrompt({
+            retrieval: retrievalSuccess({
+              floor: { alwaysLore: [lore('lore_1', 'House Eldrin', 'An exiled line.')] },
+            }),
+          })
+
+          const backgroundAt = prompt.indexOf('never the turn itself')
+          const loreAt = prompt.indexOf('# Relevant lore')
+          expect(backgroundAt).toBeGreaterThan(-1)
+          expect(loreAt).toBeGreaterThan(backgroundAt)
+        })
+
+        it('marks entries above the pair as background and the pair as this turn', async () => {
+          const prompt = await renderFallbackPrompt({
+            settings: { classifierContextEntries: 4 },
+            entries: ['e1 oldest', 'e2 older', 'e3 the action', 'e4 the reply'],
+          })
+
+          const earlierAt = prompt.indexOf('\n# Earlier turns')
+          const thisTurnAt = headingAt(prompt, '# This turn')
+          expect(earlierAt).toBeGreaterThan(-1)
+          expect(prompt.indexOf('e1 oldest')).toBeGreaterThan(earlierAt)
+          expect(prompt.indexOf('e2 older')).toBeGreaterThan(earlierAt)
+          expect(prompt.indexOf('e2 older')).toBeLessThan(thisTurnAt)
+          expect(prompt.indexOf('e3 the action')).toBeGreaterThan(thisTurnAt)
+          expect(prompt.indexOf('e4 the reply')).toBeGreaterThan(thisTurnAt)
+        })
+
+        // The pair is the evidence window — the user's action can carry the state change
+        // ("I put the sword away") — so it is never marked background, target or not.
+        it('omits the earlier-turns header when only the pair is present', async () => {
+          const prompt = await renderFallbackPrompt({
+            settings: { classifierContextEntries: 2 },
+            entries: ['e1 the action', 'e2 the reply'],
+          })
+
+          expect(prompt).not.toContain('# Earlier turns')
+          expect(headingAt(prompt, '# This turn')).toBeGreaterThan(-1)
+          expect(prompt).toContain('e1 the action')
+          expect(prompt).toContain('e2 the reply')
+        })
+
+        it('still marks this turn when the branch holds a single entry', async () => {
+          const prompt = await renderFallbackPrompt({ entries: ['e1 only'] })
+
+          expect(prompt).not.toContain('# Earlier turns')
+          expect(headingAt(prompt, '# This turn')).toBeGreaterThan(-1)
+          expect(prompt).toContain('e1 only')
+        })
       })
     })
   })

--- a/lib/pipeline/definitions/per-turn-piggyback.test.ts
+++ b/lib/pipeline/definitions/per-turn-piggyback.test.ts
@@ -1081,6 +1081,7 @@ describe('per-turn-piggyback', () => {
           sceneEntities?: string[]
           entities?: EntityRow[]
           retrieval?: RetrievalSuccess
+          worldTimes?: number[]
         } = {},
       ): Promise<string> {
         currentStoryStore.set({
@@ -1099,12 +1100,21 @@ describe('per-turn-piggyback', () => {
                 id: `entry-${i + 1}`,
                 branchId: 'b1',
                 position: i + 1,
-                kind: i % 2 === 0 ? 'user_action' : 'ai_reply',
+                // worldTimes forces the tail to a user_action over a narrative-kind
+                // predecessor — resolveWorldTimeDeltaBasis (generation-context.ts)
+                // requires that shape before it looks at either worldTime value.
+                kind: over.worldTimes
+                  ? i === contents.length - 1
+                    ? 'user_action'
+                    : 'ai_reply'
+                  : i % 2 === 0
+                    ? 'user_action'
+                    : 'ai_reply',
                 content,
                 metadata: {
                   sceneEntities: i === contents.length - 1 ? (over.sceneEntities ?? []) : [],
                   currentLocationId: null,
-                  worldTime: 100,
+                  worldTime: over.worldTimes?.[i] ?? 100,
                 },
               }) as never,
           ),
@@ -1155,6 +1165,17 @@ describe('per-turn-piggyback', () => {
         expect(prompt).toContain('# Relevant lore')
         expect(prompt).toContain('An exiled line.')
         expect(prompt).toContain('Calendar')
+      })
+
+      // The template-only half of this contract (both basis values, pure Liquid) lives in
+      // piggyback-fallback-classifier.test.ts. This is the builder half: only a real
+      // resolveWorldTimeDeltaBasis call over the seeded pair proves the phase actually
+      // supplies the variable rather than the template silently defaulting.
+      it('states the sinceUserAction basis when the tail advanced time on its own action', async () => {
+        const prompt = await renderFallbackPrompt({ worldTimes: [100, 200] })
+
+        expect(prompt).toContain("since the end of the user's action")
+        expect(prompt).toContain('never negative')
       })
     })
   })
@@ -2067,6 +2088,53 @@ describe('per-turn-piggyback', () => {
   })
 
   describe('fallbackClassifierSchema', () => {
+    /**
+     * Walks a `z.toJSONSchema()` result to one field's own `description`, treating
+     * 'items' as "descend into the array element schema" — so a caller can name
+     * `sceneEntities` and `visualChanges.items.text` the same way. Scoping to the
+     * exact node (rather than `toContain` over the whole serialized blob) is the
+     * point: a marker word landing in an unrelated field's describe would still
+     * pass a blob-wide check.
+     */
+    function fieldDescription(schema: unknown, path: readonly string[]): string | undefined {
+      let node: unknown = schema
+      for (const key of path) {
+        if (typeof node !== 'object' || node === null) return undefined
+        if (key === 'items') {
+          node = (node as { items?: unknown }).items
+          continue
+        }
+        node = (node as { properties?: Record<string, unknown> }).properties?.[key]
+      }
+      if (typeof node !== 'object' || node === null) return undefined
+      const description = (node as { description?: unknown }).description
+      return typeof description === 'string' ? description : undefined
+    }
+
+    // A schema field with no describe is a field the model never fills well. The
+    // tagged block spells these out (state-emission.ts); parity means the fallback
+    // must too — piggyback.md → Fallback classifier context.
+    it.each([
+      ['sceneEntities', ['sceneEntities'], 'present in this scene'],
+      ['currentLocation', ['currentLocation'], 'place this scene happens at'],
+      [
+        'visualChanges[].text',
+        ['visualChanges', 'items', 'text'],
+        'replaces whatever was there before',
+      ],
+      ['transfers.stackables[].key', ['transfers', 'stackables', 'items', 'key'], 'Lowercase name'],
+    ] as const)('describes %s', (_field, path, marker) => {
+      const jsonSchema = z.toJSONSchema(fallbackClassifierSchema)
+      expect(fieldDescription(jsonSchema, path)).toContain(marker)
+    })
+
+    // The describes have to survive z.toJSONSchema — that is the only path by which
+    // they reach the provider, and it throws on a transform.
+    it('serialises to JSON schema without throwing', () => {
+      expect(() => z.toJSONSchema(fallbackClassifierSchema)).not.toThrow()
+      expect(() => z.toJSONSchema(fallbackClassifierWithSuggestionsSchema)).not.toThrow()
+    })
+
     it('describes the summary field so the description survives into the emitted JSON schema', () => {
       const jsonSchema = z.toJSONSchema(fallbackClassifierSchema)
       const summary = jsonSchema.properties?.summary

--- a/lib/pipeline/definitions/per-turn-piggyback.ts
+++ b/lib/pipeline/definitions/per-turn-piggyback.ts
@@ -46,6 +46,11 @@ export function shouldFallbackFire(outcome?: PiggybackOutcome): boolean {
 }
 
 export const fallbackClassifierSchema = z.object({
+  // More explicit than state-emission.ts's "present in this scene": this call has no
+  // narrative context of its own — it did not write the prose it is classifying — so
+  // "present" needs the physically-there-vs-mentioned distinction spelled out. Not a
+  // different definition of scene presence, the same channel-justified elaboration as
+  // currentLocation's wording below.
   sceneEntities: z
     .array(z.string())
     .describe(
@@ -55,7 +60,7 @@ export const fallbackClassifierSchema = z.object({
     .string()
     .optional()
     .describe(
-      'The ID of the place this scene happens at. Only an ID from the list above; omit it if the scene moved somewhere with no ID yet.',
+      'The ID of the place this scene happens at. Only an ID from the prompt list; omit it if the scene moved somewhere with no ID yet.',
     ),
   worldTimeDelta: z.number(),
   visualChanges: z

--- a/lib/pipeline/definitions/per-turn-piggyback.ts
+++ b/lib/pipeline/definitions/per-turn-piggyback.ts
@@ -46,15 +46,28 @@ export function shouldFallbackFire(outcome?: PiggybackOutcome): boolean {
 }
 
 export const fallbackClassifierSchema = z.object({
-  sceneEntities: z.array(z.string()),
-  currentLocation: z.string().optional(),
+  sceneEntities: z
+    .array(z.string())
+    .describe(
+      'IDs of every character and item present in this scene — physically there in the last entry, not merely mentioned or remembered.',
+    ),
+  currentLocation: z
+    .string()
+    .optional()
+    .describe(
+      'The ID of the place this scene happens at. Only an ID from the list above; omit it if the scene moved somewhere with no ID yet.',
+    ),
   worldTimeDelta: z.number(),
   visualChanges: z
     .array(
       z.object({
         id: z.string(),
         type: z.enum(VISUAL_CHANGE_TYPES),
-        text: z.string(),
+        text: z
+          .string()
+          .describe(
+            'The FULL new value for that category — this replaces whatever was there before, not a partial edit.',
+          ),
       }),
     )
     .optional(),
@@ -73,7 +86,7 @@ export const fallbackClassifierSchema = z.object({
       stackables: z
         .array(
           z.object({
-            key: z.string(),
+            key: z.string().describe('Lowercase name of the stackable, e.g. gold.'),
             amount: z.number(),
             to: z.string().optional(),
             from: z.string().optional(),
@@ -150,9 +163,8 @@ export async function* piggybackFallbackClassifierPhase(
   if (!working.ok) return working.result
   const { open, entities } = working.set
 
-  // The same read the prompt's `lastTurns` comes from, so the extracted state is
-  // written back to the row the classifier actually reasoned over rather than to
-  // whatever the reader's window happens to end on.
+  // Same query at the floor width: the read is tail-anchored, so `.at(-1)`/`.at(-2)`
+  // match the wider window the prompt was built from (generation-context.ts).
   const turns = await readLastTurns(ctx.db, ctx.branchId)
   const tail = turns.at(-1)
   if (!tail) return { status: 'completed' }

--- a/lib/pipeline/definitions/per-turn-piggyback.ts
+++ b/lib/pipeline/definitions/per-turn-piggyback.ts
@@ -45,12 +45,12 @@ export function shouldFallbackFire(outcome?: PiggybackOutcome): boolean {
   return !outcome.attempted || !outcome.succeeded
 }
 
+// Mirrors state-emission.ts's "found loose, spent on someone off-scene" — the roster
+// header's "never invent one" otherwise pulls toward a plausible-but-wrong ID instead.
+const TRANSFER_PARTY_DESCRIPTION =
+  'Omit rather than inventing a roster ID — there is no other party when something is found loose or spent on someone off-scene.'
+
 export const fallbackClassifierSchema = z.object({
-  // More explicit than state-emission.ts's "present in this scene": this call has no
-  // narrative context of its own — it did not write the prose it is classifying — so
-  // "present" needs the physically-there-vs-mentioned distinction spelled out. Not a
-  // different definition of scene presence, the same channel-justified elaboration as
-  // currentLocation's wording below.
   sceneEntities: z
     .array(z.string())
     .describe(
@@ -71,7 +71,7 @@ export const fallbackClassifierSchema = z.object({
         text: z
           .string()
           .describe(
-            'The FULL new value for that category — this replaces whatever was there before, not a partial edit.',
+            'The FULL new value for the category named in `type` — this replaces whatever was there before, not a partial edit.',
           ),
       }),
     )
@@ -83,8 +83,8 @@ export const fallbackClassifierSchema = z.object({
           z.object({
             id: z.string(),
             slot: z.enum(['equipped_items', 'inventory']),
-            to: z.string().optional(),
-            from: z.string().optional(),
+            to: z.string().optional().describe(TRANSFER_PARTY_DESCRIPTION),
+            from: z.string().optional().describe(TRANSFER_PARTY_DESCRIPTION),
           }),
         )
         .default([]),
@@ -92,9 +92,9 @@ export const fallbackClassifierSchema = z.object({
         .array(
           z.object({
             key: z.string().describe('Lowercase name of the stackable, e.g. gold.'),
-            amount: z.number(),
-            to: z.string().optional(),
-            from: z.string().optional(),
+            amount: z.number().describe('Quantity moved, not the resulting total.'),
+            to: z.string().optional().describe(TRANSFER_PARTY_DESCRIPTION),
+            from: z.string().optional().describe(TRANSFER_PARTY_DESCRIPTION),
           }),
         )
         .default([]),

--- a/lib/prompts/bundled/__snapshots__/piggyback-fallback-classifier.test.ts.snap
+++ b/lib/prompts/bundled/__snapshots__/piggyback-fallback-classifier.test.ts.snap
@@ -1,0 +1,63 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`bundled piggyback fallback classifier template > matches the recorded snapshot 1`] = `
+"Known entities, referenced only by the ID shown below in brackets — write it without the brackets, never invent one:
+- [c1] Kael (character)
+- [l1] The Drowned Keep (location)
+
+- [i9] Veilstone (item, staged)
+
+Everything from here to "# This turn" is the world as it stands going into that turn — the baseline your report starts from, not a record of anything that happened in it.
+Take the changes from the turn below; nothing above it happened this turn.
+
+# In scene
+
+## Kael
+A courier with a stolen sigil.
+
+
+# Current location
+
+The Drowned Keep: Half sunk into the marsh.
+
+# Elsewhere in the world
+
+Mora — last seen at the ford.
+
+# Relevant lore
+
+House Eldrin
+An exiled line.
+
+# What has happened
+
+The siege broke on the third night.
+
+# Active threads
+
+Find the heir
+Still open.
+
+# Earlier chapters
+
+Chapter One: the marsh road.
+
+# Calendar
+This story tracks time in days (86400 seconds per day). Tiers: month (Frostmoon and Thawmoon). Convert relative-time prose ("two days later", "the next morning") into a seconds delta using these units.
+
+# Earlier turns — how the scene got here, not the turn you report on
+
+The marsh road ended at a wall of black water.
+
+Kael went first, testing the stones.
+
+# This turn
+
+I put the sword away and raised both hands.
+
+The keep answered with a single lantern, swinging.
+
+Report the scene state as of the LAST entry above, a one-sentence summary of the turn, and up to three retrieval queries naming context you want looked up for the next turn.
+Scene state is absolute, not a delta: report the full cast present at the end of the turn, not only what changed. Read the entry before it for state the user's own action changed.
+"
+`;

--- a/lib/prompts/bundled/__snapshots__/piggyback-fallback-classifier.test.ts.snap
+++ b/lib/prompts/bundled/__snapshots__/piggyback-fallback-classifier.test.ts.snap
@@ -57,7 +57,7 @@ I put the sword away and raised both hands.
 
 The keep answered with a single lantern, swinging.
 
-Report the scene state as of the LAST entry above, the time delta, a one-sentence summary of the turn, and up to three retrieval queries naming context you want looked up for the next turn.
+Report the scene state as of the LAST entry above, the time delta, a one-sentence summary of the turn, up to three retrieval queries naming context you want looked up for the next turn, and anything else the schema asks for that this turn showed.
 Scene state is absolute, not a delta: report the full cast present at the end of the turn, not only what changed. Read the entry before it for state the user's own action changed.
 For the time delta, give seconds elapsed since the previous entry, including any time the user's action itself took (0 for a flashback or memory; never negative).
 "

--- a/lib/prompts/bundled/__snapshots__/piggyback-fallback-classifier.test.ts.snap
+++ b/lib/prompts/bundled/__snapshots__/piggyback-fallback-classifier.test.ts.snap
@@ -57,8 +57,8 @@ I put the sword away and raised both hands.
 
 The keep answered with a single lantern, swinging.
 
-Report the scene state as of the LAST entry above, a one-sentence summary of the turn, and up to three retrieval queries naming context you want looked up for the next turn.
-For the time delta, give seconds elapsed since the previous entry, including any time the user's action itself took (0 for a flashback or memory; never negative).
+Report the scene state as of the LAST entry above, the time delta, a one-sentence summary of the turn, and up to three retrieval queries naming context you want looked up for the next turn.
 Scene state is absolute, not a delta: report the full cast present at the end of the turn, not only what changed. Read the entry before it for state the user's own action changed.
+For the time delta, give seconds elapsed since the previous entry, including any time the user's action itself took (0 for a flashback or memory; never negative).
 "
 `;

--- a/lib/prompts/bundled/__snapshots__/piggyback-fallback-classifier.test.ts.snap
+++ b/lib/prompts/bundled/__snapshots__/piggyback-fallback-classifier.test.ts.snap
@@ -58,6 +58,7 @@ I put the sword away and raised both hands.
 The keep answered with a single lantern, swinging.
 
 Report the scene state as of the LAST entry above, a one-sentence summary of the turn, and up to three retrieval queries naming context you want looked up for the next turn.
+For the time delta, give seconds elapsed since the previous entry, including any time the user's action itself took (0 for a flashback or memory; never negative).
 Scene state is absolute, not a delta: report the full cast present at the end of the turn, not only what changed. Read the entry before it for state the user's own action changed.
 "
 `;

--- a/lib/prompts/bundled/piggyback-fallback-classifier.test.ts
+++ b/lib/prompts/bundled/piggyback-fallback-classifier.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from 'vitest'
+
+import { renderTemplate, TEMPLATE_IDS } from '../index'
+
+const render = (context: Record<string, unknown>) =>
+  renderTemplate(TEMPLATE_IDS.piggybackFallbackClassifier, context)
+
+/**
+ * Every bucket buildGenerationContext emits, populated. Empty rather than absent
+ * where a case does not care: the builder emits all of them on every call, so a
+ * fixture that omits one tests `nil.size > 0`, which is false for the wrong reason.
+ */
+const context = (over: Record<string, unknown> = {}) => ({
+  definition: {
+    mode: 'adventure',
+    genre: { label: 'Fantasy', promptBody: '' },
+    tone: { label: 'Wry', promptBody: '' },
+    setting: '',
+  },
+  entities: [
+    {
+      id: 'c1',
+      kind: 'character',
+      name: 'Kael',
+      description: 'A courier with a stolen sigil.',
+      status: 'active',
+      injectionMode: 'auto',
+    },
+    {
+      id: 'l1',
+      kind: 'location',
+      name: 'The Drowned Keep',
+      description: 'Half sunk into the marsh.',
+      status: 'active',
+      injectionMode: 'auto',
+    },
+    {
+      id: 'i9',
+      kind: 'item',
+      name: 'Veilstone',
+      description: '',
+      status: 'staged',
+      injectionMode: 'auto',
+    },
+  ],
+  sceneEntities: ['c1', 'l1'],
+  structuralLocation: {
+    id: 'l1',
+    kind: 'location',
+    status: 'active',
+    name: 'The Drowned Keep',
+    description: 'Half sunk into the marsh.',
+  },
+  lastTurns: [
+    { position: 1, content: 'The marsh road ended at a wall of black water.' },
+    { position: 2, content: 'Kael went first, testing the stones.' },
+    { position: 3, content: 'I put the sword away and raised both hands.' },
+    { position: 4, content: 'The keep answered with a single lantern, swinging.' },
+  ],
+  calendarVocabulary: {
+    baseUnitName: 'day',
+    secondsPerBaseUnit: 86400,
+    tiers: [{ name: 'month', labels: ['Frostmoon', 'Thawmoon'] }],
+  },
+  locationIds: [],
+  structuralActiveThreads: [
+    { id: 't1', status: 'active', title: 'Find the heir', description: 'Still open.' },
+  ],
+  structuralPinnedEntities: [],
+  structuralPinnedLore: [{ id: 'lore_1', title: 'House Eldrin', body: 'An exiled line.' }],
+  structuralPinnedThreads: [],
+  retrievedEntities: [
+    { id: 'c2', displayName: 'Mora', renderedText: 'Mora — last seen at the ford.' },
+  ],
+  retrievedLore: [],
+  retrievedHappenings: [
+    { id: 'h1', displayName: 'The siege', renderedText: 'The siege broke on the third night.' },
+  ],
+  retrievedThreads: [],
+  retrievedChapters: [
+    { id: 'ch1', displayName: 'Chapter One', renderedText: 'Chapter One: the marsh road.' },
+  ],
+  piggybackFires: false,
+  suggestionsFire: false,
+  ...over,
+})
+
+describe('bundled piggyback fallback classifier template', () => {
+  /**
+   * The template mixes trimming and non-trimming delimiters on purpose — line 21's
+   * `{% comment %}` keeps the newline that separates the marker from `# In scene`,
+   * while its siblings trim. Normalising them is a plausible tidy-up that welds a
+   * heading onto the prose above it, and every `toContain` assertion survives that,
+   * because `turn.# In scene` contains `# In scene`. Only a snapshot sees it.
+   */
+  it('matches the recorded snapshot', () => {
+    expect(render(context())).toMatchSnapshot()
+  })
+
+  // piggyback.md → Fallback classifier context: Setting, Genre and Tone steer prose
+  // style and bias an extraction call toward narrating. Neither output-format macro
+  // either — this call carries its own structured-output schema.
+  it('never renders Setting, Genre, Tone or an output-format macro', () => {
+    const prompt = render(
+      context({
+        definition: {
+          mode: 'adventure',
+          setting: 'SETTING-MARKER a keep on a hill',
+          genre: { label: 'Fantasy', promptBody: 'GENRE-MARKER high fantasy' },
+          tone: { label: 'Wry', promptBody: 'TONE-MARKER dry and clipped' },
+        },
+      }),
+    )
+
+    expect(prompt).not.toContain('SETTING-MARKER')
+    expect(prompt).not.toContain('GENRE-MARKER')
+    expect(prompt).not.toContain('TONE-MARKER')
+    expect(prompt).not.toContain('# Setting')
+    expect(prompt).not.toContain('# Genre')
+    expect(prompt).not.toContain('# Tone')
+    expect(prompt).not.toContain('Write the next beat of the story as prose')
+    expect(prompt).not.toContain('<state>')
+  })
+
+  // piggybackFires stays false on this path, so macro_memory_blocks brackets no ids and
+  // the roster is the sole ID source; true would also inject per-turn.ts's
+  // tagged-block-only lines, which instruct an emission this call does not make.
+  it('renders memory blocks without bracketed ids and without tagged-block instructions', () => {
+    const prompt = render(context())
+
+    expect(prompt).toContain('# Elsewhere in the world')
+    // The whole line, not a substring: a bracketed id would prefix it.
+    expect(prompt.split('\n').find((l) => l.includes('Mora'))).toBe('Mora — last seen at the ford.')
+    expect(prompt).not.toContain('include their ID (without brackets) in the trailing')
+    expect(prompt).not.toContain('Use one of these place IDs')
+  })
+
+  describe('extraction-turn marking (mandatory, not stylistic)', () => {
+    // Newline-anchored: the background sentence quotes "# This turn" by name, so a
+    // bare indexOf would find the pointer to the header rather than the header.
+    const headingAt = (prompt: string, heading: string) => prompt.indexOf(`\n${heading}\n`)
+
+    // The memory blocks are the hazard the marking exists for — older and bulkier than
+    // any tail of entries, and arriving with no framing of their own.
+    it('marks the reference sections as background', () => {
+      const prompt = render(context())
+
+      const backgroundAt = prompt.indexOf('the world as it stands going into that turn')
+      const loreAt = prompt.indexOf('# Relevant lore')
+      expect(backgroundAt).toBeGreaterThan(-1)
+      expect(loreAt).toBeGreaterThan(backgroundAt)
+    })
+
+    it('marks entries above the pair as background and the pair as this turn', () => {
+      const prompt = render(
+        context({
+          lastTurns: [
+            { content: 'e1 oldest' },
+            { content: 'e2 older' },
+            { content: 'e3 the action' },
+            { content: 'e4 the reply' },
+          ],
+        }),
+      )
+
+      const earlierAt = prompt.indexOf('\n# Earlier turns')
+      const thisTurnAt = headingAt(prompt, '# This turn')
+      expect(earlierAt).toBeGreaterThan(-1)
+      expect(prompt.indexOf('e1 oldest')).toBeGreaterThan(earlierAt)
+      expect(prompt.indexOf('e2 older')).toBeGreaterThan(earlierAt)
+      expect(prompt.indexOf('e2 older')).toBeLessThan(thisTurnAt)
+      expect(prompt.indexOf('e3 the action')).toBeGreaterThan(thisTurnAt)
+      expect(prompt.indexOf('e4 the reply')).toBeGreaterThan(thisTurnAt)
+    })
+
+    // The pair is the evidence window — the user's action can carry the state change
+    // ("I put the sword away") — so it is never marked background, target or not.
+    it('omits the earlier-turns header when only the pair is present', () => {
+      const prompt = render(
+        context({ lastTurns: [{ content: 'e1 the action' }, { content: 'e2 the reply' }] }),
+      )
+
+      expect(prompt).not.toContain('# Earlier turns')
+      expect(headingAt(prompt, '# This turn')).toBeGreaterThan(-1)
+      expect(prompt).toContain('e1 the action')
+      expect(prompt).toContain('e2 the reply')
+    })
+
+    it('still marks this turn when the branch holds a single entry', () => {
+      const prompt = render(context({ lastTurns: [{ content: 'e1 only' }] }))
+
+      expect(prompt).not.toContain('# Earlier turns')
+      expect(headingAt(prompt, '# This turn')).toBeGreaterThan(-1)
+      expect(prompt).toContain('e1 only')
+    })
+  })
+})

--- a/lib/prompts/bundled/piggyback-fallback-classifier.test.ts
+++ b/lib/prompts/bundled/piggyback-fallback-classifier.test.ts
@@ -82,6 +82,7 @@ const context = (over: Record<string, unknown> = {}) => ({
   ],
   piggybackFires: false,
   suggestionsFire: false,
+  worldTimeDeltaBasis: 'sinceLastAiReply',
   ...over,
 })
 
@@ -133,6 +134,21 @@ describe('bundled piggyback fallback classifier template', () => {
     expect(prompt.split('\n').find((l) => l.includes('Mora'))).toBe('Mora — last seen at the ford.')
     expect(prompt).not.toContain('include their ID (without brackets) in the trailing')
     expect(prompt).not.toContain('Use one of these place IDs')
+  })
+
+  // state-emission.ts phrases the tagged block's <world_time_delta> the same way against
+  // the same variable — parity between the two per-turn implementations means a drift
+  // here is exactly the failure this template exists to close.
+  describe('world time delta basis', () => {
+    it.each([
+      ['sinceUserAction', "since the end of the user's action"],
+      ['sinceLastAiReply', 'since the previous entry'],
+    ])('states the %s basis in the prompt', (basis, phrase) => {
+      const prompt = render(context({ worldTimeDeltaBasis: basis }))
+
+      expect(prompt).toContain(phrase)
+      expect(prompt).toContain('never negative')
+    })
   })
 
   describe('extraction-turn marking (mandatory, not stylistic)', () => {

--- a/lib/prompts/bundled/piggyback-fallback-classifier.test.ts
+++ b/lib/prompts/bundled/piggyback-fallback-classifier.test.ts
@@ -19,9 +19,8 @@ function worldTimeDeltaClause(source: string): string {
 }
 
 /**
- * Every bucket buildGenerationContext emits, populated. Empty rather than absent
- * where a case does not care: the builder emits all of them on every call, so a
- * fixture that omits one tests `nil.size > 0`, which is false for the wrong reason.
+ * Every bucket buildGenerationContext emits, kept non-empty — an omitted one would make a
+ * `nil.size > 0` assertion pass for the wrong reason.
  */
 const context = (over: Record<string, unknown> = {}) => ({
   definition: {
@@ -101,19 +100,16 @@ const context = (over: Record<string, unknown> = {}) => ({
 
 describe('bundled piggyback fallback classifier template', () => {
   /**
-   * The template mixes trimming and non-trimming delimiters on purpose — line 21's
-   * `{% comment %}` keeps the newline that separates the marker from `# In scene`,
-   * while its siblings trim. Normalising them is a plausible tidy-up that welds a
-   * heading onto the prose above it, and every `toContain` assertion survives that,
-   * because `turn.# In scene` contains `# In scene`. Only a snapshot sees it.
+   * Trimming vs. non-trimming delimiters here are intentional, not inconsistent — normalising
+   * them welds a heading onto the prose above it, and `toContain` can't catch that
+   * (`turn.# In scene` still contains `# In scene`). Only the snapshot below sees it.
    */
   it('matches the recorded snapshot', () => {
     expect(render(context())).toMatchSnapshot()
   })
 
-  // piggyback.md → Fallback classifier context: Setting, Genre and Tone steer prose
-  // style and bias an extraction call toward narrating. Neither output-format macro
-  // either — this call carries its own structured-output schema.
+  // piggyback.md → Fallback classifier context: Setting/Genre/Tone bias extraction toward
+  // narrating, so neither renders here — this call carries its own structured-output schema.
   it('never renders Setting, Genre, Tone or an output-format macro', () => {
     const prompt = render(
       context({
@@ -136,9 +132,8 @@ describe('bundled piggyback fallback classifier template', () => {
     expect(prompt).not.toContain('<state>')
   })
 
-  // piggybackFires stays false on this path, so macro_memory_blocks brackets no ids and
-  // the roster is the sole ID source; true would also inject per-turn.ts's
-  // tagged-block-only lines, which instruct an emission this call does not make.
+  // piggybackFires false → macro_memory_blocks brackets no ids (roster is the sole ID source);
+  // true would also inject per-turn.ts's tagged-block lines for an emission this never makes.
   it('renders memory blocks without bracketed ids and without tagged-block instructions', () => {
     const prompt = render(context())
 

--- a/lib/prompts/bundled/piggyback-fallback-classifier.test.ts
+++ b/lib/prompts/bundled/piggyback-fallback-classifier.test.ts
@@ -1,9 +1,22 @@
 import { describe, expect, it } from 'vitest'
 
 import { renderTemplate, TEMPLATE_IDS } from '../index'
+import { PIGGYBACK_FALLBACK_CLASSIFIER } from './piggyback-fallback-classifier'
+import { STATE_EMISSION } from './state-emission'
 
 const render = (context: Record<string, unknown>) =>
   renderTemplate(TEMPLATE_IDS.piggybackFallbackClassifier, context)
+
+// Anchored on the fixed opening/closing tokens so the mid-section — the two branches'
+// inner phrasing — is whatever the source under test actually says, not assumed.
+const WORLD_TIME_DELTA_CLAUSE =
+  /\{% if worldTimeDeltaBasis == 'sinceUserAction' %\}[\s\S]*?\{% endif %\} \(0 for a flashback or memory; never negative\)/
+
+function worldTimeDeltaClause(source: string): string {
+  const match = source.match(WORLD_TIME_DELTA_CLAUSE)
+  if (!match) throw new Error('world-time-delta clause not found in template source')
+  return match[0]
+}
 
 /**
  * Every bucket buildGenerationContext emits, populated. Empty rather than absent
@@ -136,9 +149,8 @@ describe('bundled piggyback fallback classifier template', () => {
     expect(prompt).not.toContain('Use one of these place IDs')
   })
 
-  // state-emission.ts phrases the tagged block's <world_time_delta> the same way against
-  // the same variable — parity between the two per-turn implementations means a drift
-  // here is exactly the failure this template exists to close.
+  // Builder half (a real resolveWorldTimeDeltaBasis call over a seeded turn pair) is
+  // per-turn-piggyback.test.ts; this file only proves the template renders the variable.
   describe('world time delta basis', () => {
     it.each([
       ['sinceUserAction', "since the end of the user's action"],
@@ -148,6 +160,13 @@ describe('bundled piggyback fallback classifier template', () => {
 
       expect(prompt).toContain(phrase)
       expect(prompt).toContain('never negative')
+    })
+
+    // Hand-verified against state-emission.ts across three reviews; enforce it instead.
+    it('matches state-emission.ts word for word on the world-time-delta clause', () => {
+      expect(worldTimeDeltaClause(PIGGYBACK_FALLBACK_CLASSIFIER)).toBe(
+        worldTimeDeltaClause(STATE_EMISSION),
+      )
     })
   })
 

--- a/lib/prompts/bundled/piggyback-fallback-classifier.ts
+++ b/lib/prompts/bundled/piggyback-fallback-classifier.ts
@@ -53,7 +53,7 @@ a negative offset slices from the END in Liquid — coinciding with the intended
 {%- assign pairStart = lastTurns | size | minus: 2 -%}
 {%- if pairStart < 0 -%}{%- assign pairStart = 0 -%}{%- endif -%}
 {% if pairStart > 0 -%}
-# Earlier turns — background only; do not report state from these
+# Earlier turns — how the scene got here, not the turn you report on
 {% for entry in lastTurns limit: pairStart %}
 {{ entry.content }}
 {% endfor %}
@@ -62,7 +62,8 @@ a negative offset slices from the END in Liquid — coinciding with the intended
 {% for entry in lastTurns offset: pairStart %}
 {{ entry.content }}
 {% endfor %}
-Report the scene state as of the LAST entry above, a one-sentence summary of it, and up to three retrieval queries naming context you want looked up for the next turn. Read the entry before it for state the user's own action changed.
+Report the scene state as of the LAST entry above, a one-sentence summary of the turn, and up to three retrieval queries naming context you want looked up for the next turn.
+Scene state is absolute, not a delta: report the full cast present at the end of the turn, not only what changed. Read the entry before it for state the user's own action changed.
 {% if suggestionsFire -%}
 {% include 'macro_suggestion_emission_json' %}
 {%- endif -%}`

--- a/lib/prompts/bundled/piggyback-fallback-classifier.ts
+++ b/lib/prompts/bundled/piggyback-fallback-classifier.ts
@@ -1,3 +1,5 @@
+// piggyback.md → Fallback classifier context: most of what the narrative call gets, minus
+// Setting / Genre / Tone and either output-format macro, plus the flat bracketed ID roster.
 export const PIGGYBACK_FALLBACK_CLASSIFIER = `Known entities, referenced only by the ID shown below in brackets — write it without the brackets, never invent one:
 {%- assign referenceable = entities | active -%}
 {%- assign stagedEntities = entities | staged -%}
@@ -7,13 +9,60 @@ export const PIGGYBACK_FALLBACK_CLASSIFIER = `Known entities, referenced only by
 {% for e in stagedEntities %}
 - [{{ e.id }}] {{ e.name }} ({{ e.kind }}, staged)
 {%- endfor %}
-{% if referenceable.size == 0 and stagedEntities.size == 0 %}(none){% endif %}
+{% if referenceable.size == 0 and stagedEntities.size == 0 %}(none)
+{% endif %}
+{%- comment -%}
+Marking is mandatory, not stylistic (piggyback.md): the memory blocks below are older and
+bulkier than any tail of entries, so unmarked they source state read off the wrong turn.
+{%- endcomment %}
+Everything from here to "# This turn" is reference material — background for reading the turn, never the turn itself. Do not report state from it.
 
-Extract scene state, a one-sentence summary of this turn, and up to three retrieval queries naming context you want looked up for the next turn:
+{% comment %}The second half of the condition de-dupes the row named as both in-scene and the
+location; it is nil-safe, since a null structuralLocation makes it "e.id != nil".{% endcomment -%}
+{%- assign hasScene = false -%}
+{%- for e in referenceable -%}
+{%- if sceneEntities contains e.id and e.id != structuralLocation.id -%}{%- assign hasScene = true -%}{%- endif -%}
+{%- endfor -%}
+{% if hasScene -%}
+# In scene
+{% for e in referenceable -%}
+{%- if sceneEntities contains e.id and e.id != structuralLocation.id %}
+## {{ e.name }}{% if e.description != blank %}
+{{ e.description }}{% endif %}
+{% endif -%}
+{%- endfor %}
 
-{% for entry in lastTurns %}
+{% endif -%}
+{% if structuralLocation -%}
+# Current location
+
+{{ structuralLocation.name }}{% if structuralLocation.description != blank %}: {{ structuralLocation.description }}{% endif %}
+
+{% endif -%}
+{% include 'macro_memory_blocks' -%}
+{% if calendarVocabulary -%}
+# Calendar
+This story tracks time in {{ calendarVocabulary.baseUnitName }}s ({{ calendarVocabulary.secondsPerBaseUnit }} seconds per {{ calendarVocabulary.baseUnitName }}). Tiers: {% for t in calendarVocabulary.tiers %}{{ t.name }}{% if t.labels.size > 0 %} ({{ t.labels | prose_join }}){% endif %}{% unless forloop.last %}, {% endunless %}{% endfor %}. Convert relative-time prose ("two days later", "the next morning") into a seconds delta using these units.
+
+{% endif -%}
+{%- comment -%}
+lastTurns is the knob's window over the pair (cadence.md → User-tunable knobs): the pair is
+the evidence window, the last row alone the target. Clamped because a negative offset means
+slice-from-the-end in Liquid, which would coincide with the intended rows rather than mean them.
+{%- endcomment -%}
+{%- assign pairStart = lastTurns | size | minus: 2 -%}
+{%- if pairStart < 0 -%}{%- assign pairStart = 0 -%}{%- endif -%}
+{% if pairStart > 0 -%}
+# Earlier turns — background only; do not report state from these
+{% for entry in lastTurns limit: pairStart %}
 {{ entry.content }}
 {% endfor %}
+{% endif -%}
+# This turn
+{% for entry in lastTurns offset: pairStart %}
+{{ entry.content }}
+{% endfor %}
+Report the scene state as of the LAST entry above, a one-sentence summary of it, and up to three retrieval queries naming context you want looked up for the next turn. Read the entry before it for state the user's own action changed.
 {% if suggestionsFire -%}
 {% include 'macro_suggestion_emission_json' %}
 {%- endif -%}`

--- a/lib/prompts/bundled/piggyback-fallback-classifier.ts
+++ b/lib/prompts/bundled/piggyback-fallback-classifier.ts
@@ -62,7 +62,7 @@ a negative offset slices from the END in Liquid — coinciding with the intended
 {% for entry in lastTurns offset: pairStart %}
 {{ entry.content }}
 {% endfor %}
-Report the scene state as of the LAST entry above, the time delta, a one-sentence summary of the turn, and up to three retrieval queries naming context you want looked up for the next turn.
+Report the scene state as of the LAST entry above, the time delta, a one-sentence summary of the turn, up to three retrieval queries naming context you want looked up for the next turn, and anything else the schema asks for that this turn showed.
 Scene state is absolute, not a delta: report the full cast present at the end of the turn, not only what changed. Read the entry before it for state the user's own action changed.
 For the time delta, give {% if worldTimeDeltaBasis == 'sinceUserAction' %}seconds elapsed since the end of the user's action{% else %}seconds elapsed since the previous entry, including any time the user's action itself took{% endif %} (0 for a flashback or memory; never negative).
 {% if suggestionsFire -%}

--- a/lib/prompts/bundled/piggyback-fallback-classifier.ts
+++ b/lib/prompts/bundled/piggyback-fallback-classifier.ts
@@ -62,9 +62,9 @@ a negative offset slices from the END in Liquid — coinciding with the intended
 {% for entry in lastTurns offset: pairStart %}
 {{ entry.content }}
 {% endfor %}
-Report the scene state as of the LAST entry above, a one-sentence summary of the turn, and up to three retrieval queries naming context you want looked up for the next turn.
-For the time delta, give {% if worldTimeDeltaBasis == 'sinceUserAction' %}seconds elapsed since the end of the user's action{% else %}seconds elapsed since the previous entry, including any time the user's action itself took{% endif %} (0 for a flashback or memory; never negative).
+Report the scene state as of the LAST entry above, the time delta, a one-sentence summary of the turn, and up to three retrieval queries naming context you want looked up for the next turn.
 Scene state is absolute, not a delta: report the full cast present at the end of the turn, not only what changed. Read the entry before it for state the user's own action changed.
+For the time delta, give {% if worldTimeDeltaBasis == 'sinceUserAction' %}seconds elapsed since the end of the user's action{% else %}seconds elapsed since the previous entry, including any time the user's action itself took{% endif %} (0 for a flashback or memory; never negative).
 {% if suggestionsFire -%}
 {% include 'macro_suggestion_emission_json' %}
 {%- endif -%}`

--- a/lib/prompts/bundled/piggyback-fallback-classifier.ts
+++ b/lib/prompts/bundled/piggyback-fallback-classifier.ts
@@ -47,8 +47,8 @@ This story tracks time in {{ calendarVocabulary.baseUnitName }}s ({{ calendarVoc
 
 {% endif -%}
 {%- comment -%}
-lastTurns is the knob's window over the pair (cadence.md → User-tunable knobs). Clamped because
-a negative offset slices from the END in Liquid — coinciding with the intended rows, not meaning them.
+lastTurns is the knob's window over the pair (cadence.md → User-tunable knobs). Clamped because a
+negative offset slices from the END in Liquid — coinciding with the intended rows, not meaning them.
 {%- endcomment -%}
 {%- assign pairStart = lastTurns | size | minus: 2 -%}
 {%- if pairStart < 0 -%}{%- assign pairStart = 0 -%}{%- endif -%}

--- a/lib/prompts/bundled/piggyback-fallback-classifier.ts
+++ b/lib/prompts/bundled/piggyback-fallback-classifier.ts
@@ -12,10 +12,11 @@ export const PIGGYBACK_FALLBACK_CLASSIFIER = `Known entities, referenced only by
 {% if referenceable.size == 0 and stagedEntities.size == 0 %}(none)
 {% endif %}
 {%- comment -%}
-Marking is mandatory, not stylistic (piggyback.md): the memory blocks below are older and
-bulkier than any tail of entries, so unmarked they source state read off the wrong turn.
+Marking is mandatory, not stylistic (piggyback.md), and aimed at the memory blocks: older and
+bulkier than the entries. The scene sections are the baseline, so they are framed, not fenced off.
 {%- endcomment %}
-Everything from here to "# This turn" is reference material — background for reading the turn, never the turn itself. Do not report state from it.
+Everything from here to "# This turn" is the world as it stands going into that turn — the baseline your report starts from, not a record of anything that happened in it.
+Take the changes from the turn below; nothing above it happened this turn.
 
 {% comment %}The second half of the condition de-dupes the row named as both in-scene and the
 location; it is nil-safe, since a null structuralLocation makes it "e.id != nil".{% endcomment -%}
@@ -46,9 +47,8 @@ This story tracks time in {{ calendarVocabulary.baseUnitName }}s ({{ calendarVoc
 
 {% endif -%}
 {%- comment -%}
-lastTurns is the knob's window over the pair (cadence.md → User-tunable knobs): the pair is
-the evidence window, the last row alone the target. Clamped because a negative offset means
-slice-from-the-end in Liquid, which would coincide with the intended rows rather than mean them.
+lastTurns is the knob's window over the pair (cadence.md → User-tunable knobs). Clamped because
+a negative offset slices from the END in Liquid — coinciding with the intended rows, not meaning them.
 {%- endcomment -%}
 {%- assign pairStart = lastTurns | size | minus: 2 -%}
 {%- if pairStart < 0 -%}{%- assign pairStart = 0 -%}{%- endif -%}

--- a/lib/prompts/bundled/piggyback-fallback-classifier.ts
+++ b/lib/prompts/bundled/piggyback-fallback-classifier.ts
@@ -63,6 +63,7 @@ a negative offset slices from the END in Liquid — coinciding with the intended
 {{ entry.content }}
 {% endfor %}
 Report the scene state as of the LAST entry above, a one-sentence summary of the turn, and up to three retrieval queries naming context you want looked up for the next turn.
+For the time delta, give {% if worldTimeDeltaBasis == 'sinceUserAction' %}seconds elapsed since the end of the user's action{% else %}seconds elapsed since the previous entry, including any time the user's action itself took{% endif %} (0 for a flashback or memory; never negative).
 Scene state is absolute, not a delta: report the full cast present at the end of the turn, not only what changed. Read the entry before it for state the user's own action changed.
 {% if suggestionsFire -%}
 {% include 'macro_suggestion_emission_json' %}

--- a/lib/prompts/templateContextMap.ts
+++ b/lib/prompts/templateContextMap.ts
@@ -29,7 +29,7 @@ export const VARIABLES: Record<ContextGroup, VariableDef[]> = {
       type: 'Entry[]',
       category: 'Story',
       description:
-        'The last two non-system entries, bounded by the query so neither the buffer knobs nor a template can narrow them. Which kinds they are depends on when the phase asks. Overlaps `entries` — render one or the other, not both. For per-turn classification, not for narrating.',
+        'The trailing non-system entries the per-turn classifier reads, `classifierContextEntries` many, floored at the action-plus-reply pair so neither the buffer knobs nor a template can cut below it. Which kinds they are depends on when the phase asks. Overlaps `entries` — render one or the other, not both. For per-turn classification, not for narrating.',
       required: true,
     },
     {

--- a/lib/retrieval/queries.test.ts
+++ b/lib/retrieval/queries.test.ts
@@ -205,7 +205,7 @@ describe('buildQueryStack', () => {
     const long = 'a'.repeat(260)
     const stack = buildQueryStack({ ...base, piggybackSummary: long })
 
-    // Not `.toBe(MAX_QUERY_CHARS)` — deriving the expectation from the constant
+    // Not `.toBe(MAX_LLM_QUERY_CHARS)` — deriving the expectation from the constant
     // under test passes against any value it holds. 200 is canon (retrieval.md → Q3).
     expect(stack.specs[2]?.text).toHaveLength(200)
     expect(stack.specs[2]?.text).toBe('a'.repeat(200))

--- a/lib/retrieval/queries.test.ts
+++ b/lib/retrieval/queries.test.ts
@@ -218,9 +218,8 @@ describe('buildQueryStack', () => {
     expect(stack.specs[2]?.text).toBe(summary)
   })
 
-  // Trim before cap, not after: a summary padded to 205 chars by trailing
-  // whitespace must yield its 200 content chars, not 200 minus the padding.
   it('trims before capping the summary', () => {
+    // Trim before cap, not after — slicing first would yield fewer content chars.
     const stack = buildQueryStack({
       ...base,
       piggybackSummary: `   ${'b'.repeat(210)}   `,

--- a/lib/retrieval/queries.test.ts
+++ b/lib/retrieval/queries.test.ts
@@ -200,6 +200,34 @@ describe('buildQueryStack', () => {
     const s = buildQueryStack(base)
     expect(s.embedTexts).toEqual([s.specs[0].text, s.specs[1].text])
   })
+
+  it('caps an oversized piggyback summary at the shared query length', () => {
+    const long = 'a'.repeat(260)
+    const stack = buildQueryStack({ ...base, piggybackSummary: long })
+
+    // Not `.toBe(MAX_QUERY_CHARS)` — deriving the expectation from the constant
+    // under test passes against any value it holds. 200 is canon (retrieval.md → Q3).
+    expect(stack.specs[2]?.text).toHaveLength(200)
+    expect(stack.specs[2]?.text).toBe('a'.repeat(200))
+  })
+
+  it('leaves a summary under the cap untouched', () => {
+    const summary = 'The courier crossed the marsh under storm light.'
+    const stack = buildQueryStack({ ...base, piggybackSummary: summary })
+
+    expect(stack.specs[2]?.text).toBe(summary)
+  })
+
+  // Trim before cap, not after: a summary padded to 205 chars by trailing
+  // whitespace must yield its 200 content chars, not 200 minus the padding.
+  it('trims before capping the summary', () => {
+    const stack = buildQueryStack({
+      ...base,
+      piggybackSummary: `   ${'b'.repeat(210)}   `,
+    })
+
+    expect(stack.specs[2]?.text).toBe('b'.repeat(200))
+  })
 })
 
 describe('emitted Q4 queries', () => {

--- a/lib/retrieval/queries.ts
+++ b/lib/retrieval/queries.ts
@@ -32,11 +32,11 @@ export const QUERY_SLOT_OF_SOURCE = {
 /** retrieval.md → Q4: capped at three, and the cap is a cost decision. */
 export const MAX_EMITTED_QUERIES = 3
 /**
- * retrieval.md → Q3 and Q4. One cap for both emitted slots. A retrieval ask is
- * phrase-shaped; a summary is one sentence. Query-build only — `metadata.summary`
- * and `metadata.retrievalQueries` persist uncapped for the reader.
+ * retrieval.md → Q3 and Q4, one cap for both. Q1 and Q2 are deliberately outside it.
+ * Query-build only: `metadata.summary` and `metadata.retrievalQueries` persist
+ * uncapped — the summary is a reader surface.
  */
-const MAX_QUERY_CHARS = 200
+const MAX_LLM_QUERY_CHARS = 200
 
 export type QueryStack = {
   /** Q1, Q2, Q3, then one per emitted Q4. Empty `text` means the slot is absent. */
@@ -49,6 +49,7 @@ export type QueryStack = {
 
 const trimmed = (s: string | null): string => s?.trim() ?? ''
 const nonEmpty = (s: string): boolean => s !== ''
+const queryText = (s: string | null): string => trimmed(s).slice(0, MAX_LLM_QUERY_CHARS)
 
 function structuralDigest(input: QueryStackInput): string {
   const scene = [...input.sceneEntityNames, input.currentLocationName].map(trimmed).filter(nonEmpty)
@@ -69,7 +70,7 @@ function emittedSpecs(raw: readonly string[]): QuerySpec[] {
   const seen = new Set<string>()
   const out: QuerySpec[] = []
   for (const candidate of raw) {
-    const text = candidate.trim().slice(0, MAX_QUERY_CHARS)
+    const text = queryText(candidate)
     if (text === '' || seen.has(text)) continue
     seen.add(text)
     out.push({ text, source: 'classifier_emitted' })
@@ -84,10 +85,7 @@ export function buildQueryStack(input: QueryStackInput): QueryStack {
   const specs: QuerySpec[] = [
     { text: input.userAction.trim(), source: 'user_action' },
     { text: structuralDigest(input), source: 'structural_digest' },
-    {
-      text: trimmed(input.piggybackSummary).slice(0, MAX_QUERY_CHARS),
-      source: 'piggyback_summary',
-    },
+    { text: queryText(input.piggybackSummary), source: 'piggyback_summary' },
     ...emittedSpecs(input.emittedQueries ?? []),
   ]
   const slots = specs.map((q) => QUERY_SLOT_OF_SOURCE[q.source])

--- a/lib/retrieval/queries.ts
+++ b/lib/retrieval/queries.ts
@@ -32,9 +32,8 @@ export const QUERY_SLOT_OF_SOURCE = {
 /** retrieval.md → Q4: capped at three, and the cap is a cost decision. */
 export const MAX_EMITTED_QUERIES = 3
 /**
- * retrieval.md → Q3 and Q4, one cap for both. Q1 and Q2 are deliberately outside it.
- * Query-build only: `metadata.summary` and `metadata.retrievalQueries` persist
- * uncapped — the summary is a reader surface.
+ * retrieval.md → Q3/Q4 share this cap; Q1/Q2 are deliberately exempt. Query-build only —
+ * persisted `metadata.summary`/`retrievalQueries` stay uncapped: the summary is reader-visible.
  */
 const MAX_LLM_QUERY_CHARS = 200
 

--- a/lib/retrieval/queries.ts
+++ b/lib/retrieval/queries.ts
@@ -31,8 +31,12 @@ export const QUERY_SLOT_OF_SOURCE = {
 
 /** retrieval.md → Q4: capped at three, and the cap is a cost decision. */
 export const MAX_EMITTED_QUERIES = 3
-/** retrieval.md → Q4. A retrieval ask is phrase-shaped, far under any embedder input window. */
-const MAX_EMITTED_QUERY_CHARS = 200
+/**
+ * retrieval.md → Q3 and Q4. One cap for both emitted slots. A retrieval ask is
+ * phrase-shaped; a summary is one sentence. Query-build only — `metadata.summary`
+ * and `metadata.retrievalQueries` persist uncapped for the reader.
+ */
+const MAX_QUERY_CHARS = 200
 
 export type QueryStack = {
   /** Q1, Q2, Q3, then one per emitted Q4. Empty `text` means the slot is absent. */
@@ -65,7 +69,7 @@ function emittedSpecs(raw: readonly string[]): QuerySpec[] {
   const seen = new Set<string>()
   const out: QuerySpec[] = []
   for (const candidate of raw) {
-    const text = candidate.trim().slice(0, MAX_EMITTED_QUERY_CHARS)
+    const text = candidate.trim().slice(0, MAX_QUERY_CHARS)
     if (text === '' || seen.has(text)) continue
     seen.add(text)
     out.push({ text, source: 'classifier_emitted' })
@@ -80,7 +84,10 @@ export function buildQueryStack(input: QueryStackInput): QueryStack {
   const specs: QuerySpec[] = [
     { text: input.userAction.trim(), source: 'user_action' },
     { text: structuralDigest(input), source: 'structural_digest' },
-    { text: trimmed(input.piggybackSummary), source: 'piggyback_summary' },
+    {
+      text: trimmed(input.piggybackSummary).slice(0, MAX_QUERY_CHARS),
+      source: 'piggyback_summary',
+    },
     ...emittedSpecs(input.emittedQueries ?? []),
   ]
   const slots = specs.map((q) => QUERY_SLOT_OF_SOURCE[q.source])

--- a/lib/stores/current-story/current-story.test.ts
+++ b/lib/stores/current-story/current-story.test.ts
@@ -16,6 +16,7 @@ const definition = storyDefinitionSchema.parse({
 })
 const settings = storySettingsSchema.parse({
   classifierCadence: 8,
+  classifierContextEntries: 4,
   piggybackMode: 'off',
   embeddingBackend: 'local',
   embedding_model_id: 'm',


### PR DESCRIPTION
Third and last PR of the query-stack stack. Stacked on #493, which is stacked on #490 — review those first; this diff is only its own 24 commits.

## What this closes

`piggybackMode` defaults to `'off'` and no capability-detection pipeline exists, so **the fallback classifier is what a default story runs on every turn.** #493 gave it a Q4 field — up to three retrieval queries naming context the model wants looked up next turn — but it saw only a flat entity roster and two entries. `retrieval.md → Q4` says answering it "requires seeing what the turn was already given"; `piggyback.md → Fallback classifier context` says the two per-turn implementations "are one contract with two implementations and equivalent output cannot come from strictly poorer input". It was being asked a question it could not answer well.

Now it receives the assembled memory blocks, the in-scene and current-location sections with descriptions, and the calendar vocabulary — reusing the run's stashed retrieval outcome, never a second retrieval pass. It still gets no Setting, Genre or Tone (they bias an extraction call toward narrating) and neither output-format macro. It keeps the flat bracketed roster the narrative call never has.

How far back it sees is now `classifierContextEntries` (default 4, floor 2), with migration `0013` backfilling existing stories. The floor lives inside `readLastTurns`, so no caller can cut the action-plus-reply pair — the pair is bounded because the user's action can itself carry state changes.

Six schema fields gained instructions the tagged block already had: `sceneEntities`, `currentLocation`, `visualChanges[].text`, `transfers.stackables[].key`, `stackables[].amount`, and the `to`/`from` omission rule. `worldTimeDelta`'s instruction is in the template instead, conditional on `worldTimeDeltaBasis`, because a module-scope `.describe()` is built once and cannot carry it.

## The one developer decision

**Q3's summary is capped at 200 characters, sharing one constant with Q4** (`MAX_LLM_QUERY_CHARS`), applied at query build only — `metadata.summary` is a reader surface and reaches templates as `sceneMetadata.summary`, so capping at persist would truncate what a user reads.

This was chosen, not defaulted. The recommendation was a separate, more generous ~400 cap, on the grounds that 200 binds on a legitimately long compound sentence and a summary's tail often carries the newest information. The single shared constant was chosen for the simpler contract, accepting that cost. **Please don't "fix" it back to two constants** — `retrieval.md → Q3` records the trade-off, and the probe makes the binding observable for free (a Q3 query cut at exactly 200 chars).

Q1 and Q2 remain uncapped, which is why the constant is named for the LLM-authored slots rather than the stack. Filed to triage.

## What it costs, measured

The four describes cost 91 tokens; this branch's total prompt addition is 128 per fallback call. On a realistic mid-story fixture the template went 227 → 602 tokens.

The number that matters isn't either of those. On a default story the fallback fires every turn, so **the assembled memory-block section is now sent twice per turn** — once in the narrative call, once here. That is not a constant; it is the narrative call's memory blocks doubled, scaling with the story's retrieval budgets. `piggyback.md → Capability gate` accepts this explicitly ("the alternative is a stand-in that cannot stand in") and notes it skews toward the most token-sensitive users. Landing here, recorded for the file.

## Canon

`piggyback.md → Fallback classifier context` contradicted itself: it opened calling `lastTurns` "a fixed pair" and closed saying `classifierContextEntries` controls how far the background extends. The opener predated the knob. Resolved **against canon's own other statements** — `cadence.md → User-tunable knobs`, `data-model.md`, and that section's own closing sentence all describe the pair as a floor — not against the code. Two lines changed.

The section was then audited claim by claim against the shipped template; all six hold.

## Known boundaries

- **The E2E does not assert prompt content.** If the template rendered a section empty at runtime the spec would pass, since the mock serves a canned reply regardless of prompt. Deliberate: `.claude/rules/testing.md` bars E2E from re-verifying rendering, and the wiring is unit-covered by the context builder's narrative-vs-classifier key parity check and the template's own snapshot.
- **The `sinceUserAction` branch of the delta clause is currently unreachable on this path.** The narrative phase commits its `ai_reply` before the fallback runs, so `resolveWorldTimeDeltaBasis` always returns `sinceLastAiReply`. The conditional stays for parity with `state-emission.ts`, which would matter if phase ordering changed.
- **`sceneEntities`' describe is more precise than the tagged block's** ("physically there, not merely mentioned or remembered" vs "present in this scene"). Canon's parity rule forbids the fallback being poorer, not richer, and editing the narrative prompt was out of scope — but the same precision belongs in `state-emission.ts`, for whoever next opens it.

## Filed to `triage.md`

Three cross-cutting gaps this work surfaced, none with a single owner: Q1/Q2 carrying no length cap; nothing mechanically linking a new required settings key to its backfill migration; and no bundled template exercising the scene-read gate's false branch.

## Test plan

- [x] `pnpm typecheck`, `pnpm lint`, `pnpm lint:docs` clean
- [x] `pnpm test:run` — 446 files / 4763 tests passed (both projects)
- [x] `pnpm test:e2e` — `retrieval-q4-fallback`, `retrieval-q4`, `classifier`, `turn` all pass
- [x] New E2E covers Q4 end-to-end on the fallback path at `piggybackMode: 'off'`, with three mutations proving it fails for the right reasons and a 3-run flake check
- [x] Migration 0013 tested against pre-migration blobs, corrupt blobs, and re-runs; both halves of the runtime bundle wiring asserted
- [x] Comment audit run over the range — 15 blocks compressed, no deletions, rendered prompt byte-identical (snapshot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configurable classifier context window, defaulting to four entries.
  - Expanded fallback classification context with scene, location, memory, calendar, and recent-turn details.
  - Improved fallback outputs with clearer state reporting, summaries, and retrieval queries.
- **Improvements**
  - Retrieval queries now trim summaries and classifier-generated text to 200 characters.
  - Existing story settings are updated safely to include the new context setting while preserving other values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->