### PR TITLE
plan: M4 — World + Plot read surfaces (milestone + slices)

### DIFF
--- a/docs/implementation/milestones/04-world-plot-read-surfaces/milestone.md
+++ b/docs/implementation/milestones/04-world-plot-read-surfaces/milestone.md
@@ -1,0 +1,654 @@
+# Milestone 4: World + Plot read surfaces
+
+## Goal
+
+Users can browse and edit the entity graph the memory pipeline
+produces. The World panel renders entities by kind and lore with the
+full per-kind detail composition, resolves name collisions, and
+deletes cleanly; the Plot panel renders threads and happenings with
+their involvement and awareness links; the reader gains the Browse
+rail and peek drawer that make the graph visible without leaving the
+prose; Story Settings grows from the M3 shell into the basic surface
+real data needs (model overrides, story identity, authoring aids,
+memory knobs); and every per-row kind can be imported from and
+exported to an `.avts` file. Stories made in M4 are inspectable and
+correctable by hand.
+
+## Why now
+
+M3 fills the `entities`, `lore`, `happenings`, `happening_awareness`,
+`happening_involvements`, `character_relationships` and `threads`
+tables from live traffic, and nothing renders them — the memory
+pipeline is invisible and its mistakes are uncorrectable except by
+rollback. This milestone is read-heavy with light edit: it validates
+the classifier's output against human eyes (the inspection need named
+in
+[`roadmap.md → Milestones that may merge or split`](../../roadmap.md#milestones-that-may-merge-or-split))
+and gives the user the correction surfaces canon already specifies —
+collision review, manual entity edits, delete, keyword authoring. It
+lands before chapters (M5) because chapter close compacts exactly
+these rows, and a compaction nobody can see is untestable. The build
+itself is the strongest cross-milestone look-ahead candidate in the
+roadmap: every shape it renders is frozen in
+[`data-model.md`](../../../data-model.md), and `pnpm db:seed` already
+carries thirteen entities plus lore, threads, happenings, awareness and
+relationships, so surfaces were buildable against seeds mid-M3 and
+only the definition of done waits on real classifier output.
+
+## Narrative / overview
+
+Three surfaces and one settings extension, converging on the reader.
+The **World track** is the milestone's spine.
+[Slice 4.1](./slices/01-world-shell.md) lands the World route on the
+shipped `ScreenShell` / `MasterDetailLayout` / `EntityListPane` /
+`DetailPane` shells: five-category kind dropdown, per-kind filter
+chips and accordion grouping, the four-layer entity sort and two-layer
+lore sort, category-aware search over row columns and `state` JSON,
+the four-channel row composition, the Actions menu's `GO TO` group,
+and the collision **surfacing** chrome (top-bar review pill, per-row
+strip, collapsed-accordion badge). It also owns two substrate modules
+every later surface reads: the derived-signal selectors for
+recently-classified and in-scene (C1) and the per-kind list modules
+(C2). [Slice 4.2a](./slices/02a-entity-detail.md) fills the detail
+pane for the four entity kinds — the hand-written Overview / Identity
+/ Carrying / Connections / Settings panes, the relationships
+sub-section, the per-row save session (C7), create mode, `Set as
+lead` (C5), raw JSON, and the `parent_location_id` cycle guard the
+wizard adopts too. [Slice 4.2b](./slices/02b-lore-history-delete.md)
+adds the lore detail (Body / Settings / History), the shared History
+tab module (C4) that backfills the entity History tab and later serves
+Plot, and the first delete surfaces — entity and lore — with the link
+cascade and vector sweep (C3) that the roadmap's carried deferrals
+named. [Slice 4.2c](./slices/02c-collision-review.md) wires the
+shipped `CollisionResolveDialog` to real drivers: merge, rename and
+keep-as-distinct under one `action_id`, the dialog's drifted
+`InjectionMode` and `ScalarField` unions fixed as the first step.
+
+The **Plot track** is one slice. [Slice 4.3](./slices/03-plot-panel.md)
+lands the Plot route on the same shells with the Threads / Happenings
+segment toggle, status-tier and chapter-bucket grouping, the thread and
+happening detail panes with the Involvements and Awareness editors,
+and the entry-ref picker (C8) this milestone introduces as the first
+consumer of a pattern later entry-ref surfaces reuse. The kind-aware
+entity picker is the other C8 half, owned by 4.2a and shared with
+Plot's link editors.
+
+The **settings track** extends the M3.11 shell rather than replacing
+it. [Slice 4.4](./slices/04-story-settings-basic.md) is the "basic
+surface" the roadmap deferred here: the Models tab (narrative override
+plus the five story-agent overrides over `resolveModel`), the About
+tab with the story-list `Edit info` route, the Generation tab's
+Authoring aids completed with composer modes and wrap POV (which
+brings the definitional-change confirmation for `composerWrapPov`),
+the Memory tab's chapter-close, prompt-context, classifier-cadence,
+retrieval-budget and keyword-retrieval knobs, the story-open
+embedding upgrade prompt beside `SwapResumeHost` with both `Keep`
+write sites, and the phone save-bar placement call M3.7b queued. The
+M7.2 boundary is drawn explicitly in that slice: definitional fields,
+the classifier status panel and `piggybackMode` gate, Pack, Calendar,
+Translation, Advanced and Probe stay deep.
+
+The **reader track** converges last. The roadmap entry named only a
+peek drawer, but Slice 2.5 deferred the whole Browse rail to "M4-era"
+and the reader still renders a placeholder column, and canon opens the
+peek only from rail rows — so the rail joined at promotion.
+[Slice 4.5a](./slices/05a-browse-rail.md) builds it: the
+seven-category dropdown grouped World / Plot, the rows and queries
+reused from 4.1 and 4.3 via C2, the collapsed strip dashboard with its
+per-kind classifier tint, the manual-plus-viewport state model, and
+the phone `[☰ Browse]` chip in the shell's shipped chip-strip slot
+that opens the rail as a Sheet built to morph (C10).
+[Slice 4.5b](./slices/05b-peek-drawer.md) adds the peek drawer as a
+440 px projection of 4.2a's Overview (and the lore peek), the
+`Set as lead` affordance over C5, and the `Open in panel →` route that
+lands World / Plot pre-selected (C6). The roadmap's "awareness chips
+on entries" phrase was dropped at promotion: no canonical doc specs an
+entry-level awareness affordance, and the scene chips the world-state
+panel already renders are M3.2's. Finally
+[Slice 4.6](./slices/06-import-export.md) wires the shipped
+`ImportDialog` as its first consumer — the four per-row envelope kinds
+with kind-narrowed Zod payload schemas, import actions behind the
+`[+] From JSON file…` menus on both panels, and the matching per-row
+export behind the detail-head `⋯` menus (C9). The roadmap's
+install-and-rebuild prerequisite for that slice is stale:
+`expo-document-picker` and `expo-file-system` are installed and
+already imported by the dialog; what the slice actually needs on
+native is a share / save path for export.
+
+What changes from "before" to "after": the app goes from "a memory
+pipeline whose output is visible only through the developer probe" to
+"a world the user can browse from the reader, open in its workshop,
+correct, merge, delete, and carry between stories as files." M5 then
+closes chapters over a graph the user has seen.
+
+Three deliberate M4 limits are worth naming. History tabs render
+against **raw delta-log queries** — correct but uncached; M6.4's diff
+cache upgrades the summary prose without changing the C4 contract.
+The entity **Assets tab and portrait slot ship as placeholders**:
+canon specs them, but `entry_assets` links entries only and the asset
+gallery that would give entities attachments is parked with "surfaces
+TBD" ([open question](#open-questions)). And Plot's **chapter buckets
+are seed-only until M5**: nothing opens a chapter before chapter close
+lands, so the `Current chapter` / `Earlier chapters` split and the
+`This chapter` chip render against `pnpm db:seed` fixtures and collapse
+to one implicit bucket on every real M4 story.
+
+## Slices
+
+- [Slice 4.1](./slices/01-world-shell.md) — World panel shell and
+  list pane: route, kind dropdown, filters, sort, search, rows,
+  collision surfacing chrome, `GO TO` menu group; C1 derived-signal
+  selectors, C2 list modules
+- [Slice 4.2a](./slices/02a-entity-detail.md) — entity detail: four
+  per-kind panes, relationships, save session (C7), create mode,
+  `Set as lead` (C5), raw JSON, cycle guard, entity picker (C8 half),
+  overflow menu (C11 half)
+- [Slice 4.2b](./slices/02b-lore-history-delete.md) — lore detail,
+  shared History tab module (C4), entity and lore delete with cascade
+  and vector sweep (C3)
+- [Slice 4.2c](./slices/02c-collision-review.md) — collision review
+  drivers: merge / rename / keep under one `action_id`,
+  `InjectionMode` and `ScalarField` drift fixes
+- [Slice 4.3](./slices/03-plot-panel.md) — Plot panel: threads and
+  happenings lists and details, Involvements and Awareness editors,
+  entry-ref picker (C8 half), overflow menu (C11 half)
+- [Slice 4.4](./slices/04-story-settings-basic.md) — Story Settings
+  basic surface: Models, About, Authoring aids completion, Memory
+  knobs, story-open upgrade prompt, phone save-bar call
+- [Slice 4.5a](./slices/05a-browse-rail.md) — reader Browse rail:
+  seven categories, collapsed strip, state model, phone Browse chip
+  and rail-as-Sheet (C10)
+- [Slice 4.5b](./slices/05b-peek-drawer.md) — peek drawer: Overview
+  projection, lore peek, lead affordance, `Open in panel →` (C6)
+- [Slice 4.6](./slices/06-import-export.md) — per-row `.avts` import
+  and export: envelope kinds, payload schemas (C9), `ImportDialog`
+  first wiring, native share path
+
+## Dependency graph
+
+```
+day-one: 4.1   4.3   4.4   (+ 4.6-schemas)
+
+4.1 ───→ 4.2a ───→ 4.2b ───→ 4.2c
+4.1 ┄──→ 4.2c     (partial: dialog wiring, rename and keep drivers)
+4.1 ┄──→ 4.3      (partial: C1 signals, C6 World deep link)
+4.2b ┄─→ 4.3      (partial: C3 delete arms, C4 History tab)
+4.1, 4.3 ──────→ 4.5a ───→ 4.5b
+4.2a ──────────────────────→ 4.5b   (Overview projection, C5)
+4.1, 4.3 ┄─────→ 4.6      (import hosts)
+4.2a, 4.2b, 4.3 ┄→ 4.6    (export hosts)
+```
+
+- **Day-one startable:** 4.1 (shells, stores and CRUD arms are M1.5;
+  row data from `pnpm db:seed`), 4.3 (same, plus the M3.3 happening
+  cascade), 4.4 (extends the merged M3.11 shell), and the
+  build-independent half of 4.6 — envelope kinds, payload schemas,
+  import actions, export serializer.
+- **4.1 gates 4.2a** — the detail pane is hosted in the shell, and
+  `[+] Blank` opens 4.2a's create mode (4.2b's for lore). **4.2a gates
+  4.2b** — lore detail rides the per-row save-session host C7 and the
+  `⋯` menu 4.2a establishes; the shared History module backfills
+  4.2a's placeholder tab. **4.2b gates 4.2c** — the merge driver
+  deletes the losing row through the hardened delete arm (C3: link
+  cascade, vector sweep, lead refusal). 4.2c's rename and keep drivers
+  and the dialog wiring itself need only 4.1 — a partial gate drawn
+  above — so its planning may start early; only merge waits.
+- **4.3** is day-one with two partial gates. From 4.1 it consumes the
+  C1 selectors for its row signals and the C6 World deep link its
+  Involvements and Awareness rows route to. From 4.2b it consumes the
+  C4 History module and the C3-hardened thread and happening delete
+  arms — 4.3 ships its History tab as a placeholder and its `Delete …`
+  entries present-but-disabled until 4.2b merges. Everything else —
+  shell, lists, details, editors, pickers — builds against seeds. 4.3
+  and 4.2a are a
+  [doc-as-contract](../../conventions.md#sequencing-vs-doc-as-contract)
+  pair over C7 (the per-row save-session host), C8 (the two picker
+  primitives) and C11 (the overflow-menu compound); 4.3 and 4.1 are a
+  pair over C6 (the deep-link param shape). Whichever lands first fixes
+  the names.
+- **4.5a** gates on 4.1 and 4.3 in full — it renders their row
+  renderers and calls their list queries (C2) rather than building a
+  third copy. **4.5b** gates on 4.5a (the rail hosts the peek and owns
+  the Sheet morph seam, C10) and 4.2a (the peek body is a projection of
+  the Overview component; the lead affordance calls C5). C1 and C6
+  reach 4.5b through 4.5a's gates.
+- **4.6** gates partially: the import wiring needs 4.1's and 4.3's
+  `[+]` menus to host the dialog; the export wiring needs 4.2a's,
+  4.2b's and 4.3's `⋯` menus. Those hosts ship their `From JSON file…`
+  and `Export … as JSON` entries present-but-disabled with a
+  "lands in Slice 4.6" reason, and 4.6 flips them.
+- **4.4** has no build edge in either direction. Its keyword-retrieval
+  panel is only _useful_ once 4.2a's and 4.2b's keyword editors make
+  keywords authorable (the roadmap's carried deferral asked for the two
+  to be sequenced together), so its milestone-level validation follows
+  4.2b the way M3.8's followed M3.2 — without blocking its build.
+- **The roadmap's parallel-paths sketch is superseded.** It drew
+  `{4.1, 4.2} || {4.3} || {4.4} || {4.5}` with 4.6 gated only on the
+  shells. The rail joined at promotion and consumes both panels'
+  modules, the peek projects 4.2a's Overview, and export needs the
+  detail heads, so 4.5a, 4.5b and 4.6 are converging slices here.
+
+## Slice contracts
+
+### C1 — Derived row-signal selectors
+
+[Slice 4.1](./slices/01-world-shell.md) owns one pure module that
+computes the two runtime-derived row signals every list surface
+renders, so no consumer computes its own.
+
+**Recently-classified.** Given the branch's delta rows and its latest
+entries, return `ReadonlyMap<rowId, RecentlyClassified>` — the
+shipped value union from `components/compounds/list-row.tsx`
+(`'fresh' | 'fading'`) — over every classifier-touched row across
+`entities`, `lore`, `threads` and `happenings`, plus a per-kind
+aggregate (`fresh` if any contributor is fresh, `fading` if all are
+fading, absent otherwise) for the rail strip's cells and the phone
+Browse chip. "Touched" follows
+[the accent rule](../../../ui/patterns/entity.md#recently-classified-row-accent):
+deltas whose `source` is a pipeline agent (not `user_edit`) anchored
+within the last two turns, **and** scene-presence transitions read by
+diffing `metadata.sceneEntities` / `metadata.currentLocationId`
+between the latest entry and its predecessor. Decay is pinned at two
+turns as this milestone's default; that resolves a
+[`plot.md` open question](../../../ui/screens/plot/plot.md#screen-specific-open-questions),
+so 4.1's PR amends `plot.md` to record it.
+
+**In-scene.** From the branch tail's scene triple (read through the
+reader's inherited-metadata helper, so a tail `user_action` inherits
+correctly): characters and items present in `sceneEntities`, the one
+location equal to `currentLocationId`, factions never. Returned as a
+set of row ids.
+
+Consumers: 4.1 (World rows, detail-head badge), 4.3 (Plot rows and
+badge), 4.5a (rail rows, strip cells and counts, Browse chip), 4.5b
+(peek head badge). Exact turn-boundary rule and names fixed in 4.1's
+first commit.
+
+### C2 — Per-kind list modules
+
+Two owners, one interface. [Slice 4.1](./slices/01-world-shell.md)
+owns the entity and lore modules; [Slice 4.3](./slices/03-plot-panel.md)
+owns the thread and happening modules. Every module exports the same
+shape — a `ListModule` with: a branch-scoped **query** taking
+`{ search, filter }` and returning rows in canonical order (entities:
+the
+[four-layer sort](../../../ui/patterns/entity.md#entity-list-sort-order--static-four-layer)
+with the search scope from
+[`patterns/entity.md → Search scope`](../../../ui/patterns/entity.md#search-scope);
+lore: priority then title; threads: status tier then title;
+happenings: `occurred_at` position DESC with `temporal` rows last); the
+**grouping key** the All view's accordion uses; the **filter-chip
+vocabulary**; the **search-scope copy** (placeholder, tooltip, ⓘ
+popover body); the **empty-state and no-results copy** for the kind;
+and a **row renderer** composing the shipped `ListRow` that takes the
+row plus its C1 signals (lead, in-scene, recently-classified,
+collision) as props, reads no store itself, and accepts a **density
+prop** for the rail's narrower layout. The **category label** is
+surface-owned and passed in, because canon itself diverges — World's
+dropdown says `Locations`, the rail's says `Places` — so the module
+never hardcodes it. Consumer: [Slice 4.5a](./slices/05a-browse-rail.md)
+mounts the same renderers and calls the same queries; any divergence
+is a prop, never a fork. The interface and its names are fixed by
+whichever of 4.1 / 4.3 lands first; the other conforms.
+
+### C3 — Delete arm hardening
+
+[Slice 4.2b](./slices/02b-lore-history-delete.md) owns the first
+delete surfaces and therefore the correctness of the four delete arms
+M1.5 left without a production caller. Pinned behavior, and the
+mechanism where the shipped runner forces it:
+
+- Deleting an **entity** is one `applyDeltaActionGroup` under one
+  `action_id`. The group carries **one** `updateEntity` per other
+  entity that references the id, with every affected ref field
+  (`current_location_id`, `parent_location_id`, `at_location_id`,
+  `faction_id`, `equipped_items[]`, `inventory[]`) merged into a single
+  `state` patch — the runner rejects two writes to one row's column —
+  then one `updateStoryEntryMetadata` dropping the id from the tail
+  entry's `sceneEntities` / `currentLocationId`, then the
+  `deleteEntity` whose registered `cascadeDeleteOps` removes its
+  `happening_involvements`, `happening_awareness`,
+  `character_relationships` and `translations` rows. The link and
+  translation set mirrors the merge path canon gives in
+  [`world.md → Reversibility`](../../../ui/screens/world/world.md#reversibility)
+  minus the rewrite-to-canonical half. The tail-metadata drop is this
+  milestone's **default assumption** — canon is silent on it for both
+  delete and merge — routed as an [open question](#open-questions) for
+  a `world.md` amendment.
+- Deleting the **lead character** is refused with a named rejection
+  (`lead-entity`) rather than nulling `definition.leadEntityId`, which
+  the schema's `needsLead` refine forbids in adventure or first- and
+  second-person stories; the confirm dialog explains and points at
+  `Set as lead`. The same refusal applies to a merge whose losing row
+  is the lead.
+- Deleting a **lore**, **thread** or **happening** row deletes the row
+  and its cascade. Because 4.3 makes the user a second writer of
+  `happening_involvements` and `happening_awareness`, 4.2b moves the
+  happening cascade's child read and delete into one critical section
+  under the key lock — the shipped cascade's own comment calls it safe
+  only while the classifier is the sole writer.
+- Every delete — forward, and again on **redo** — leaves zero vec0
+  rows for the id across every dim family. The sweep lives in
+  `cascadeDeleteOps` via `deleteVecOps`, because `applyRedo` rebuilds
+  a delete from the descriptor plus that hook and never re-runs the
+  handler. Reverse-replay restores the row `embedding_stale` so the
+  drain re-embeds it (already shipped).
+
+Consumers: 4.2c (the merge's losing row goes through the entity arm,
+never a bespoke delete), 4.3 (thread and happening delete — its
+entries ship disabled until 4.2b), and any later delete surface. A
+delete that bypasses the arm is a contract violation.
+
+### C4 — History tab module
+
+[Slice 4.2b](./slices/02b-lore-history-delete.md) owns the delta-log
+History tab every detail pane shares. Pinned surface: a branch-scoped
+**query** taking `{ targetTable, targetId, op?, search?, sort, cursor }`
+and returning one load-older chunk (search is `LIKE` over
+`target_table` / `op` plus `json_extract` over `undo_payload`, per
+[`world.md → History tab`](../../../ui/screens/world/world.md#history-tab));
+a **host humanizer** mapping a `deltas` row to the
+[`DeltaLogRow` props](../../../ui/patterns/delta-log-row.md#compound-api)
+— target display name resolved from the working-set stores, field
+path, a summary derived from `undo_payload` keys (the M4 interim;
+M6.4's diff cache upgrades the prose without changing this contract),
+source, relative time, `entry #n`; and a **`HistoryTab` component**
+taking `{ branchId, targetTable, targetId }` that composes search,
+op-filter chips, sort, the load-older list and the read-only empty
+state. The humanizer owns the field-path label vocabulary: a later
+slice that adds a delta-logged column (4.2c adds `nameCollisionFlag`)
+also adds its label. Consumers: 4.2b itself (entity and lore), 4.3
+(thread and happening — partial gate). Names fixed in 4.2b's first
+commit.
+
+### C5 — Story-definition lead mutator
+
+[Slice 4.2a](./slices/02a-entity-detail.md) owns the first
+post-creation writer of `stories.definition`: no such arm exists
+today — `updateStorySettings` takes settings only — so this is a new
+action, not a settings-path call. Pinned: it sets
+`definition.leadEntityId` for a story, validating that the target is a
+`kind='character'` entity on the story's current branch and that the
+result still satisfies the schema's `needsLead` refine; it writes no
+delta (`stories` is absent from `deltas.target_table`); it refuses
+while `isUserEditBlocked` holds, because both its consumers sit
+outside C7's gating; and it refreshes the current-story and stories
+stores so the reader's `You` anchor re-anchors immediately (the
+feedback canon names in
+[`reader-composer.md → Peek drawer`](../../../ui/screens/reader-composer/reader-composer.md#peek-drawer--lead-affordance-for-characters)).
+Consumers: 4.2a's `⋯ → Set as lead`, 4.5b's peek-head `Set as lead`.
+M7.2's Generation-tab lead picker is a later consumer of the same
+action. Name fixed in 4.2a's first commit.
+
+### C6 — Panel deep link with a pre-selected row
+
+[Slice 4.1](./slices/01-world-shell.md) and
+[Slice 4.3](./slices/03-plot-panel.md) own the World and Plot routes
+and are a doc-as-contract pair over this shape. Pinned: both accept an
+optional selection `{ kind, id, tab? }` in their route params; when
+present the surface mounts with that row selected, on that tab when
+given, and — on phone — directly in the detail state, with the first
+`←` returning to the list (per
+[`collapse.md → Two-pane navigation surfaces`](../../../ui/foundations/mobile/collapse.md#two-pane-navigation-surfaces-world-plot-settings)).
+Whichever route lands first fixes the param names; the other mirrors
+them. A link into a route that does not exist yet renders inert with a
+"lands in Slice 4.x" reason — 4.2a's Involvements rows until 4.3
+merges, 4.3's Involvements and Awareness rows until 4.1 merges.
+Consumers: 4.5b (`Open in panel →`, including the Overview
+region-to-tab click-through), 4.2a (Involvements → Plot happening),
+4.3 (Involvements / Awareness → World entity), 4.1's collision strip
+(`Collides with <other>`, in-surface).
+
+### C7 — Per-row save-session host for World and Plot detail panes
+
+[Slice 4.2a](./slices/02a-entity-detail.md) owns the shared hook that
+turns a detail pane into a
+[save session](../../../ui/patterns/save-sessions.md): one
+react-hook-form session per selected row; dirty state surfaces the
+shipped `SaveBar` in `DetailPane`'s `saveBar` slot with the
+user-recognizable dirty-field labels; `Cmd/Ctrl-S` saves; the session
+exposes a `requestLeave` that the surface routes every in-surface
+transition through — row switch, kind or segment switch, `←` via
+`useMasterDetailBack`, the Actions menu's `beforeNavigate` — raising
+Save / Discard / Cancel when dirty (the Story Settings precedent),
+while `useUnsavedChangesGuard` covers only what it was built for:
+navigator removal, window close and reload. Save commits every change
+as deltas under **one** `action_id` through `applyDeltaActionGroup`,
+which means a relationship row authored with both perspectives is
+**one** action — 4.2a extends the M1.5 `upsertCharacterRelationship`
+payload to carry both pov columns, since the runner rejects two
+writes to one row's column in a group. Discard resets; success fires
+the `Saved.` toast; an invalid draft disables Save and renders its
+reason in the bar's `notice` slot; every control disables with the
+principle-owned tooltip while `isUserEditBlocked(txState)` holds; and
+on phone the bar hides while the keyboard is open and returns on blur
+(per
+[`touch.md → Save bar on phone`](../../../ui/foundations/mobile/touch.md#save-bar-on-phone)
+— a `SaveBar` change 4.2a owns, which Story Settings inherits). This
+is **not** the Story Settings session from M3.11 — that one aggregates
+sections into a single settings write with no delta; this one is
+per-row and delta-logged. Consumers: 4.2b (lore pane), 4.2c (the
+relationship re-keying shape), 4.3 (thread and happening panes — a
+doc-as-contract pair with 4.2a; whichever lands first creates the hook
+and the other adopts it). Name fixed in the first commit to land.
+
+### C8 — Picker primitives: entity picker and entry-ref picker
+
+Two primitives this milestone introduces, each owned by its first
+consumer. [Slice 4.2a](./slices/02a-entity-detail.md) owns the
+**kind-aware entity picker** — an `Autocomplete` over the branch's
+entities filtered to a set of kinds, excluding given ids, returning
+an entity id — used by Connections (`current_location_id`,
+`faction_id`, `parent_location_id`, `at_location_id`), Carrying
+(`equipped_items[]`, `inventory[]`) and Relationships (characters
+minus self). [Slice 4.3](./slices/03-plot-panel.md) owns the
+**entry-ref picker** — a searchable list over the branch's entries
+returning an entry id, displaying `entry #n` plus a content excerpt —
+with two editable consumers, `occurred_at_entry_id` and
+`learned_at_entry_id` (the two thread refs render read-only per
+[`plot.md → Threads side`](../../../ui/screens/plot/plot.md#threads-side)),
+and consumes the entity picker for Involvements (kind-aware) and
+Awareness (characters). Both are controlled components taking
+`{ value, onChange, disabled, disabledReason }` and the domain filter
+as props; both present per the Select / Sheet tier rules. The
+entry-ref picker's UX is a
+[canonical open question](../../../ui/screens/plot/plot.md#screen-specific-open-questions)
+4.3 resolves at planning (see [Open questions](#open-questions)).
+Doc-as-contract between 4.2a and 4.3: whichever lands first creates
+the entity picker at this shape.
+
+### C9 — Per-row `.avts` envelope kinds and payload schemas
+
+[Slice 4.6](./slices/06-import-export.md) owns the four per-row
+formats from
+[`data-model.md → Aventuras file format`](../../../data-model.md#aventuras-file-format-avts)
+— `aventuras-entity` (payload key `entity`, a discriminated union over
+the four kinds), `aventuras-lore`, `aventuras-thread`,
+`aventuras-happening` — each with a Zod **payload schema** that
+excludes server-owned columns (`id`, `branch_id`, `embedding_stale`,
+`name_collision_flag`, timestamps) and carries the same cross-field
+refinements the row schemas enforce (happening time-anchor
+exclusivity, lore body required), an **import action** per kind that
+creates the row through the existing create arm with
+`source = 'user_edit'` and returns the new id, and an **export
+serializer** per kind producing the envelope with `formatVersion`
+`1.0`. Pinned for the hosts: World and Plot mount `ImportDialog` with
+its real props — `format`, `supportedMajor`, `payloadKey`, the
+(kind-narrowed, for entities) `schema`, `title`, and an `onValidated`
+that runs this module's import action and selects the new row — and
+the detail-head `⋯ Export … as JSON` entries call the serializer.
+Hosts own nothing about the envelope. Names fixed in 4.6's first
+commit; the host menu entries ship disabled until then.
+
+### C10 — Rail Sheet morph seam
+
+[Slice 4.5a](./slices/05a-browse-rail.md) owns the phone rail Sheet
+and builds it to morph: its host holds `{ content: 'list' | 'peek',
+size }` state, renders the rail vocabulary or a peek body from that
+state inside **one** `Sheet`, and changes the Sheet's size between the
+medium and tall detents on a content swap — never a second Sheet, per
+[`layout.md → Stacking`](../../../ui/foundations/mobile/layout.md#stacking).
+Pinned because the shipped `Sheet` primitive maps each `size` to one
+snap point and derives its keyboard behavior from it, so a runtime
+size change is primitive work 4.5b would otherwise discover after
+4.5a merged. 4.5a ships the seam with the `peek` content slot empty
+and a criterion exercising the size change; [Slice 4.5b](./slices/05b-peek-drawer.md)
+fills the slot and wires the icon-only `←`. Names fixed in 4.5a's
+first commit.
+
+### C11 — Detail-head overflow menu
+
+`DetailPane.overflowMenu` is a bare slot with no compound behind it,
+and [Slice 4.2a](./slices/02a-entity-detail.md) and
+[Slice 4.3](./slices/03-plot-panel.md) both fill it in parallel.
+Pinned: one overflow-menu compound taking an ordered list of entries
+`{ key, label, disabled?, disabledReason?, destructive?, onPress }`,
+rendering the `⋯` trigger with a Popover on desktop and tablet and a
+Sheet (short) on phone, showing a disabled entry's reason as a tooltip
+(web) or inline hint (native). The disabled-with-reason state is what
+4.2b (`Delete`), 4.2c (`Resolve →` is list-side but shares the
+convention) and 4.6 (`Export …`) later flip. Doc-as-contract between
+4.2a and 4.3: whichever lands first creates it; the other consumes.
+
+### C12 — Keyword normalizer
+
+Every user-authored write to a `keywords` column — 4.2a's entity
+Settings editor, 4.2b's lore Settings editor, 4.2c's merge union,
+4.6's import payloads — normalizes and de-duplicates through
+`normalizeTerm` from `lib/keyword-terms` (re-exported by
+`lib/retrieval/name-index.ts`), the same helper the classifier's
+append path and `matchTerms` use, so a case variant can never survive
+as a second entry and retrieval sees one vocabulary. No slice adds a
+second normalizer. Owner: none — the module is shipped; this pins its
+use.
+
+## Definition of done
+
+- **World loop, both platforms.** On Electron desktop and an Android
+  device / emulator, on a story played past one classifier cadence:
+  the World panel lists the classifier-created entities with the
+  fresh / fading tint on the rows it wrote this turn and last; opening
+  a character shows its Overview glance card with resolved location
+  and faction links; editing `description` on Identity and saving
+  writes one delta group under a single `action_id` (verified in the
+  DB); CTRL-Z in the reader reverses it; the entity's History tab
+  lists the edit and the classifier's earlier writes.
+- **Collision resolved.** On a branch with a `name_collision_flag`
+  pair (seeded by 4.1 or real): the top-bar pill reads
+  `⚠ 1 need review`, the flagged row carries the strip, and merging through `Resolve →` removes the losing row, moves its awareness and involvement
+  rows, rewrites inverse refs, clears the flag and writes everything
+  under one `action_id`; CTRL-Z restores both rows and the restored
+  loser is `embedding_stale` (vitest on the driver plus manual smoke).
+- **Delete is clean.** Deleting an entity leaves zero vec0 rows for
+  its id in every dim family, zero dangling link rows, and no trace in
+  the tail entry's `sceneEntities`; undo restores the row stale; redo
+  re-deletes and re-sweeps; deleting the lead is refused with
+  `lead-entity` (vitest over the arm; asserted in the DB).
+- **Plot audit.** On a branch with one open and one closed chapter
+  (seed fixtures until M5 opens chapters in real play), happenings
+  group into Current chapter / Earlier chapters / Out of narrative; a
+  happening's Awareness tab adds and removes a row through the
+  character picker and entry-ref picker; toggling `common_knowledge`
+  on swaps the tab for the notice; a thread is creatable from
+  `[+] Blank` and shows its status pill in the list (vitest on the
+  grouping; E2E on the awareness edit and thread creation; manual
+  smoke on the notice).
+- **Rail and peek.** On desktop the rail lists all seven categories
+  and its collapsed strip shows scene counts for characters and items;
+  clicking a row opens the peek; `Set as lead` on a non-lead character
+  re-anchors the reader's `You` badge without a confirm; the peek foot link lands World with that row selected (E2E). On phone
+  the `[☰ Browse]` chip opens the rail as a Sheet, a row tap morphs it
+  to the peek, `←` returns to the list (manual smoke on Android;
+  component test on the morph state machine).
+- **Story Settings basic.** A narrative override picked on the Models
+  tab is the model the next turn sends on the wire (asserted against
+  the mock LLM's recorded requests in E2E); `Edit info` on a story
+  card lands on About and the first `←` returns to the library (E2E);
+  enabling composer modes makes the reader's mode picker appear
+  (component test); `keywordRetrieval.mode = inject` seats a keyworded
+  lore row in the next turn's prompt (E2E via the probe capture); on
+  opening a story whose embedding model differs from the app default
+  the upgrade prompt appears once, and `Keep on the current model`
+  suppresses it until the default changes (vitest on the gate; E2E on
+  the Keep path).
+- **Import / export round trip.** Exporting an entity writes an
+  `aventuras-entity` envelope; importing it through the Characters
+  slot on another story creates the row and selects it; importing it
+  through the Locations slot surfaces a payload error with one issue
+  at `kind` (vitest on serializer, schema and import action; E2E on
+  the clipboard import path; manual smoke on the desktop file hop and
+  the Android share sheet).
+- **Cycle guard.** Setting `A.parent_location_id = B` when
+  `B.parent_location_id = A` is rejected with `parent-cycle` as a form
+  error in World and as a rejected commit in the wizard (vitest on
+  the shared guard).
+- **Hygiene.** Storybook stories exist for every compound M4
+  introduces; every new chrome string routes through `t()` in the new
+  `world` and `plot` namespaces or the existing ones; `pnpm lint`,
+  `pnpm typecheck`, `pnpm lint:docs`, and the full vitest suite pass
+  on every slice's PR; the E2E suite gains World, Plot, rail and
+  settings happy paths per
+  [`testing.md → Coverage`](../../../testing.md#coverage-thorough-not-exhaustive).
+
+## Open questions
+
+- **Entry-ref picker and `decay_resistance` UI shape.**
+  [`plot.md`](../../../ui/screens/plot/plot.md#screen-specific-open-questions)
+  leaves both open (inline recent-entries list vs searchable popover;
+  numeric vs slider vs stepped preset). They are canonical open
+  questions, not planning ones: resolve in
+  [Slice 4.3](./slices/03-plot-panel.md) planning and amend `plot.md`
+  in the same PR. If the picker wants more than a `SearchableOverlayList`
+  over entries with an excerpt, stop and run the design route.
+- **Entity Assets tab and portrait slot have no schema.**
+  [`world.md`](../../../ui/screens/world/world.md#assets-involvements-history)
+  and [`entity.md`](../../../ui/patterns/entity.md#why-portrait-lives-only-on-overview)
+  spec both, but `entry_assets` links entries only and
+  [`parked.md → Asset gallery`](../../../parked.md#asset-gallery) has
+  "surfaces TBD" for entity attachments. M4 ships the tab and slot as
+  placeholders (decided at promotion). The entity-to-asset link is a
+  data-model decision for the asset gallery pass.
+- **Tail-metadata drop on delete and merge.** C3 pins dropping a
+  deleted id from the tail entry's scene triple as a default
+  assumption; canon is silent for both paths
+  ([`world.md → Reversibility`](../../../ui/screens/world/world.md#reversibility)
+  lists the merge writes without it). 4.2b's PR amends `world.md` to
+  record the rule, or records the deviation if review rejects it.
+- **Plot chapter buckets before M5.** No chapter is opened in M4, so
+  the chapter-keyed grouping is seed-only. Default: one implicit bucket
+  and a hidden `This chapter` chip while the branch has no open
+  chapter; confirm in [Slice 4.3](./slices/03-plot-panel.md) planning.
+- **Plot detail `⋯` menu contents.** Canon names only `View raw JSON`
+  for threads and happenings. Default assumption: mirror World minus
+  `Set as lead` (`Export … as JSON`, `View raw JSON`, `Delete …`);
+  confirm in 4.3 planning and amend `plot.md`.
+- **Category label divergence.**
+  [`world.md → Top-bar`](../../../ui/screens/world/world.md#top-bar)
+  says `Locations`; [`principles.md → World / Plot split`](../../../ui/principles.md#world--plot-split--unified-panels-by-purpose)
+  gives the rail `Places`. C2 makes the label surface-owned so both
+  canon lines are honored; whether the two docs should agree is a
+  canon question for whoever touches either next.
+- **Rail manual-preference storage.** Canon calls the venue an
+  implementation detail. Default assumption: an additive
+  `app_settings.appearance.readerRailCollapsed` key, mirroring how
+  `showJumpToBottom` landed. Resolve in
+  [Slice 4.5a](./slices/05a-browse-rail.md).
+- **Phone Browse chip on a chapterless story.**
+  [`navigation.md → Reader chip strip`](../../../ui/foundations/mobile/navigation.md#reader-chip-strip-phone-only)
+  hides the whole strip, Browse chip included, until the story has a
+  chapter — which makes the rail unreachable on phone for every M4
+  story, since chapters close in M5 and the wizard-authored cast is
+  browsable from turn one. Resolve in 4.5a; likely a canon amendment.
+- **Peek quick-edits.**
+  [`save-sessions.md → Quick-edit exception`](../../../ui/patterns/save-sessions.md#quick-edit-exception--peek-drawer)
+  and [`collapse.md → Reader / composer`](../../../ui/foundations/mobile/collapse.md#reader--composer-narrative--rail--narrative--rail-strip)
+  spec pencil edits committing on blur, while
+  [`reader-composer.md → State-field composition`](../../../ui/screens/reader-composer/reader-composer.md#state-field-composition--same-as-world-panel-overview)
+  says peek is read-mostly with the lead mutation as its only inline
+  write. M4 follows the reader doc and files the pencil edits in
+  [`parked.md → Peek quick-edits`](../../../parked.md#peek-quick-edits);
+  the three docs want reconciling when that entry is picked up.
+- **4.3 sizing.** Plot is one slice because its two detail panes are
+  lighter than World's four, but it carries both picker primitives
+  and two link-table editors. If planning runs past "days, not
+  weeks," split threads from happenings at the segment boundary.

--- a/docs/implementation/milestones/04-world-plot-read-surfaces/slices/01-world-shell.md
+++ b/docs/implementation/milestones/04-world-plot-read-surfaces/slices/01-world-shell.md
@@ -1,0 +1,243 @@
+# Slice 4.1 — World panel shell + list pane
+
+## Metadata
+
+- **Milestone:** [Milestone 4 — World + Plot read surfaces](../milestone.md)
+- **Depends on:** none (day-one; the M1.5 entity and lore layers, the
+  shipped `ScreenShell` / `MasterDetailLayout` / `EntityListPane` /
+  `DetailPane` shells, and the M3.3 classifier that writes
+  `name_collision_flag` are merged prerequisites; row data comes from
+  `pnpm db:seed` until real stories exist). Doc-as-contract pair with
+  [Slice 4.3](./03-plot-panel.md) over C6 (the deep-link param shape).
+- **Blocks:** [Slice 4.2a](./02a-entity-detail.md) (detail pane host,
+  `[+] Blank`) and through it [Slice 4.2b](./02b-lore-history-delete.md)
+  (lore create mode); [Slice 4.2c](./02c-collision-review.md) (the
+  `Resolve →` hand-off — partial); [Slice 4.3](./03-plot-panel.md)
+  (C1 signals and the C6 World deep link — partial);
+  [Slice 4.5a](./05a-browse-rail.md) (row renderers and list queries —
+  C2); [Slice 4.6](./06-import-export.md) (import host — partial)
+
+## Goal
+
+The World route exists and lists the branch's entities and lore the
+way canon draws it: kind dropdown, per-kind filter chips, accordion
+grouping on the All view, the four-layer entity sort and two-layer
+lore sort, category-aware search over row columns and `state` JSON,
+four-channel rows, collision surfacing chrome, the Actions menu's
+`GO TO` group, phone collapse. The detail pane is hosted but empty — a
+placeholder until 4.2a. Two substrate modules land here because every
+later surface reads them: the derived row-signal selectors (C1) and
+the per-kind list modules (C2).
+
+## Background
+
+World is the deep-edit workshop level of the three-level entity
+surfacing (rail → peek → panel). Its shell decomposition is already
+shipped and story-covered — this slice wires, it does not build
+chrome. What it builds is the **data side** of the list pane: the
+search SQL that reaches into `entities.state` per kind with
+`json_extract` / `json_each`, the rule-driven sort with the lead
+pinned, the accordion keyed on status tier, and the per-row derived
+signals (in-scene from the tail entry's `metadata`, recently-classified
+from the delta log, collision from the flag). Collision **resolution**
+is 4.2c; this slice only makes the flag visible everywhere canon says
+it should be.
+
+## Required reading
+
+- [`world.md → Layout`](../../../../ui/screens/world/world.md#layout),
+  [`Top-bar`](../../../../ui/screens/world/world.md#top-bar),
+  [`List pane — search scope`](../../../../ui/screens/world/world.md#list-pane--search-scope),
+  [`Per-row import`](../../../../ui/screens/world/world.md#per-row-import),
+  [`List sort — lore`](../../../../ui/screens/world/world.md#list-sort--lore-static-two-layer),
+  [`List filter — lore`](../../../../ui/screens/world/world.md#list-filter--lore),
+  [`Surfacing`](../../../../ui/screens/world/world.md#surfacing) and
+  [`Mobile expression`](../../../../ui/screens/world/world.md#mobile-expression)
+  — the screen contract this slice fulfills.
+- [`patterns/entity.md → Entity row indicators`](../../../../ui/patterns/entity.md#entity-row-indicators--four-orthogonal-channels),
+  [`Entity list sort order`](../../../../ui/patterns/entity.md#entity-list-sort-order--static-four-layer),
+  [`Browse filter chips`](../../../../ui/patterns/entity.md#browse-filter-chips),
+  [`Accordion grouping on "All" view`](../../../../ui/patterns/entity.md#accordion-grouping-on-all-view),
+  [`Search scope`](../../../../ui/patterns/entity.md#search-scope)
+  (including SQLite mechanics and the ⓘ popover copy) and
+  [`Recently-classified row accent`](../../../../ui/patterns/entity.md#recently-classified-row-accent)
+  — the row-level rules, and the definition of "touched" C1 encodes.
+- [`patterns/lists.md → Search bar scope`](../../../../ui/patterns/lists.md#search-bar-scope),
+  [`Empty list / table state`](../../../../ui/patterns/lists.md#empty-list--table-state)
+  and [`No-results state`](../../../../ui/patterns/lists.md#no-results-state-search--filter-narrowed-to-zero).
+- [`patterns/data.md → Import counterparts`](../../../../ui/patterns/data.md#import-counterparts--file-based--vault)
+  — the three-option `[+]` menu this slice mounts.
+- [`patterns/collision-resolve.md → CollisionListRow`](../../../../ui/patterns/collision-resolve.md#collisionlistrow)
+  and [`Out of scope`](../../../../ui/patterns/collision-resolve.md#out-of-scope)
+  — the strip compound this slice mounts, and the pill and badge chrome
+  the pattern leaves to the screen.
+- [`patterns/generation-status-pill.md → Open items`](../../../../ui/patterns/generation-status-pill.md#open-items)
+  — the World `⚠ N need review` pill and the top-bar consumer wiring.
+- [`patterns/actions-menu.md → Curated core`](../../../../ui/patterns/actions-menu.md#curated-core)
+  and [`Contextual zone`](../../../../ui/patterns/actions-menu.md#contextual-zone)
+  — the `GO TO` group with its self-omit rule, and World's entries.
+- [`principles.md → World / Plot split`](../../../../ui/principles.md#world--plot-split--unified-panels-by-purpose),
+  [`Universal in-story chrome`](../../../../ui/principles.md#universal-in-story-chrome),
+  [`Master-detail sub-header`](../../../../ui/principles.md#master-detail-sub-header),
+  [`Breadcrumb tappability`](../../../../ui/principles.md#breadcrumb-tappability)
+  and [`Scene presence is runtime-derived`](../../../../ui/principles.md#scene-presence-is-runtime-derived-not-status).
+- [`collapse.md → Two-pane navigation surfaces`](../../../../ui/foundations/mobile/collapse.md#two-pane-navigation-surfaces-world-plot-settings),
+  [`navigation.md → Cross-surface navigation model`](../../../../ui/foundations/mobile/navigation.md#cross-surface-navigation-model)
+  and [`Stack-aware Return on mobile`](../../../../ui/foundations/mobile/navigation.md#stack-aware-return-on-mobile).
+- [`data-model.md → World-state storage`](../../../../data-model.md#world-state-storage)
+  and [`Entry metadata shape`](../../../../data-model.md#entry-metadata-shape)
+  — the `state` paths search traverses and the scene triple in-scene
+  derives from.
+- [`memory/edge-cases.md → Name collision`](../../../../memory/edge-cases.md#name-collision-and-disambiguation)
+  — where the flag comes from.
+- [Milestone contracts C1, C2, C6](../milestone.md#slice-contracts).
+
+## Scope: in
+
+- **Route and chrome:** the World route reachable from the reader's
+  in-story chrome and the Actions menu; `ScreenShell` in-story variant
+  with the `<title> / World` breadcrumb, status pill slot, chapter
+  progress strip; the master-detail sub-header
+  (`Characters / Kael`) with tappable parent segments; the
+  deep-link selection params `{ kind, id, tab? }` (C6, World half).
+- **Actions menu:** the shared `GO TO` group (`Open Reader` /
+  `Open World` / `Open Plot` / `Open Chapter Timeline` /
+  `Open Story Settings`) in `AppActionsMenu`, gated on an open story
+  and omitting the current surface — no navigation zone exists in the
+  shipped compound; 4.3 adds nothing, since its entry is in the group
+  already — plus World's contextual entries `Add entity…` /
+  `Add lore…` routing to the `[+]` menu.
+- **List pane:** `EntityListPane` with the five-category `Select`
+  dropdown (Characters / Locations / Items / Factions / Lore),
+  per-kind filter chips (`All` / `In scene` / `Active` / `Staged` /
+  `Retired`; none for lore), accordion grouping on All by status tier
+  (Active expanded, Staged and Retired collapsed, session-scoped),
+  search with the category-aware placeholder, tooltip and ⓘ popover
+  copy, per-kind empty states and the no-results line.
+- **Shell change:** `EntityListPane`'s `addAction` becomes a trigger
+  slot so the `[+]` can host an `ImporterMenu` (today it renders a bare
+  `IconAction`); 4.3 consumes the same slot.
+- **C2 modules — entities and lore:** the `ListModule` interface and
+  its two World instances — list query (LIKE over `name` /
+  `description` / `tags` / `retired_reason`, `json_extract` for
+  single-string state fields, `json_each` for array state fields,
+  composed per active kind; lore over `title` / `body` / `category` /
+  `tags`), the four-layer sort with the lead pinned and the lore
+  two-layer sort, grouping keys, chip vocabularies, search-scope copy,
+  empty and no-results copy, and the `EntityRow` / `LoreRow` renderers
+  over `ListRow` taking derived signals and a density prop, with the
+  category label passed in by the surface.
+- **C1 module:** the recently-classified window selector with its
+  per-kind aggregate, and the in-scene selector over the tail entry's
+  scene triple through the reader's inherited-metadata helper; the
+  World rows and the detail-head badge slot consume both. The 4.1 PR
+  amends `plot.md`'s decay open question to record the two-turn
+  default.
+- **Collision surfacing:** `CollisionListRow` on flagged rows with
+  `Collides with <other>` (in-surface jump to the other row) and
+  `Resolve →` (disabled with the "lands in Slice 4.2c" reason until
+  that slice, and gated while generation is in flight); the top-bar
+  `⚠ N need review` pill (`Tag tone="warning"`, click scrolls to the
+  first flagged row and expands its group; glyph and count on phone);
+  the collapsed-accordion `⚠ N` badge.
+- **Seed:** `pnpm db:seed` gains one flagged same-name character pair
+  so the surfacing chrome — and 4.2c's drivers later — are exercisable
+  without a real classifier run.
+- **`[+]` affordance:** the `ImporterMenu` with per-kind tooltip
+  (`New character` … `New lore`) and the three options — `Blank`
+  (disabled until 4.2a / 4.2b), `From JSON file…` (disabled until
+  4.6), `From Vault…` (disabled, "Vault lands in M8") — each disabled
+  entry exposing its reason.
+- **Detail pane host:** `DetailPane` mounted with a "select a row"
+  empty state and, on selection, a read-only placeholder body naming
+  the row (kind icon, name, recently-classified badge) — the tab strip,
+  editors and `⋯` menu are 4.2a.
+- **Phone collapse:** list-first via `MasterDetailLayout`, row tap →
+  detail state, `useMasterDetailBack` for `←` and hardware back, the
+  sub-header at route level.
+- **i18n:** new `world` namespace.
+- **Storybook:** list-pane states (each kind, each filter, accordion
+  collapsed with badge, flagged row, empty, no-results) and the
+  detail placeholder.
+
+## Scope: out
+
+- Every detail-pane editor, the `⋯` menu, save session — 4.2a / 4.2b.
+- The resolve dialog driver — [Slice 4.2c](./02c-collision-review.md).
+- `From JSON file…` wiring and export — [Slice 4.6](./06-import-export.md).
+- The Browse rail, which reuses these modules — [Slice 4.5a](./05a-browse-rail.md).
+- Bulk operations (parked), character-side Awareness tab (parked).
+- FTS5 search — parked; v1 stays on `LIKE` and JSON1.
+- Plot's thread and happening modules — [Slice 4.3](./03-plot-panel.md).
+
+## Acceptance criteria
+
+- The World route opens from the reader and from the Actions menu's
+  `GO TO` group on desktop and Android and lists the seeded branch's
+  rows for every category; switching the dropdown swaps filters,
+  search scope copy and rows; the `GO TO` group omits `Open World`
+  while on World (manual smoke plus E2E happy path; component test on
+  the self-omit rule).
+- Search on Characters for a term that appears only in
+  `state.visual.hair` matches; the same term on Locations does not;
+  an array field (`traits`) matches via `json_each`, and a term that
+  only appears in JSON syntax never matches (vitest on the query
+  builder against an in-memory DB).
+- The entity list order is lead → Active in-scene → Active
+  off-scene → Staged → Retired, alphabetical within each; filtering
+  to `Staged` keeps alphabetical order; lore sorts by `priority` DESC
+  then `title` (vitest on the sort).
+- A character in the tail entry's `sceneEntities` renders the in-scene
+  stripe and one absent from it does not; the `currentLocationId`
+  location renders it and sibling locations do not; a tail
+  `user_action` inherits the triple from the entry above (vitest on
+  the C1 in-scene selector plus Storybook).
+- A row the classifier wrote this turn renders `fresh`; the same row
+  one turn later renders `fading`; two turns later untinted; a
+  character whose only change is leaving the scene tints; a
+  `user_edit` delta never tints (vitest on the C1 module over fixture
+  deltas and entries).
+- With the seeded flagged pair, the pill reads `⚠ 1 need review` on
+  desktop and `⚠ 1` on phone, the flagged row carries the strip,
+  collapsing its group shows the badge, and clicking the pill expands
+  the group and scrolls to the row (component test plus manual).
+- `Blank`, `From JSON file…`, `From Vault…` and `Resolve →` render
+  present, disabled, and each exposes its deferral reason (component
+  test).
+- Mounting the route with `{ kind, id }` selects that row, with `tab`
+  preselecting a tab once 4.2a's strip exists, and on phone lands in
+  the detail state; the first `←` returns to the list (component test
+  on the param parser and pre-selection; the UI-driven E2E lives in
+  4.5b, whose `Open in panel →` is the first real producer).
+- Every chrome string routes through `t()`; new compounds have stories.
+
+## Tests
+
+- Vitest: C2 query builder (per-kind WHERE composition, JSON-syntax
+  non-match, NULL safety), sort layers, C1 recently-classified matrix
+  (fresh / fading / expired, scene-transition touch, source
+  exclusions, per-kind aggregate), C1 in-scene selector (characters,
+  items, singleton location, inherited tail).
+- Component tests: list pane rendering per kind, accordion and badge,
+  collision strip, disabled entries, empty and no-results states,
+  deep-link parser, `GO TO` self-omit.
+- Storybook: the matrix above plus phone list-first and detail
+  placeholder.
+- E2E (desktop): open World from the reader and from `GO TO`, switch
+  category, search, select a row.
+
+## Open questions
+
+- **Turn boundary for C1.** Whether "the last turn" is measured from
+  the latest `ai_reply` entry's position or from the latest
+  `action_id`. Default: the last `ai_reply`, since boot recovery
+  reverse-replays a dangling in-flight turn and a failed turn leaves a
+  system entry behind. Pin in the module's doc comment.
+- **Lore `Recently classified` before M5.** Lore is classifier-touched
+  only at chapter close, which lands in M5; the badge slot is wired
+  here and stays inert until then — confirm nothing in M4 fakes it.
+
+## Implementation notes
+
+_Populated at finish: notable deviations from the plan and resolved
+developer decisions._

--- a/docs/implementation/milestones/04-world-plot-read-surfaces/slices/02a-entity-detail.md
+++ b/docs/implementation/milestones/04-world-plot-read-surfaces/slices/02a-entity-detail.md
@@ -1,0 +1,249 @@
+# Slice 4.2a — Entity detail: per-kind panes, save session, create mode
+
+## Metadata
+
+- **Milestone:** [Milestone 4 — World + Plot read surfaces](../milestone.md)
+- **Depends on:** [Slice 4.1](./01-world-shell.md) (the shell hosts
+  the pane; `[+] Blank` opens create mode). Doc-as-contract pair with
+  [Slice 4.3](./03-plot-panel.md) over C7 (save-session host), C8
+  (entity picker) and C11 (overflow menu); the Involvements tab's
+  Plot links render inert until 4.3's route exists (C6).
+- **Blocks:** [Slice 4.2b](./02b-lore-history-delete.md) (C7 host,
+  C11 menu), [Slice 4.5b](./05b-peek-drawer.md) (Overview projection,
+  C5), [Slice 4.6](./06-import-export.md) (export host — partial)
+
+## Goal
+
+The four entity kinds get their hand-written detail panes —
+`CharacterDetailPane`, `LocationDetailPane`, `ItemDetailPane`,
+`FactionDetailPane` — with the Overview / Identity / Carrying /
+Connections / Settings tabs, the Relationships sub-section, the
+per-row save session (C7), create mode from `[+] Blank`, the
+overflow-menu compound (C11) with `Set as lead` (C5) and `View raw
+JSON`, the kind-aware entity picker (C8), and the
+`parent_location_id` cycle guard the wizard adopts. Involvements
+renders read-only; Assets renders a placeholder; History renders a
+placeholder 4.2b fills.
+
+## Background
+
+`entities.state` is a typed discriminated union, so the panes are
+hand-written per kind rather than generated: schema is the validation
+contract, UI owns layout, and tabs distribute fields by semantic
+purpose. Overview is a read-mostly glance card whose regions route to
+the edit tab; it doubles as the peek body at 440 px, which is why its
+component must take its width and region handler as props. Every edit
+rides the save-session pattern — one react-hook-form session per row,
+explicit Save, one `action_id` — and disables while generation is in
+flight. The authorship contract matters here: `lastSeenAt` is
+classifier-only and renders read-only; everything else the user may
+edit, knowing the classifier may overwrite it on contradicting prose.
+
+## Required reading
+
+- [`world.md → Detail head structure`](../../../../ui/screens/world/world.md#detail-head-structure),
+  [`Tabs — per-kind composition`](../../../../ui/screens/world/world.md#tabs--per-kind-composition)
+  through
+  [`Settings — entity-management chrome`](../../../../ui/screens/world/world.md#settings--entity-management-chrome),
+  [`Assets, Involvements, History`](../../../../ui/screens/world/world.md#assets-involvements-history),
+  [`Detail pane — raw JSON viewer`](../../../../ui/screens/world/world.md#detail-pane--raw-json-viewer)
+  and [`Mobile expression`](../../../../ui/screens/world/world.md#mobile-expression)
+  — every field, every tab, every tier rule.
+- [`world.md → Relationships — character-to-character`](../../../../ui/screens/world/world.md#relationships--character-to-character)
+  — row composition, the three perspective states, the edit sheet,
+  the CHECK gate.
+- [`patterns/entity.md → Entity detail-pane composition`](../../../../ui/patterns/entity.md#entity-detail-pane-composition)
+  and [`Entity editing — uses the save-session pattern`](../../../../ui/patterns/entity.md#entity-editing--uses-the-save-session-pattern).
+- [`patterns/save-sessions.md`](../../../../ui/patterns/save-sessions.md)
+  in full — session semantics, save bar, invalid draft, navigate-away
+  guard.
+- [`patterns/tabs.md → Tab-strip overflow rule`](../../../../ui/patterns/tabs.md#tab-strip-overflow-rule)
+  and [`patterns/forms.md → Select primitive`](../../../../ui/patterns/forms.md#select-primitive),
+  [`Form rows — stacked-on-narrow-container`](../../../../ui/patterns/forms.md#form-rows--stacked-on-narrow-container),
+  [`TagInput pattern`](../../../../ui/patterns/forms.md#taginput-pattern),
+  [`Autocomplete-with-create primitive`](../../../../ui/patterns/forms.md#autocomplete-with-create-primitive).
+- [`patterns/data.md → Raw JSON viewer`](../../../../ui/patterns/data.md#raw-json-viewer--shared-modal-pattern).
+- [`touch.md → Save bar on phone`](../../../../ui/foundations/mobile/touch.md#save-bar-on-phone)
+  — the keyboard-hide rule C7 adds to `SaveBar`.
+- [`principles.md → Edit restrictions during in-flight generation`](../../../../ui/principles.md#edit-restrictions-during-in-flight-generation)
+  and [`Mode, lead, and narration`](../../../../ui/principles.md#mode-lead-and-narration--three-orthogonal-concepts).
+- [`data-model.md → World-state storage`](../../../../data-model.md#world-state-storage)
+  through [`Authorship contract`](../../../../data-model.md#authorship-contract)
+  — the four `*State` shapes, stackables, containers, the cycle guard
+  owner and its rejection shape, relationships and `normalizeForWrite`.
+- [`data-model.md → Injection modes`](../../../../data-model.md#injection-modes--unified-enum--structural-invariant)
+  and [`memory/retrieval.md → Keywords schema`](../../../../memory/retrieval.md#keywords-schema)
+  — what the Settings tab's `injection_mode`, `keywords` and
+  `priority` mean.
+- [`data-model.md → Story settings shape`](../../../../data-model.md#story-settings-shape)
+  — `definition.leadEntityId` and its cross-field constraint (C5).
+- [`generation-pipeline.md → Action rejection`](../../../../generation-pipeline.md#action-rejection--defense-in-depth)
+  — the `{ status: 'rejected', reason }` shape the guard returns.
+- [Milestone contracts C5, C6, C7, C8, C11, C12](../milestone.md#slice-contracts).
+
+## Scope: in
+
+- **Per-kind panes:** the four components with the shared tab
+  skeleton (Carrying character-only), rendered through `DetailPane`
+  inside one `Tabs` root; the tab strip on desktop and the Select
+  primitive on tablet (count > 3) and phone per the overflow rule.
+- **Overview** per kind, as one width-agnostic component taking a
+  `variant` (`panel` / `peek`) and an `onRegionPress(tab)` handler so
+  4.5b can project it: status pill with `retired_reason` inline, the
+  non-default `injection_mode` chip, description, visual line,
+  `TRAITS` / `DRIVES` chips with `+ N`, `IN <location>` with
+  `last seen N days ago` from `lastSeenAt`, `WITH <faction>` — links
+  resolved from the entities store — carrying summary, tags read-only,
+  portrait **placeholder** slot; location parent-chain breadcrumb,
+  `condition`, "Characters here" / "Items here" inverse counts; item
+  position (`at_location_id` or "Held by" inverse); faction `standing`,
+  agenda chips, member count. Every region press routes to its edit
+  tab; empty regions render the `— not yet described —` placeholder
+  with an `add →` link.
+- **Identity** per kind (description; character `visual.*` and
+  personality sub-sections; location / item `condition`; faction
+  `standing` and `agenda[]`).
+- **Carrying** (character): `stackables` chip row with `<key> × <n>`
+  and `+ add`, `equipped_items[]` and `inventory[]` entity-ref lists
+  through the C8 entity picker (kind `item`).
+- **Connections** per kind: positional / compositional / affiliation
+  pickers (C8, kind-filtered, self-excluded), inverse-derived read-only
+  lists, `lastSeenAt` read-only; the **Relationships** sub-section —
+  `ListRow` rows with both perspectives, `+ Add relationship`, an edit
+  sheet (Autocomplete over characters minus self, `kind` and
+  `inverse_kind` inputs, at-least-one gate, Delete inside the sheet).
+  The sheet's save is **one** action: this slice extends the M1.5
+  `upsertCharacterRelationship` payload to carry both perspective
+  columns, since the group runner rejects two writes to one row's
+  column (C7).
+- **Settings:** `status`, `injection_mode` with its explanation,
+  `retired_reason` (enabled only when retired), `keywords` and `tags`
+  as `TagInput` — keywords normalized through C12 at commit — and
+  `priority` integer `0..100`. These are the entity keyword editors the
+  2026-09-06 keyword-retrieval design left without a surface.
+- **C7 save-session host:** the shared per-row hook — react-hook-form
+  session, `SaveBar` in the pane slot with dirty-field labels,
+  `Cmd/Ctrl-S`, a `requestLeave` the surface routes row switch, kind
+  switch, `useMasterDetailBack` and the Actions menu's
+  `beforeNavigate` through, `useUnsavedChangesGuard` for navigator
+  removal, window close and reload, one `applyDeltaActionGroup`
+  commit per Save under one `action_id`, toast, invalid-draft reason
+  in the bar's `notice`, `isUserEditBlocked` gating with the
+  principle-owned tooltip, and the `SaveBar` phone change — hide while
+  the keyboard is open, return on blur.
+- **Cycle guard:** the action-layer pre-commit walk for
+  `parent_location_id` (depth-cap 100, `reason: 'parent-cycle'`),
+  living in the entity update handler so every writer gets it; the
+  wizard's Finish and `cast-import.ts` adopt it in this slice (the
+  roadmap's carried deferral); the World form maps the rejection to a
+  field error.
+- **Create mode:** `[+] Blank` opens the active kind's pane in create
+  state with the schema defaults; Save runs the create arm and selects
+  the new row.
+- **C11 overflow menu:** the compound (entries with `disabled` and
+  `disabledReason`, Popover on desktop and tablet, Sheet (short) on
+  phone) and World's entries — `Set as lead` (characters only, via
+  C5), `Export entity as JSON` (disabled until 4.6), `View raw JSON`
+  (`JSONViewer` with row and `state` merged), `Delete entity`
+  (disabled until 4.2b).
+- **C5:** the new story-definition write arm that sets
+  `leadEntityId` under the `needsLead` refine and the in-flight gate,
+  with its store refresh.
+- **C8 entity picker:** the kind-aware `Autocomplete`-based picker
+  with `excludeIds`.
+- **Detail head:** `InlineEditableName` (edits dirty the session),
+  kind breadcrumb, the C1 `Recently classified` badge, the
+  injection-mode chip.
+- **Involvements tab:** read-only `happening_involvements` rows for
+  this entity with role, each linking to Plot via C6 — inert with a
+  "lands in Slice 4.3" reason until that route exists; empty state.
+- **Assets tab and History tab:** placeholder bodies (`lands with
+the asset gallery pass` / `lands in Slice 4.2b`).
+- **Storybook:** each pane per kind (populated / sparse / retired /
+  staged), Overview in both variants, relationships states, create
+  mode, phone Select-mode tabs.
+
+## Scope: out
+
+- Lore detail, History module, delete —
+  [Slice 4.2b](./02b-lore-history-delete.md).
+- Collision resolution — [Slice 4.2c](./02c-collision-review.md).
+- Export — [Slice 4.6](./06-import-export.md).
+- Portrait upload, Assets tab body, image preview — the asset gallery
+  pass (parked; see the milestone's open questions).
+- Character-side Awareness tab (parked), inter-faction relationships
+  (deferred by canon), bulk operations (parked).
+- Per-field provenance / classifier lock — parked.
+
+## Acceptance criteria
+
+- Editing `description` and a `visual.hair` on Identity, then a tag on
+  Settings, and saving writes one `updateEntity` delta whose
+  `undo_payload` carries exactly the three pre-change paths, under one
+  `action_id`; CTRL-Z from the reader reverses all three (vitest on
+  the session commit plus E2E).
+- Switching rows with a dirty session raises Save / Discard / Cancel;
+  Cancel keeps the row and the draft; Discard drops the draft; a
+  window-close attempt with a dirty session raises the same dialog
+  (E2E).
+- Setting `A.parent_location_id = B` when `B.parent_location_id = A`
+  is rejected with `reason: 'parent-cycle'` from the handler and
+  surfaces as a field error on Connections; the same pair authored in
+  the wizard's location editor is rejected at Finish (vitest on the
+  guard; component test on the form).
+- Saving a relationship with both perspectives filled writes one
+  action and one row with `a_id < b_id`; with only `inverse_kind`
+  filled it saves; with neither filled Save is disabled; the row
+  renders `your view: not recorded · they see you: rival` (vitest on
+  the extended arm and the sheet's write mapping).
+- `Set as lead` on a character updates `definition.leadEntityId`,
+  the reader's `You` badge moves on return, the entry is absent on
+  non-character kinds, and the action is refused while a turn is in
+  flight (vitest on C5 plus manual).
+- `[+] Blank` on Locations creates a location with empty state on
+  Save and selects it; the create form respects `isUserEditBlocked`
+  (component test).
+- Pressing the visual line lands Identity, the carrying summary lands
+  Carrying, the location link lands Connections, per kind (component
+  test on `onRegionPress`).
+- Every control disables during an in-flight turn with the
+  `Generation is in flight. Cancel to edit.` tooltip (component test
+  with a mocked `txState`).
+- The Overview `peek` variant at 440 px renders every region with
+  `scrollWidth <= clientWidth` on the pane root (Storybook story with
+  a `play` assertion).
+- Two keyword entries differing only in case collapse to one on
+  commit (vitest on the Settings editor's C12 normalization).
+- Every chrome string routes through `t()`; new compounds have stories.
+
+## Tests
+
+- Vitest: cycle guard (self, two-cycle, deep chain, cap hit), C5
+  validation and gate, relationship both-pov arm and write mapping,
+  session commit grouping, Overview derivations (parent chain,
+  held-by inverse, member count, `lastSeenAt` relative days), C12
+  normalization at commit.
+- Component tests: per-kind pane field routing, conditional
+  `retired_reason`, injection chip visibility, region routing, create
+  mode, edit gating, overflow menu disabled entries.
+- Storybook: the matrix above.
+- E2E (desktop): edit, save, undo round trip; dirty-switch and
+  window-close guards.
+
+## Open questions
+
+- **Portrait placeholder shape.** Whether the slot renders an
+  `Avatar` initial or nothing until the asset link exists — pick the
+  one that survives the gallery pass without a re-layout; the
+  thumbnail tap per
+  [`patterns/image-preview.md`](../../../../ui/patterns/image-preview.md)
+  stays inert until then.
+- **Relationship delete inside the sheet.** Whether the sheet's Delete
+  commits immediately (one-field session, like the peek exception) or
+  joins the pane's session as a `deleteCharacterRelationship` in the
+  group. Default: joins, so one Save reverses everything.
+
+## Implementation notes
+
+_Populated at finish: notable deviations from the plan and resolved
+developer decisions._

--- a/docs/implementation/milestones/04-world-plot-read-surfaces/slices/02b-lore-history-delete.md
+++ b/docs/implementation/milestones/04-world-plot-read-surfaces/slices/02b-lore-history-delete.md
@@ -1,0 +1,202 @@
+# Slice 4.2b — Lore detail, History tab module, delete arms
+
+## Metadata
+
+- **Milestone:** [Milestone 4 — World + Plot read surfaces](../milestone.md)
+- **Depends on:** [Slice 4.2a](./02a-entity-detail.md) (C7
+  save-session host, C11 overflow menu, the History placeholder this
+  slice fills)
+- **Blocks:** [Slice 4.2c](./02c-collision-review.md) (the merge's
+  losing row deletes through C3), the History tab and delete entries
+  of [Slice 4.3](./03-plot-panel.md) (C4 and C3 — partial),
+  [Slice 4.6](./06-import-export.md) (lore export host — partial)
+
+## Goal
+
+Lore gets its detail pane (Body / Settings / History), the delta-log
+History tab lands as a shared module (C4) that also fills 4.2a's
+placeholder, and the first delete surfaces ship — `Delete entity` and
+`Delete` on lore — over hardened delete arms (C3): the entity link
+cascade, inverse-ref rewrite, tail-metadata drop, lead refusal, the
+happening cascade's critical section, and the vector sweep on forward
+delete and redo for every embedded kind.
+
+## Background
+
+Lore is a separate, simpler kind: text-heavy, no lifecycle, no scene
+presence, a required `body`, and — since the 2026-09-06 design — a
+`keywords` editor that is load-bearing for the keyword retrieval
+pathway (embedding models have no prior for invented terms). History
+is the per-row delta log: read-only, searchable over field paths and
+`undo_payload`, load-older chunked, rendered through the shipped
+`DeltaLogRow` with host-side humanization. Delete is where M1.5's
+"no production caller" arms meet reality: `deleteEntity` removes one
+row and leaves `happening_awareness`, `happening_involvements`,
+`character_relationships`, inverse `state` refs and `translations`
+dangling (all FK-less by composite-PK necessity), and nothing on any
+delete path reaches the vec0 tables — `deleteVecOps` exists with no
+caller. Reverse-replay already restores rows stale; redo rebuilds a
+delete from the registry's `cascadeDeleteOps` hook, never from the
+handler, which is where the sweep must therefore live.
+
+## Required reading
+
+- [`world.md → Lore — separate kind`](../../../../ui/screens/world/world.md#lore--separate-kind)
+  through [`History tab — lore`](../../../../ui/screens/world/world.md#history-tab--lore)
+  — the three-tab skeleton, detail head, Body and Settings fields,
+  the required-body invariant.
+- [`world.md → History tab`](../../../../ui/screens/world/world.md#history-tab),
+  [`Detail head structure`](../../../../ui/screens/world/world.md#detail-head-structure)
+  (the `Delete entity` entry) and
+  [`Mobile expression`](../../../../ui/screens/world/world.md#mobile-expression)
+  (lore's three-tab Select rule on phone; History controls reflow).
+- [`patterns/tabs.md → Tab-strip overflow rule`](../../../../ui/patterns/tabs.md#tab-strip-overflow-rule).
+- [`patterns/forms.md → Autocomplete-with-create primitive`](../../../../ui/patterns/forms.md#autocomplete-with-create-primitive)
+  (the `category` suggestions), [`Select primitive`](../../../../ui/patterns/forms.md#select-primitive),
+  [`Input primitive`](../../../../ui/patterns/forms.md#input-primitive),
+  [`Textarea primitive`](../../../../ui/patterns/forms.md#textarea-primitive)
+  (the body field's auto-grow), [`TagInput pattern`](../../../../ui/patterns/forms.md#taginput-pattern)
+  and [`Form rows — stacked-on-narrow-container`](../../../../ui/patterns/forms.md#form-rows--stacked-on-narrow-container).
+- [`patterns/delta-log-row.md → Compound API`](../../../../ui/patterns/delta-log-row.md#compound-api)
+  through [`Click behavior`](../../../../ui/patterns/delta-log-row.md#click-behavior)
+  — what the host pre-formats, and the cache-miss summary rule.
+- [`patterns/lists.md → Load-older`](../../../../ui/patterns/lists.md#load-older--log-shaped-unbounded-lists)
+  and [`Search bar scope`](../../../../ui/patterns/lists.md#search-bar-scope)
+  (the History row of the table).
+- [`patterns/alert-dialog.md → Destructive CTA`](../../../../ui/patterns/alert-dialog.md#destructive-cta-via-button-composition)
+  — the delete confirmation shape.
+- [`data-model.md → Entry mutability & rollback`](../../../../data-model.md#entry-mutability--rollback)
+  — delta encoding, `undo_payload` shapes, and what redo replays.
+- [`world.md → Reversibility`](../../../../ui/screens/world/world.md#reversibility)
+  — the merge write set C3 mirrors for delete.
+- [`data-model.md → Story settings shape`](../../../../data-model.md#story-settings-shape)
+  — the `needsLead` constraint behind the lead refusal.
+- [`patterns/entry-card.md → World-state panel`](../../../../ui/patterns/entry-card.md#world-state-panel)
+  — historical entries render an unresolvable id as an Unknown-entity
+  chip, which is why the delete need not touch them; the tail drop is
+  this milestone's default, not canon (C3).
+- [`memory/retrieval.md → Compute lifecycle`](../../../../memory/retrieval.md#compute-lifecycle)
+  and [`Keywords schema`](../../../../memory/retrieval.md#keywords-schema)
+  — the vec0 write and sweep obligations and lore `keywords`.
+- [`architecture.md → Delta history diff resolution`](../../../../architecture.md#delta-history-diff-resolution)
+  — the M6.4 cache the C4 summary later upgrades into; read for the
+  contract boundary, not to build it.
+- [Milestone contracts C3, C4, C7, C11, C12](../milestone.md#slice-contracts).
+
+## Scope: in
+
+- **Lore pane:** `LoreDetailPane` on the C7 host — detail head
+  (kind icon and `Lore`, `InlineEditableName` on `title`, recently-
+  classified badge, C11 menu with `Export lore as JSON` disabled until
+  4.6, `View raw JSON`, `Delete`; no `Set as lead`); **Body** tab
+  (`category` input with a branch-scoped suggestions popover, body
+  textarea filling the pane; Save disabled while body is empty);
+  **Settings** tab (`injection_mode` with explanation, `priority`
+  `0..100` with the shipped-semantics tooltip, `keywords` normalized
+  through C12, `tags`); create mode from `[+] Blank` on Lore; tabs via
+  Tab strip on desktop and tablet, Select dropdown on phone.
+- **C4 History module:** the load-older query, the humanizer with its
+  field-path label vocabulary, and the `HistoryTab` component with
+  search (field-path / op / summary), op-filter chips, newest / oldest
+  sort, `Load older`, the read-only empty state, and controls that
+  reflow on narrow widths; mounted on the lore pane and on 4.2a's four
+  entity panes (replacing the placeholder), and renderable for the
+  `threads` and `happenings` target tables so 4.3 mounts it unchanged.
+  Rows link to the reader entry when `entryId` is set.
+- **C3 delete arms**, per the milestone's pinned mechanism: the
+  grouped entity delete — one merged `updateEntity` per referencing
+  entity, one `updateStoryEntryMetadata` for the tail scene drop, then
+  `deleteEntity` with `cascadeDeleteOps` covering the three link tables
+  and translations; the `lead-entity` refusal when the target is the
+  story's lead; the happening cascade's child read and delete moved
+  into one critical section under the key lock; and `deleteVecOps`
+  emitted from each embedded kind's `cascadeDeleteOps` so forward
+  delete and redo both sweep. The 4.2b PR amends `world.md` to record
+  the tail-scene drop, or records the deviation if review rejects it.
+- **Delete surfaces:** `Delete entity` and lore `Delete` in the C11
+  menus over an `AlertDialog` naming what goes with the row (link-row
+  counts, the tail-scene drop) or, for the lead, the refusal and a
+  pointer to `Set as lead`; gated while generation is in flight;
+  routed through the reader's CTRL-Z stack.
+- **Storybook:** lore pane states (populated / empty body / create),
+  History tab states (rows per op and source, empty, loading older),
+  delete confirm and lead refusal.
+
+## Scope: out
+
+- Entity panes and the save-session host — [Slice 4.2a](./02a-entity-detail.md).
+- The merge driver that consumes the delete arm — [Slice 4.2c](./02c-collision-review.md).
+- Thread and happening delete **surfaces** — [Slice 4.3](./03-plot-panel.md)
+  (the arms are hardened here; 4.3's entries stay disabled until this
+  slice merges).
+- The diff cache and rich diff prose — M6.4.
+- Lore Assets (parked), lore categories as dynamic chips (no
+  followup until volume demands).
+- Global delta-log browser — M7.3 Diagnostics Hub.
+
+## Acceptance criteria
+
+- Deleting a character with two awareness rows, one involvement, one
+  relationship, a translation row, and another character holding it in
+  both `current_location_id` and `inventory[]` leaves none of those
+  rows, rewrites both refs in one `updateEntity`, removes the id from
+  the tail entry's `sceneEntities`, and leaves zero vec0 rows for the
+  id in every dim family — all under one `action_id` (vitest against
+  an in-memory DB with vec tables).
+- CTRL-Z of that delete restores the entity, every cascaded row, the
+  inverse refs and the tail scene, with the restored entity
+  `embedding_stale = 1`; redo re-deletes and the vec tables are empty
+  for the id again (vitest on reverse-replay and redo).
+- Deleting the story's lead character is refused with `lead-entity`
+  from the arm and the confirm dialog shows the refusal instead of the
+  cascade summary (vitest on the arm; component test on the dialog).
+- Deleting a lore, thread or happening row leaves zero vec0 rows for
+  the id; two concurrent writers on a happening's involvements cannot
+  interleave with its delete (vitest per kind; vitest on the key lock).
+- Historical entries that referenced the deleted id still render it
+  as an Unknown-entity chip (component test on the world-state panel
+  with a deleted id in `sceneEntities`).
+- The delete confirm for a character with two awareness rows, one
+  involvement and one relationship names those counts and the
+  tail-scene drop (component test plus Storybook).
+- Saving lore with an empty body is impossible from the Body tab and
+  from create mode (component test).
+- History search for a field path (`state.traits`) returns only
+  updates touching it; op filter `delete` returns only deletes;
+  `Load older` appends the next chunk and never auto-loads on scroll
+  (vitest on the query; component test on the tab).
+- A `periodic_classifier` delta on the entity renders the
+  `periodic classifier` source label and `entry #n` link; clicking it
+  navigates to that entry in the reader; the `HistoryTab` renders a
+  `threads` and a `happenings` fixture delta with resolved names
+  (component test plus manual).
+- Every chrome string routes through `t()`; new compounds have stories.
+
+## Tests
+
+- Vitest: C3 cascade matrix (each link table, merged multi-field ref
+  rewrite, tail scene, translations, lead refusal, happening critical
+  section), sweep-on-delete and sweep-on-redo per kind, C4 query
+  (search shapes, op filter, sort, cursor), humanizer per op, source
+  and target table.
+- Component tests: lore pane, required body, History tab controls,
+  delete confirm and refusal.
+- Storybook: the matrix above.
+- E2E (desktop): delete entity → undo → redo, asserting vec rows and
+  link rows in the DB.
+
+## Open questions
+
+- **Critical-section shape for the happening cascade.** Whether the
+  child read moves inside the delete's transaction or the whole
+  `cascadeDeleteOps` call takes the per-happening key lock the
+  awareness arm already uses; either satisfies C3. Pick at planning.
+- **Group ordering.** The entity delete must come last in the group so
+  the referencing entities' `state` patches and the tail metadata
+  write are built against rows that still exist; confirm the runner's
+  pre-group-state rule makes the order irrelevant, or pin it.
+
+## Implementation notes
+
+_Populated at finish: notable deviations from the plan and resolved
+developer decisions._

--- a/docs/implementation/milestones/04-world-plot-read-surfaces/slices/02c-collision-review.md
+++ b/docs/implementation/milestones/04-world-plot-read-surfaces/slices/02c-collision-review.md
@@ -1,0 +1,165 @@
+# Slice 4.2c — Collision review drivers
+
+## Metadata
+
+- **Milestone:** [Milestone 4 — World + Plot read surfaces](../milestone.md)
+- **Depends on:** [Slice 4.2b](./02b-lore-history-delete.md) (the
+  merge's losing row deletes through the hardened entity arm — C3);
+  the dialog wiring, rename and keep drivers need only
+  [Slice 4.1](./01-world-shell.md) (a partial gate in the milestone
+  graph)
+- **Blocks:** none
+
+## Goal
+
+The shipped `CollisionResolveDialog` gets real drivers. `Resolve →`
+on a flagged row opens the dialog with both rows projected to
+`EntitySummary`, and each resolution writes deltas under one
+`action_id`: **merge** (canonical update, loser delete through C3,
+awareness / involvement / relationship reattachment with the UNIQUE
+rule, inverse-ref rewrite, translations move, keyword and tag union),
+**rename** (both rows, flag clear), **keep as distinct** (flag clear
+only). The dialog's drifted `InjectionMode` and `ScalarField` unions
+are fixed first.
+
+## Background
+
+The periodic classifier writes `name_collision_flag = 1` when a
+freshly extracted entity's description does not match an existing
+same-name row strongly enough to promote it. The World panel is the
+only surface that resolves the flag; 4.1 made it visible and seeded a
+flagged pair, this slice makes it actionable. The compound is a pure
+View with a Promise-driven `onResolve`; the pattern doc's own open
+item is exactly this slice — real DB-write drivers. Two known drifts
+to clear before wiring: `collision-resolve-diff.ts` declares
+`'always' | 'on-relevance' | 'never'` against the shipped
+`'always' | 'auto' | 'disabled'` enum, and its `ScalarField` omits
+`priority`, which canon lists among the per-row radio scalars.
+
+## Required reading
+
+- [`world.md → Collision review and entity merge`](../../../../ui/screens/world/world.md#collision-review-and-entity-merge)
+  through [`Authorship and 3+ collisions`](../../../../ui/screens/world/world.md#authorship-and-3-collisions)
+  — every path's writes, the UNIQUE-collision rule, reversibility,
+  the in-flight gate, the 3+ iteration rule.
+- [`patterns/collision-resolve.md`](../../../../ui/patterns/collision-resolve.md)
+  in full — dialog props, `EntitySummary` projection, `Resolution`
+  shape, divergence and merge reducer, submit rules, open items.
+- [`layout.md → Mapping — desktop to mobile`](../../../../ui/foundations/mobile/layout.md#mapping--desktop-to-mobile)
+  — a short Modal stays a Modal on phone; the dialog has no Sheet
+  expression.
+- [`memory/edge-cases.md → Name collision`](../../../../memory/edge-cases.md#name-collision-and-disambiguation)
+  and [`Polymorphic naming`](../../../../memory/edge-cases.md#polymorphic-naming--v1-limitation).
+- [`data-model.md → Happenings & character knowledge`](../../../../data-model.md#happenings--character-knowledge)
+  (the awareness UNIQUE constraint) and
+  [`Character-to-character relationships`](../../../../data-model.md#character-to-character-relationships)
+  (the `a_id < b_id` invariant a reattached row must keep).
+- [`data-model.md → Translation targets`](../../../../data-model.md#translation-targets)
+  — the rows that move with the canonical id.
+- [`memory/retrieval.md → Keywords schema`](../../../../memory/retrieval.md#keywords-schema)
+  — why keywords union and de-duplicate.
+- [Milestone contracts C3, C4, C7, C12](../milestone.md#slice-contracts).
+
+## Scope: in
+
+- **Drift fixes** as the first commit: the compound imports the
+  shipped `InjectionMode`, and `ScalarField` / `SCALAR_FIELDS` gain
+  `priority` so a divergent priority renders its radio row.
+- **Projection:** the World consumer builds two `EntitySummary`
+  values (older by `created_at` first) with real `relationCounts`
+  read from the stores / DB (awareness, involvements, inverse refs
+  across the six ref fields, embeddings 0 | 1, translations).
+- **Merge driver:** one `applyDeltaActionGroup` under a single
+  `action_id` with `source = 'user_edit'` — `updateEntity` on the
+  canonical (chosen scalars, keyword union normalized through C12, tag
+  union), awareness rows moved to the canonical id (loser's row
+  dropped on a `(branch_id, character_id, happening_id)` collision,
+  footnoted in the summary), involvements moved, relationships
+  re-keyed through the both-perspective action C7 pins (a pair that
+  would collapse to self is dropped; a duplicate pair merges
+  perspectives, canonical's non-null winning), inverse `state` refs on
+  other entities rewritten to the canonical — one merged
+  `updateEntity` per affected row — translations re-targeted, the
+  loser deleted through the C3 entity arm (which sweeps its vectors,
+  drops it from the tail scene, and refuses if the loser is the lead),
+  and the flag cleared. The canonical re-embeds via `embedding_stale`
+  if an embedded field changed (already the update arm's behavior).
+- **Rename driver:** two `updateEntity` deltas (sparse — only rows
+  whose name changed) plus the flag clear, one `action_id`.
+- **Keep driver:** the flag clear alone, one `action_id`.
+- **Flag clear as a delta.** Canon makes every path CTRL-Z
+  reversible; keep-as-distinct's only write is the clear, so the
+  clear must be delta-logged — this slice adds `nameCollisionFlag` to
+  the entity update arm's delta-logged columns for the user-edit
+  path, leaving the classifier's operational **set** on the M1.5
+  non-delta seam, and adds the field's label to C4's humanizer.
+- **Wiring:** 4.1's `Resolve →` opens the dialog — a Modal on every
+  tier, as shipped — disabled while generation is in flight; a merge
+  whose loser is the lead surfaces the `lead-entity` refusal inline;
+  after a resolution the list re-derives (pill count drops, strip
+  disappears, a remaining pair re-surfaces for 3+ collisions).
+- **Storybook:** the dialog already has stories; add the `priority`
+  radio row and the phone 3-line prose clamp state if the pattern's
+  open item is picked up here.
+
+## Scope: out
+
+- Surfacing chrome (pill, strip, badge) and the seeded pair —
+  [Slice 4.1](./01-world-shell.md).
+- N-way merge UI — not v1 by canon; the user iterates pairs.
+- Per-field diff inside `state` — v1 limitation by canon.
+- The classifier's flag-setting path — M3.3 (unchanged).
+
+## Acceptance criteria
+
+- Merging B into A where B holds an awareness row A already has for
+  the same happening keeps A's row, drops B's, and the summary
+  footnote fires; every other awareness / involvement / relationship
+  row of B is on A afterwards; the two other entities holding B in
+  `inventory[]` and `current_location_id` point at A through one
+  update each; B's translations target A; B is gone with zero vec0
+  rows; A's `name_collision_flag = 0` (vitest over fixtures).
+- CTRL-Z of the merge restores B with every row it held, restores
+  the inverse refs, re-flags B, and B is `embedding_stale = 1`;
+  redo re-merges (vitest on reverse-replay and redo of the group).
+- A merge whose losing row is the story's lead is refused with
+  `lead-entity` before any write (vitest).
+- The projection's `relationCounts` match the DB for a fixture entity
+  across all six inverse-ref fields, awareness, involvements and
+  translations (vitest on the projection builder).
+- Rename with only B's name changed writes one `updateEntity` delta
+  and the flag clear; Save is disabled while neither name changed
+  (vitest plus component test).
+- Keep-as-distinct writes exactly one delta (the flag clear), CTRL-Z
+  re-flags the row, and the History tab labels the field (vitest;
+  component test on the humanizer).
+- With three same-name rows, resolving one pair leaves the remaining
+  pair flagged and visible on next open (vitest on the list
+  derivation).
+- `Resolve →` is disabled with the in-flight tooltip during a turn
+  (component test).
+- `tsc --noEmit` passes with the compound consuming the shipped
+  `InjectionMode`, and a fixture pair differing only in `priority`
+  renders one radio row (component test).
+
+## Tests
+
+- Vitest: merge driver matrix (each relation table, UNIQUE collision,
+  relationship self-collapse and pair-merge, inverse refs per field
+  merged per row, translations, keyword and tag union normalization,
+  lead refusal), rename and keep drivers, group reversibility,
+  projection counts.
+- Component tests: wiring gates, refusal copy, humanizer label.
+- E2E (desktop): seeded pair → merge → undo, asserting rows in the DB.
+
+## Open questions
+
+- **Delta-logging the flag clear.** Adding `nameCollisionFlag` to the
+  update arm's `UPDATABLE` set makes any future user-edit path able to
+  flip it; confirm no classifier path routes through the user-edit
+  arm so the M1.5 operational seam stays the only setter.
+
+## Implementation notes
+
+_Populated at finish: notable deviations from the plan and resolved
+developer decisions._

--- a/docs/implementation/milestones/04-world-plot-read-surfaces/slices/03-plot-panel.md
+++ b/docs/implementation/milestones/04-world-plot-read-surfaces/slices/03-plot-panel.md
@@ -1,0 +1,235 @@
+# Slice 4.3 — Plot panel: threads + happenings
+
+## Metadata
+
+- **Milestone:** [Milestone 4 — World + Plot read surfaces](../milestone.md)
+- **Depends on:** none for the build (day-one; the M1.5 thread and
+  happening layers with the M3.3 happening cascade, the shipped
+  shells, and seed rows are merged prerequisites). Two partial gates:
+  from [Slice 4.1](./01-world-shell.md) the C1 row signals and the C6
+  World deep link its link rows route to; from
+  [Slice 4.2b](./02b-lore-history-delete.md) the C4 History module and
+  the C3-hardened delete arms — History ships as a placeholder and
+  `Delete …` ships disabled until then. Doc-as-contract pair with
+  [Slice 4.2a](./02a-entity-detail.md) over C7 (save-session host), C8
+  (pickers) and C11 (overflow menu), and with 4.1 over C6.
+- **Blocks:** [Slice 4.5a](./05a-browse-rail.md) (thread and
+  happening list modules — C2), [Slice 4.6](./06-import-export.md)
+  (import and export hosts — partial)
+
+## Goal
+
+The Plot route on the shared shells: the Threads / Happenings segment
+toggle driving both panes, status-tier and chapter-bucket grouping
+with a chapterless fallback, the thread and happening detail panes
+with the Involvements and Awareness editors, common-knowledge
+interaction, manual creation, raw JSON, and the entry-ref picker (C8
+half, this slice owns it) beside the kind-aware entity picker consumed
+from 4.2a's shape. Threads data may be sparse until M5's chapter close
+populates it; the surface ships now.
+
+## Background
+
+Plot is the monitor / audit half of the World / Plot split:
+predominantly classifier-written rows the user reviews, occasionally
+authors. Same shell decomposition as World, different kind selector
+(a two-cell segment), row shapes, tab compositions and filter rules.
+Happenings anchor to narrative time through `occurred_at_entry_id`
+or to free-text `temporal`, never both — the CHECK constraint is the
+floor and the Zod refine is the friendly surface. Awareness rows are
+character memory; a `common_knowledge` happening skips them and the
+tab says so. Every entry reference stores a branch-scoped entry id,
+so the picker returns ids and the host derives `entry #n` at render.
+Nothing opens a chapter before M5, so the chapter-keyed grouping is
+real only against seed fixtures in this milestone.
+
+## Required reading
+
+- [`plot.md`](../../../../ui/screens/plot/plot.md) in full — in
+  particular
+  [`Layout`](../../../../ui/screens/plot/plot.md#layout),
+  [`Implementation reuse`](../../../../ui/screens/plot/plot.md#implementation-reuse),
+  [`Threads side`](../../../../ui/screens/plot/plot.md#threads-side),
+  [`Happenings side`](../../../../ui/screens/plot/plot.md#happenings-side),
+  [`Row indicators`](../../../../ui/screens/plot/plot.md#row-indicators),
+  [`Manual creation + per-row import`](../../../../ui/screens/plot/plot.md#manual-creation--per-row-import),
+  [`Detail pane — raw JSON viewer`](../../../../ui/screens/plot/plot.md#detail-pane--raw-json-viewer),
+  [`Save session`](../../../../ui/screens/plot/plot.md#save-session),
+  [`Top-bar`](../../../../ui/screens/plot/plot.md#top-bar),
+  [`Mobile expression`](../../../../ui/screens/plot/plot.md#mobile-expression)
+  and [`Screen-specific open questions`](../../../../ui/screens/plot/plot.md#screen-specific-open-questions).
+- [`patterns/entity.md → Accordion grouping on "All" view`](../../../../ui/patterns/entity.md#accordion-grouping-on-all-view)
+  and [`Recently-classified row accent`](../../../../ui/patterns/entity.md#recently-classified-row-accent).
+- [`patterns/save-sessions.md`](../../../../ui/patterns/save-sessions.md)
+  in full, and [`patterns/lists.md → Empty list / table state`](../../../../ui/patterns/lists.md#empty-list--table-state).
+- [`patterns/forms.md → Select primitive`](../../../../ui/patterns/forms.md#select-primitive)
+  and [`patterns/searchable-overlay-list.md`](../../../../ui/patterns/searchable-overlay-list.md)
+  in full — the substrate the entry-ref picker most plausibly composes.
+- [`data-model.md → Happenings & character knowledge`](../../../../data-model.md#happenings--character-knowledge)
+  — the two-layer model, time-field exclusivity, entry refs as ids,
+  awareness UNIQUE upsert, `decay_resistance`, `source`.
+- [`data-model.md → Injection modes`](../../../../data-model.md#injection-modes--unified-enum--structural-invariant)
+  — `injection_mode` on threads; why happenings carry none.
+- [`memory/retrieval.md → Pinning — decay_resistance`](../../../../memory/retrieval.md#pinning--decay_resistance)
+  — what the Awareness tab's numeric field means to the ranker.
+- [`data-model.md → Chapters / memory system`](../../../../data-model.md#chapters--memory-system)
+  — the open chapter the `This chapter` filter and `Current chapter`
+  bucket key on.
+- [`principles.md → Edit restrictions during in-flight generation`](../../../../ui/principles.md#edit-restrictions-during-in-flight-generation),
+  [`Universal in-story chrome`](../../../../ui/principles.md#universal-in-story-chrome)
+  and [`Actions menu (contextual zone)`](../../../../ui/patterns/actions-menu.md#contextual-zone).
+- [`collapse.md → Two-pane navigation surfaces`](../../../../ui/foundations/mobile/collapse.md#two-pane-navigation-surfaces-world-plot-settings).
+- [Milestone contracts C1, C2, C3, C4, C6, C7, C8, C11](../milestone.md#slice-contracts).
+
+## Scope: in
+
+- **Route and chrome:** the Plot route from in-story chrome and the
+  Actions menu's `GO TO` group (4.1 owns the group; Plot's entry is in
+  it); `<title> / Plot` breadcrumb; the sub-header
+  `[Threads|Happenings] / <name>`; contextual entries `Add thread…` /
+  `Add happening…`; deep-link selection params mirroring 4.1's shape
+  (C6 — whichever lands first fixes the names).
+- **List pane:** the two-cell segment toggle (Select segment mode at
+  every tier) with a `[+]` tooltip tracking the active side, in the
+  trigger slot 4.1 adds to `EntityListPane`; **threads** — rows
+  (glyph, title, status pill, category), status chips, status-tier
+  sort and accordion (Active expanded), search; **happenings** — rows
+  (glyph, title, when-marker as entry chip or `temporal`, category,
+  `⊙` slot kept when unset), chips (`All` / `This chapter` /
+  `Common knowledge` / `Out-of-narrative`), chronological sort with
+  `temporal` rows pinned last, chapter-bucket accordion (Current
+  expanded; Earlier flat; Out of narrative), search; per-side empty
+  states with the classifier explainer.
+- **Chapterless fallback:** while the branch has no open chapter —
+  every real M4 story — the happenings All view renders one implicit
+  narrative bucket plus Out of narrative, and the `This chapter` chip
+  is hidden; the chapter-keyed shape engages when an open chapter
+  exists (seed fixtures now, M5 later).
+- **C2 modules — threads and happenings:** `ListModule` instances
+  with queries, grouping keys, chip vocabularies, search-scope copy,
+  empty and no-results copy, `ThreadRow` / `HappeningRow` renderers
+  over `ListRow` (C1 signals as props, density prop).
+- **Thread pane** on the C7 host: Overview (status, category, icon
+  from the preset catalog, description, `injection_mode` with
+  explanation, `triggered_at_entry_id` and `resolved_at_entry_id`
+  read-only — the latter only when resolved / failed, tags); History
+  as a placeholder until C4 merges, then the shared `HistoryTab`.
+  Tabs: strip on desktop and tablet, Select segment on phone.
+- **Happening pane:** Overview (title, description, category, icon,
+  `common_knowledge` toggle with its `⊙`, the mutually exclusive time
+  anchor — entry-ref picker **or** `temporal`, refined at the form
+  boundary, tags); **Involvements** (rows with the C8 entity picker,
+  kind-aware over all four kinds, free-form `role`; add / remove
+  through the M1.5 arms); **Awareness** (rows with a character-only
+  picker, `learned_at` entry-ref picker, `decay_resistance` `0..1`,
+  free-form `source`; add / remove; the UNIQUE upsert through the M1.5
+  arm; the common-knowledge notice replacing the body when the toggle
+  is on); History as above. Link rows route to World via C6, inert
+  with a "lands in Slice 4.1" reason until that route exists. Tabs:
+  strip on desktop, Select dropdown on tablet and phone.
+- **Entry-ref picker (C8 half):** the controlled primitive returning
+  an entry id, rendering `entry #n` plus an excerpt, Popover / Sheet
+  per tier, with a dangling-ref state when the id no longer resolves;
+  two consuming fields wired (`occurred_at_entry_id`,
+  `learned_at_entry_id`).
+- **Manual creation:** `[+] Blank` for each side opens the pane in
+  create mode; `From JSON file…` present-disabled until 4.6;
+  `From Vault…` disabled.
+- **C11 menu:** `View raw JSON` (happening merged with involvements
+  and awareness summary; thread row alone); `Export … as JSON`
+  disabled until 4.6; `Delete …` disabled until 4.2b (default
+  assumption that Plot carries delete and export at all — see the
+  milestone open question).
+- **Row indicators mirrored in the detail head:** recently-classified
+  badge, `⊙` beside the toggle, status on Overview.
+- **Phone collapse:** list-first, detail route, `useMasterDetailBack`,
+  segment switch firing the C7 `requestLeave` when dirty.
+- **i18n:** new `plot` namespace. **Storybook:** both sides' list
+  states, both panes, the CK notice, the pickers, the chapterless
+  fallback.
+
+## Scope: out
+
+- Chapter close, chapter-numbered sub-grouping inside `Earlier
+chapters` (deferred by canon), and `retrieval_count` review — M5.
+- The C1 selectors, the C4 module and the C3 arms themselves — 4.1
+  and 4.2b.
+- The kind-aware entity picker's authorship — 4.2a (this slice
+  consumes; if it lands first, it creates the picker at the pinned
+  shape).
+- Import and export — [Slice 4.6](./06-import-export.md).
+- Bulk operations (parked); the visual icon set for categories
+  (visual identity — placeholder glyphs).
+
+## Acceptance criteria
+
+- Over fixtures with one open and one closed chapter, happenings group
+  into Current chapter (the open chapter's entry range), Earlier
+  chapters, and Out of narrative (`temporal` set); `This chapter`
+  flattens to the first group; `Out-of-narrative` to the third; with
+  no open chapter the view collapses to the implicit narrative bucket
+  plus Out of narrative and the `This chapter` chip is absent (vitest
+  on the query and grouping; component test on the chip).
+- Setting both `occurred_at_entry_id` and `temporal` on a happening
+  is refused at the form (inline error) and, if forced through the
+  arm, by the CHECK constraint (vitest on the schema refine and DB).
+- Adding an involvement writes one `happening_involvements` row with
+  the picked entity and role; removing it deletes exactly that row;
+  both under one `action_id` (vitest on the arm; component test on the
+  editor).
+- Adding an awareness row for a character who already has one for
+  that happening updates rather than duplicates; toggling
+  `common_knowledge` on replaces the tab body with the notice and
+  hides the add affordance; toggling off shows the surviving rows
+  (component test plus vitest on the arm).
+- The entry-ref picker returns an id whose `position` renders as
+  `entry #n` in the field; after a rollback that removes that entry
+  the field shows the dangling-ref state rather than a bare id
+  (component test).
+- Creating a thread via `[+] Blank` with `status = pending` shows it
+  under Pending with the right pill; saving edits on Overview writes
+  one `updateThread` delta under one `action_id` and CTRL-Z reverses
+  it (E2E).
+- The History tab, `Delete …`, `Export …` and the World links render
+  present, disabled or placeholder, each with its deferral reason
+  (component test).
+- On phone, switching the segment with a dirty pane raises the guard;
+  the happening pane's four tabs render through the Select dropdown
+  (manual on Android; Storybook viewport).
+- Every chrome string routes through `t()`; new compounds have stories.
+
+## Tests
+
+- Vitest: C2 thread and happening queries and grouping (with and
+  without an open chapter), time-anchor refine, involvement and
+  awareness arm paths, entry-ref position derivation.
+- Component tests: both panes, CK interaction, pickers, segment
+  guard, disabled and placeholder states.
+- Storybook: the matrix above.
+- E2E (desktop): create thread, edit happening awareness, undo.
+
+## Open questions
+
+- **Entry-ref picker UX** — canonical open question. Default
+  assumption: `SearchableOverlayList` over the branch's entries,
+  newest first, row = `entry #n · kind · first ~80 chars`, search over
+  content; amend `plot.md` with the choice, and reconcile its
+  open-question wording (four picker fields) with `Threads side` (two
+  thread refs read-only) in the same PR.
+- **`decay_resistance` control** — canonical open question. Default
+  assumption: numeric `0..1` input with three preset chips (low /
+  medium / high → 0.2 / 0.5 / 0.8) above it; amend `plot.md`.
+- **Plot `⋯` Delete and Export entries** — canon silent; default
+  mirrors World minus `Set as lead` (milestone open question).
+- **Chapterless fallback** — confirm the single-bucket shape at
+  planning and note it in `plot.md` beside the chapter-bucket rule.
+- **Sizing.** If planning runs long, split at the segment boundary:
+  4.3a shell and threads (with the entry-ref picker), 4.3b happenings.
+- **Thread `icon` catalog.** The "string key from a preset catalog"
+  has no shipped catalog; pick the smallest honest set (a few Lucide
+  names) and let visual identity revise.
+
+## Implementation notes
+
+_Populated at finish: notable deviations from the plan and resolved
+developer decisions._

--- a/docs/implementation/milestones/04-world-plot-read-surfaces/slices/04-story-settings-basic.md
+++ b/docs/implementation/milestones/04-world-plot-read-surfaces/slices/04-story-settings-basic.md
@@ -1,0 +1,259 @@
+# Slice 4.4 — Story Settings basic surface
+
+## Metadata
+
+- **Milestone:** [Milestone 4 — World + Plot read surfaces](../milestone.md)
+- **Depends on:** none (day-one; extends the merged M3.11 shell and
+  its section-registration seam — M3's C7, not this milestone's — the
+  M3.7b Authoring aids section, the M3.1b Memory-tab embedder section,
+  and the shipped `ProviderModelPicker`). Milestone-level validation of
+  the keyword-retrieval panel follows [Slice 4.2b](./02b-lore-history-delete.md),
+  whose keyword editors make keywords authorable; that is a
+  verification order, not a build gate.
+- **Blocks:** none in M4 (M7.2 extends this surface later)
+
+## Goal
+
+The Story Settings screen becomes the basic surface real data needs:
+the **Models** tab (narrative override plus the five story-agent
+overrides over `resolveModel`), the **About** tab with the story-list
+`Edit info` route, the Generation tab's **Authoring aids** completed
+with the composer-modes toggle and wrap POV (bringing the
+definitional-change confirmation for `composerWrapPov`), the
+**Memory** tab's chapter-close, prompt-context, classifier-cadence,
+retrieval-budget and keyword-retrieval knobs, the **story-open
+embedding upgrade prompt** beside `SwapResumeHost` with both `Keep`
+write sites, and the phone save-bar placement call. The M7.2 boundary
+is drawn here: definitional fields, the classifier status panel and
+`piggybackMode` gate, Pack, Calendar, Translation, Advanced and Probe
+stay deep.
+
+## Background
+
+M3.11 shipped the route, the eight-tab rail with placeholders, and a
+save session that merges per-section patches into one
+`updateStorySettings` write (no delta, no CTRL-Z — `stories` is
+absent from `deltas.target_table`). Sections join through
+`useStorySettingsSection` and must own disjoint top-level keys. Three
+carried deferrals land here: composer modes are unreachable on every
+real story because nothing can flip `composerModesEnabled`; the five
+`keywordRetrieval` knobs are in the schema with no UI, and
+`mode: 'inject'` is a behaviour users will expect to reach; and the
+story-open upgrade prompt is specced with no host. About edits
+`stories` columns, not JSON — that needs a small new arm beside the
+M2.4 favorite and archive setters, and a session commit that can carry
+a column patch beside the settings patch.
+
+## Required reading
+
+- [`story-settings.md → Layout`](../../../../ui/screens/story-settings/story-settings.md#layout)
+  and [`Two sections under one roof`](../../../../ui/screens/story-settings/story-settings.md#two-sections-under-one-roof--wizard-editable-vs-post-creation-tuning)
+  — the About tab's fields live in the section split.
+- [`story-settings.md → Models tab — overrides only`](../../../../ui/screens/story-settings/story-settings.md#models-tab--overrides-only)
+  through [`Data model`](../../../../ui/screens/story-settings/story-settings.md#data-model)
+  — note the `Agent overrides` list includes `wizard-assist`, which
+  the `Data model` block, the schema and `resolveModel` all exclude;
+  this slice follows the schema and fixes the doc line.
+- [`story-settings.md → Generation tab`](../../../../ui/screens/story-settings/story-settings.md#generation-tab--definitional-fields--authoring-aids)
+  (the Authoring aids grouping) and
+  [`Definitional-change confirmations`](../../../../ui/screens/story-settings/story-settings.md#definitional-change-confirmations)
+  through [`When the story is empty`](../../../../ui/screens/story-settings/story-settings.md#when-the-story-is-empty).
+- [`story-settings.md → Memory tab`](../../../../ui/screens/story-settings/story-settings.md#memory-tab):
+  [`Chapter close`](../../../../ui/screens/story-settings/story-settings.md#chapter-close),
+  [`Prompt context`](../../../../ui/screens/story-settings/story-settings.md#prompt-context),
+  [`Classifier`](../../../../ui/screens/story-settings/story-settings.md#classifier)
+  (the cadence-config bullet only; status block and `piggybackMode`
+  are M7.2),
+  [`Embedder`](../../../../ui/screens/story-settings/story-settings.md#embedder)
+  (for the second `Keep` write site only),
+  [`Retrieval budgets`](../../../../ui/screens/story-settings/story-settings.md#retrieval-budgets),
+  [`Keyword retrieval`](../../../../ui/screens/story-settings/story-settings.md#keyword-retrieval).
+- [`story-settings.md → Mobile expression`](../../../../ui/screens/story-settings/story-settings.md#mobile-expression)
+  and [`patterns/save-sessions.md → Save bar`](../../../../ui/patterns/save-sessions.md#save-bar--the-visible-ui)
+  — the two canon lines the phone save-bar call weighs.
+- [`memory/cadence.md → User-tunable knobs`](../../../../memory/cadence.md#user-tunable-knobs)
+  — the buffer-aware cadence indicator and the `classifierContextEntries`
+  floor.
+- [`memory/retrieval.md → Keyword injection`](../../../../memory/retrieval.md#keyword-injection),
+  [`Keyword injection budget`](../../../../memory/retrieval.md#keyword-injection-budget),
+  [`Per-type retrieval budgets`](../../../../memory/retrieval.md#per-type-retrieval-budgets)
+  and [`The story-open upgrade prompt`](../../../../memory/retrieval.md#the-story-open-upgrade-prompt).
+- [`principles.md → Models are override-only`](../../../../ui/principles.md#models-are-override-only-per-story),
+  [`Composer mode`](../../../../ui/principles.md#composer-mode--send-time-transform-narration-aware)
+  and [`Stack-aware Return`](../../../../ui/principles.md#stack-aware-return).
+- [`architecture.md → Settings`](../../../../architecture.md#settings-strict-types-defaults-at-load)
+  — `resolveModel`'s chain and the M2 C3 failure vocabulary the
+  sentinel renders.
+- [`patterns/provider-model-picker.md → API`](../../../../ui/patterns/provider-model-picker.md#api).
+- [`story-list.md → Story card`](../../../../ui/screens/story-list/story-list.md#story-card--text-first)
+  — the `Edit info` entry and its one-shot Return.
+- [`data-model.md → Story settings shape`](../../../../data-model.md#story-settings-shape)
+  and [`Story identity fields`](../../../../data-model.md#story-identity-fields).
+- [Slice 3.11 → Implementation notes](../../03-memory-floor/slices/11-story-settings-shell.md#implementation-notes),
+  [Slice 3.7b → Implementation notes](../../03-memory-floor/slices/07b-suggestion-settings.md#implementation-notes)
+  and [Slice 3.2 → Scope: out](../../03-memory-floor/slices/02-piggyback.md#scope-out)
+  — the seam's real shape, the two queued calls this slice owns, and
+  where `piggybackMode`'s UI was deferred.
+
+## Scope: in
+
+- **Models tab:** the always-visible Narrative row with the
+  `App default: <model> (<profile>)` sentinel from `resolveModel`
+  (or the typed failure rendered as the broken-chain state),
+  `ProviderModelPicker` to pin a model id, `×` to clear;
+  `+ Add override` opening a picker over the five story agents
+  (`classifier`, `translation`, `suggestion`, `lore-mgmt`,
+  `retrieval` — `wizard-assist` is a global agent with no story slot)
+  each showing its resolved chain; override rows with picker and `×`;
+  a section joining the save session owning `models`; the
+  `story-settings.md → Agent overrides` line naming `wizard-assist`
+  corrected in this PR.
+- **About tab:** `title`, `description`, `tags` (`TagInput`), accent
+  color (`ColorPicker`, `(none)` = mode-derived, stored as null),
+  library status segment (`active` / `archived`), favorite `SwitchRow`
+  with star; cover **deferred** (asset gallery); a new
+  `updateStoryInfo` arm for the `stories` columns beside the M2.4
+  setters; the section joins the save session and the provider's
+  commit gains an optional **column patch** written in the same
+  transaction as the settings patch.
+- **`Edit info` routing:** the story card's `onEditInfo` boots the
+  story and lands on About; the first `←` returns to the library via
+  the navigation store's one-shot target.
+- **Authoring aids completion:** `composerModesEnabled` `SwitchRow`
+  (adventure-only — disabled with a hint in creative mode) and
+  `composerWrapPov` segment (`1st` / `3rd`) added to the M3.7b section;
+  the **definitional-change confirmation modal** at save for
+  `composerWrapPov` when the story has entries (built generically over
+  the flagged-field table so M7.2 adds `mode`, `narration` and
+  `activePackId` by listing them). The Generation-tab warn-box is
+  **not** added here — its copy describes genre / tone / setting,
+  which land with M7.2.
+- **Memory tab knobs**, each a section on the save session: chapter
+  threshold chip-row presets plus custom input and `chapterAutoClose`;
+  `fullChapterInBuffer` with the projected-cost line,
+  `partialChapterBuffer` (greyed in full mode), `protectedBuffer`,
+  `classifierContextEntries` (min 2), `classifierCadence` with the
+  buffer-aware overlap indicator and warning chip (partial mode only);
+  the five `retrievalBudgets` inputs; the **Keyword retrieval** panel
+  (`mode` select with explanation; `budgetShare`, `scanEntries`,
+  `cascade` and `cascadeMaxDepth` disclosed only under `Inject`).
+- **Story-open upgrade prompt:** an app-level host beside
+  `SwapResumeHost`, keyed on the open story and mounted after the
+  crash-recovery and swap-resume hosts so only one modal ever portals,
+  gated on no swap marker, the story's `embedding_model_id` differing
+  from the app default, the app default set, and
+  `embedding_upgrade_declined` not naming that default; three actions
+  — `Upgrade` fires the shipped `SwapDialog`; Keep (canon copy: Keep on the current model) writes the declined key; `Later` defers for the session
+  (overlay tap and hardware back map to it). The shipped
+  `SwapDialog`'s own `Keep` (the Memory-panel path) writes the same
+  key — the second write site.
+- **Phone save bar:** the one-line deliverable is that a dirty session
+  is visible from the phone rail state; the placement decision is an
+  [open question](#open-questions) below and lands with its canon
+  amendment in this PR.
+- **Tab-qualified invalid reason:** the snapshot already publishes
+  `invalidSectionId` and each section its `tab`; surface the tab
+  beside the reason in the save bar now that more than one section can
+  be invalid.
+- **Storybook:** each new section (empty / populated / disabled /
+  invalid), the sentinel states, the confirmation modal, the upgrade
+  prompt, the phone save-bar placement.
+
+## Scope: out
+
+- Generation's definitional fields (`mode`, `lead`, `narration`,
+  genre / tone / setting), their confirmations and the tab's warn-box
+  — M7.2.
+- The Classifier status block, `Run classifier now`, and the
+  `piggybackMode` toggle with its structured-output capability gate —
+  M7.2 (deferred there by Slice 3.2; the setting is readable since
+  M1.5). The Embedder section is unchanged apart from the `Keep`
+  write.
+- Probe section — M7.5.
+- Pack, Calendar, Translation, Advanced tabs — M7.2.
+- Cover upload — the asset gallery pass.
+- The standalone `Re-index this story now` button — shipped in M3.1b;
+  untouched.
+- App Settings' story-defaults mirror of the Memory knobs — M7.1.
+
+## Acceptance criteria
+
+- Pinning a narrative override writes `settings.models.narrative`;
+  the next turn's request in the mock LLM's recorded requests carries
+  that model id; clearing the override restores the sentinel and the
+  chain (E2E over the mock provider; vitest on the section patch).
+- Adding a `classifier` override writes `settings.models.classifier`
+  and `resolveModel('classifier')` returns it; `×` restores the chain
+  sentinel; `wizard-assist` is not offered (vitest on `resolveModel`
+  and the section patch; component test on the picker list).
+- The sentinel renders the resolved `<model> (<profile>)` and, with
+  the assignment removed, the `no-profile-assigned` state without
+  throwing (component test).
+- `Edit info` on a card lands on About with the fields populated;
+  editing `title` and saving updates the card; the first `←` returns
+  to the library, a second visit's `←` follows the stack (E2E).
+- A save with an About column edit and a Memory-tab knob both dirty
+  commits in one transaction; a rejected column patch rolls the
+  settings patch back (vitest on the provider commit).
+- Enabling composer modes on an adventure story makes the reader's
+  mode picker appear on return; the toggle is disabled with a hint on
+  a creative story; changing wrap POV on a story with entries raises
+  the confirmation modal and `Save anyway` commits (component tests on
+  the picker gate and the modal; vitest on the flag detection).
+- Cadence 12 with partial buffer 10 shows the warning chip; switching
+  to full mode hides it; `classifierContextEntries` cannot go below 2
+  (component test).
+- Setting keyword mode to `Inject` discloses the four controls; the
+  saved `keywordRetrieval` patch matches the schema; a keyworded lore
+  row is seated in the next turn's prompt (E2E via the probe capture,
+  over a lore row seeded with keywords).
+- Opening a story whose `embedding_model_id` differs from the app
+  default shows the prompt once; `Keep` writes
+  `embedding_upgrade_declined` and the prompt stays away on reopen;
+  changing the app default to a third model brings it back; `Later`
+  brings it back next launch; a pending swap marker suppresses it
+  (vitest on the gate matrix).
+- A dirty session with the rail collapsed on phone surfaces the save
+  bar, and the chosen placement is written into
+  `story-settings.md → Mobile expression` in the same PR (Storybook
+  viewport plus component test).
+- Two sections dirty and one invalid: the save bar names the tab of
+  the invalid one (component test).
+- Every chrome string routes through `t()`; new compounds have stories.
+
+## Tests
+
+- Vitest: section patches per tab, About column-patch commit and
+  rollback, upgrade prompt gate matrix, confirmation-modal flag
+  detection, cadence overlap arithmetic, `resolveModel` with
+  overrides.
+- Component tests: Models tab states, knob constraints, keyword
+  disclosure, modal, picker gate, phone save-bar placement,
+  tab-qualified reason.
+- Storybook: the matrix above.
+- E2E (desktop): override → turn over the mock provider; `Edit info`
+  round trip; keyword inject via the probe capture.
+
+## Open questions
+
+- **Phone save-bar placement.** Canon puts the bar inside the detail
+  route, so a dirty session collapsed back to the phone rail shows no
+  bar. Default: lift the bar to the surface level on phone, amending
+  `story-settings.md → Mobile expression` and
+  `save-sessions.md → Save bar` in this PR; alternative: keep canon and
+  add a dirty indicator on the rail rows. Record the call in
+  Implementation notes.
+- **About's column patch through the settings session.** The
+  provider merges `Partial<StorySettings>`; About needs
+  `Partial<Story>` columns. Default: extend the section contract with
+  an optional column patch — one save bar, one commit, per the
+  one-session-per-surface rule — rather than a second session.
+- **Upgrade prompt vs the other app-level hosts.** Recovery modal,
+  swap-resume prompt and upgrade prompt all key on boot or open; the
+  order above (recovery, resume, upgrade) is the default — confirm the
+  three never portal together.
+
+## Implementation notes
+
+_Populated at finish: notable deviations from the plan and resolved
+developer decisions._

--- a/docs/implementation/milestones/04-world-plot-read-surfaces/slices/05a-browse-rail.md
+++ b/docs/implementation/milestones/04-world-plot-read-surfaces/slices/05a-browse-rail.md
@@ -1,0 +1,183 @@
+# Slice 4.5a — Reader Browse rail
+
+## Metadata
+
+- **Milestone:** [Milestone 4 — World + Plot read surfaces](../milestone.md)
+- **Depends on:** [Slice 4.1](./01-world-shell.md) and
+  [Slice 4.3](./03-plot-panel.md) (the C2 list modules for all seven
+  categories; the C1 selectors; the C6 routes a row click lands on)
+- **Blocks:** [Slice 4.5b](./05b-peek-drawer.md) (the rail hosts the
+  peek and owns the Sheet morph seam, C10)
+
+## Goal
+
+The reader's placeholder column becomes the Browse rail: a
+seven-category dropdown grouped World / Plot, the same rows and
+queries the panels use, filter chips, search, the collapsed strip
+dashboard with per-kind classifier tint, the manual-plus-viewport
+collapse state model with hysteresis, the ~150 ms slide, and on phone
+the `[☰ Browse]` chip filling the shell's shipped chip-strip slot,
+opening the rail's content as a bottom Sheet built to morph into the
+peek (C10). Added at promotion: Slice 2.5 deferred the rail to
+"M4-era" and no roadmap slice owned it.
+
+## Background
+
+The rail is level one of entity surfacing — list only, fast glance,
+row click. It renders exactly what the World and Plot list panes
+render, at ~300 px, which is why it consumes C2 rather than building a
+third row set: any divergence is a prop. Collapsed, it is not a
+silhouette but a compact dashboard — scene counts for characters and
+items, quick-access cells for location and factions, each tinted by
+the strongest recently-classified signal of its kind — with three hit
+zones. Display is the product of two decoupled inputs: a manual
+preference persisted app-globally and an event-driven viewport
+collapse with ~80 px hysteresis that never overwrites the preference.
+Phone has no in-place rail; `ScreenShell` already ships the phone chip
+strip and a right-anchored `mobileChipAction` slot waiting for this
+chip, whose tint is the aggregate classifier signal.
+
+## Required reading
+
+- [`reader-composer.md → Layout`](../../../../ui/screens/reader-composer/reader-composer.md#layout),
+  [`Browse rail — collapse / expand`](../../../../ui/screens/reader-composer/reader-composer.md#browse-rail--collapse--expand)
+  through [`Animation`](../../../../ui/screens/reader-composer/reader-composer.md#animation),
+  [`Browse rail — search scope`](../../../../ui/screens/reader-composer/reader-composer.md#browse-rail--search-scope)
+  and [`Mobile expression`](../../../../ui/screens/reader-composer/reader-composer.md#mobile-expression)
+  — the whole rail contract, including the strip anatomy, hit zones,
+  state model and the phone rail-as-Sheet.
+- [`principles.md → World / Plot split`](../../../../ui/principles.md#world--plot-split--unified-panels-by-purpose)
+  — the grouped seven-category dropdown (with `Places` as the
+  location label).
+- [`patterns/entity.md → Entity surfacing`](../../../../ui/patterns/entity.md#entity-surfacing--three-levels-same-data),
+  [`Browse filter chips`](../../../../ui/patterns/entity.md#browse-filter-chips),
+  [`Accordion grouping on "All" view`](../../../../ui/patterns/entity.md#accordion-grouping-on-all-view)
+  and [`Recently-classified row accent`](../../../../ui/patterns/entity.md#recently-classified-row-accent)
+  (the strip's aggregation reads the same window).
+- [`collapse.md → Reader / composer`](../../../../ui/foundations/mobile/collapse.md#reader--composer-narrative--rail--narrative--rail-strip)
+  and [`State preservation on reflow`](../../../../ui/foundations/mobile/collapse.md#state-preservation-on-reflow).
+- [`navigation.md → Reader chip strip (phone-only)`](../../../../ui/foundations/mobile/navigation.md#reader-chip-strip-phone-only)
+  and [`touch.md → Chip-strip safe zone`](../../../../ui/foundations/mobile/touch.md#chip-strip-safe-zone),
+  [`Tap-to-tooltip on inert chrome text`](../../../../ui/foundations/mobile/touch.md#tap-to-tooltip-on-inert-chrome-text).
+- [`layout.md → Sheet`](../../../../ui/foundations/mobile/layout.md#sheet)
+  and [`Stacking`](../../../../ui/foundations/mobile/layout.md#stacking)
+  — the single-Sheet content-swap rule C10 encodes.
+- [`patterns/lists.md → Empty list / table state`](../../../../ui/patterns/lists.md#empty-list--table-state)
+  and [`No-results state`](../../../../ui/patterns/lists.md#no-results-state-search--filter-narrowed-to-zero).
+- [`data-model.md → Entry metadata shape`](../../../../data-model.md#entry-metadata-shape)
+  — the scene triple the strip counts from; factions not scene-tagged.
+- [`data-model.md → App settings storage`](../../../../data-model.md#app-settings-storage)
+  — where the manual preference most plausibly lives.
+- [Milestone contracts C1, C2, C6, C10](../milestone.md#slice-contracts).
+
+## Scope: in
+
+- **Expanded rail** (tablet / desktop): header with the `›` collapse
+  chevron; the grouped category `Select` (World: Characters, Places,
+  Items, Factions, Lore; Plot: Threads, Happenings — the label passed
+  into C2 per surface); per-category filter chips (entity chips; none
+  for lore; Plot's own); search with the rotating placeholder and
+  standard tooltip / ⓘ from C2's copy; the C2 renderers at the rail's
+  density, grouped on the All view by C2's grouping key (the 4.5a PR
+  adds the rail to `entity.md`'s per-surface key list); per-category
+  empty and no-results states from C2's copy; `+ Import from Vault`
+  footer (disabled, "Vault lands in M8"). Until 4.5b lands, a row
+  click routes straight to the owning panel with the row pre-selected
+  (C6).
+- **Collapsed strip:** the affordance chevron, Group A counted cells
+  (characters, items — counts from C1's in-scene selector, `0` muted,
+  `9+`), separator, Group B glyph cells (location, factions), empty
+  region; per-cell tint from C1's per-kind aggregate; three hit zones
+  with their tooltips; hover per zone; tablet long-press tooltip.
+- **State model:** manual preference (chevron, strip, `Cmd/Ctrl+\`)
+  persisted app-globally; viewport-forced collapse on a downward
+  cross of ~900 px and restore on an upward cross of ~980 px,
+  event-driven, preference untouched; first-launch default open;
+  ~150 ms symmetric slide with the narrative edge in lockstep;
+  collapsing closes an open peek (the hook 4.5b binds to).
+- **Phone Browse chip:** fills `ScreenShell`'s shipped
+  `mobileChipAction` slot with the right-anchored `[☰ Browse]` chip,
+  tinted by C1's aggregate across every rail-surfaceable category; tap
+  opens the rail content as a Sheet (bottom, medium initial).
+- **C10 morph seam:** the Sheet host holding `{ content, size }`,
+  rendering the rail vocabulary for `list`, an empty slot for `peek`,
+  and changing the Sheet's detent on a content swap; a criterion below
+  exercises the size change so 4.5b inherits a working morph.
+- **Placeholder removal:** the `railPlaceholder` string and column go.
+- **Storybook:** rail per category, collapsed strip tint states,
+  phone chip and Sheet, the morph seam at both sizes.
+
+## Scope: out
+
+- The peek drawer and the Sheet's peek content — [Slice 4.5b](./05b-peek-drawer.md).
+- Row renderers, queries and copy — consumed, not built (C2).
+- The rail's `scope chip if active` row from the Layout sketch — the
+  awareness-scoped browse it implies has no v1 spec beyond the parked
+  character-side Awareness tab; the row is omitted until that work
+  exists.
+- The other three phone chips — M5 (chapter), M6 (branch), M7.2
+  (time-chip era affordances).
+- Vault import — M8.3.
+
+## Acceptance criteria
+
+- A vitest imports the rail's renderer map and the C2 modules and
+  asserts referential identity for all seven categories (the rail
+  mounts 4.1's and 4.3's renderers, never copies); search scope copy
+  rotates with the category (component test).
+- The strip's character cell shows the count of characters in the
+  tail entry's `sceneEntities`, renders `9+` above nine and muted at
+  zero; a cell whose kind has a fresh classifier write tints full,
+  fading tints half, otherwise none (vitest on the aggregation plus
+  Storybook).
+- Clicking a cell expands the rail **and** switches its category;
+  the chevron and empty region expand without switching (component
+  test).
+- Resizing below ~900 px collapses the display without changing the
+  stored preference; resizing back above ~980 px restores it; a
+  manual expand inside the small window sticks until the next
+  downward cross (vitest on the state reducer with fake resize
+  events).
+- The manual preference persists: after toggling, the stored value is
+  readable from the settings row (E2E asserting the DB through the
+  fixture helper; a relaunch assertion only if the harness gains a
+  second `launchApp` against the same user-data directory).
+- On phone the Browse chip renders in the shell's slot; tapping opens
+  the Sheet with the full rail vocabulary; a test-only content swap to
+  `peek` grows the Sheet to the tall detent and back; drag-down and
+  backdrop dismiss it (component test on the Sheet host; manual on
+  Android).
+- `Cmd/Ctrl+\` toggles regardless of focus (E2E on desktop).
+- `reader:railPlaceholder` no longer exists in `locales/` and no
+  component references it (grep in review; the i18n key test if one
+  exists).
+- Every chrome string routes through `t()`; new compounds have stories.
+
+## Tests
+
+- Vitest: state reducer (manual / viewport / hysteresis), strip
+  aggregation, renderer identity, preference persistence.
+- Component tests: rail per category, hit zones, chip, Sheet host and
+  morph.
+- Storybook: the matrix above including narrow-window and phone.
+- E2E (desktop): open reader → rail rows → collapse / expand →
+  preference in DB.
+
+## Open questions
+
+- **Preference storage.** Default assumption: an additive
+  `app_settings.appearance.readerRailCollapsed` boolean with a Zod
+  default (the `showJumpToBottom` precedent). Alternative: device
+  storage outside the DB. Canon calls this an implementation detail.
+- **Chapterless phone strip.** Canon hides the whole strip — Browse
+  chip included — until the story has a chapter, which makes the rail
+  unreachable on phone for every story before M5. Default: show the
+  strip with the Browse chip whenever the branch has any browsable
+  row, and amend `navigation.md`'s empty-state rule in this PR.
+- **Rail width.** Canon says ~300 px; the placeholder is 260 px. Pick
+  at planning against the reader's narrow-window behavior.
+
+## Implementation notes
+
+_Populated at finish: notable deviations from the plan and resolved
+developer decisions._

--- a/docs/implementation/milestones/04-world-plot-read-surfaces/slices/05b-peek-drawer.md
+++ b/docs/implementation/milestones/04-world-plot-read-surfaces/slices/05b-peek-drawer.md
@@ -1,0 +1,149 @@
+# Slice 4.5b — Peek drawer
+
+## Metadata
+
+- **Milestone:** [Milestone 4 — World + Plot read surfaces](../milestone.md)
+- **Depends on:** [Slice 4.5a](./05a-browse-rail.md) (the rail hosts
+  the peek and owns the Sheet morph seam, C10; C1 and C6 reach this
+  slice through 4.5a's gates) and [Slice 4.2a](./02a-entity-detail.md)
+  (the peek body is the Overview component in its `peek` variant;
+  `Set as lead` calls C5)
+- **Blocks:** none
+
+## Goal
+
+Clicking a rail row opens the peek drawer — a ~440 px right Sheet on
+desktop and tablet, the rail Sheet morphed to its tall detent on phone
+— whose body is the World panel's Overview component for entities, the
+read-only Body-plus-signals projection for lore, and a summary for
+threads and happenings; whose head carries the `You` / `Protagonist`
+badge or the `Set as lead` action for characters; and whose foot link
+`Open in [World|Plot] panel →` lands the panel with the row
+pre-selected (C6).
+
+## Background
+
+Peek is level two of entity surfacing: summary plus escalation. Canon
+insists on one design, two surfaces — the peek body **is** the
+Overview tab rendered narrower, including the non-default injection
+chip — so this slice renders 4.2a's exported component with its `peek`
+variant rather than restating it. Lore has no Overview, so its peek is
+its own read-only composition. The lead-character mutation is the only
+inline write on the peek; no confirm, the reader's `You` anchor
+re-anchoring is the feedback. Peek implies rail open: collapsing the
+rail closes the peek, and on phone the peek is the `peek` content
+state of the rail Sheet with an icon-only `←` rather than a second
+Sheet.
+
+## Required reading
+
+- [`reader-composer.md → Peek drawer — lead affordance for characters`](../../../../ui/screens/reader-composer/reader-composer.md#peek-drawer--lead-affordance-for-characters),
+  [`State-field composition — same as World panel Overview`](../../../../ui/screens/reader-composer/reader-composer.md#state-field-composition--same-as-world-panel-overview),
+  [`State-field composition — lore peek`](../../../../ui/screens/reader-composer/reader-composer.md#state-field-composition--lore-peek),
+  [`Peek drawer — peek implies rail open`](../../../../ui/screens/reader-composer/reader-composer.md#peek-drawer--peek-implies-rail-open)
+  and the peek bullets of
+  [`Mobile expression`](../../../../ui/screens/reader-composer/reader-composer.md#mobile-expression).
+- [`world.md → Overview — glance summary, read-mostly`](../../../../ui/screens/world/world.md#overview--glance-summary-read-mostly)
+  — the component being projected.
+- [`patterns/entity.md → Entity surfacing`](../../../../ui/patterns/entity.md#entity-surfacing--three-levels-same-data).
+- [`patterns/save-sessions.md → Quick-edit exception — peek drawer`](../../../../ui/patterns/save-sessions.md#quick-edit-exception--peek-drawer)
+  — the exception this slice does **not** build; see Scope: out.
+- [`principles.md → Mode, lead, and narration`](../../../../ui/principles.md#mode-lead-and-narration--three-orthogonal-concepts).
+- [`layout.md → Surface bindings`](../../../../ui/foundations/mobile/layout.md#surface-bindings--existing-app-surfaces)
+  (the Peek drawer row) and
+  [`Mapping — desktop to mobile`](../../../../ui/foundations/mobile/layout.md#mapping--desktop-to-mobile).
+- [`navigation.md → Cross-surface navigation model`](../../../../ui/foundations/mobile/navigation.md#cross-surface-navigation-model)
+  and [`collapse.md → Two-pane navigation surfaces`](../../../../ui/foundations/mobile/collapse.md#two-pane-navigation-surfaces-world-plot-settings)
+  — the pre-selected deep link on both tiers.
+- [Milestone contracts C1, C5, C6, C10](../milestone.md#slice-contracts).
+
+## Scope: in
+
+- **Drawer host:** desktop / tablet right Sheet (~440 px) sliding
+  over rail and narrative; `×` and Esc close; opening on rail-row
+  click only (replacing 4.5a's interim route-to-panel); closing when
+  the rail collapses (manual or viewport-forced).
+- **Peek head:** kind icon, name, the C1 recently-classified badge;
+  for characters the `You` / `Protagonist` badge (mode-dependent copy)
+  when lead, otherwise the inline `Set as lead` text-action calling
+  C5 and transitioning in place; portrait thumbnail slot (placeholder
+  until the asset link exists).
+- **Peek body:** entities — 4.2a's Overview in its `peek` variant at
+  440 px, with `onRegionPress(tab)` routing to the World panel via C6's
+  `tab` param; lore — chip row (injection chip when non-default,
+  category chip), body truncated at ~10 lines, tags; threads — status,
+  category, description; happenings — when-marker, `⊙` if common
+  knowledge, description, involvement and awareness counts.
+- **Foot link:** `Open in World panel →` / `Open in Plot panel →`
+  routing with `{ kind, id }` (C6); on phone the destination mounts in
+  detail state.
+- **Phone content:** fills C10's `peek` slot — row tap inside the
+  rail Sheet swaps content and grows to the tall detent; icon-only `←`
+  returns to the list; drag-down and backdrop dismiss the whole Sheet
+  from either state.
+- **Reader hooks:** the `You` anchor and narration re-anchor after
+  `Set as lead` (already store-driven; assert it).
+- **Storybook:** peek per kind at 440 px, lead / not-lead heads,
+  phone content states.
+
+## Scope: out
+
+- Pencil quick-edits on peek text fields.
+  [`reader-composer.md → State-field composition`](../../../../ui/screens/reader-composer/reader-composer.md#state-field-composition--same-as-world-panel-overview)
+  makes the lead mutation the peek's only inline write, while
+  `save-sessions.md` and `collapse.md` still spec the blur-commit
+  exception; M4 follows the reader doc and the edits are filed in
+  [`parked.md → Peek quick-edits`](../../../../parked.md#peek-quick-edits)
+  with the canon conflict noted.
+- The rail and the Sheet host — [Slice 4.5a](./05a-browse-rail.md).
+- Overview composition — [Slice 4.2a](./02a-entity-detail.md).
+
+## Acceptance criteria
+
+- A vitest asserts the peek body for an entity and the World panel's
+  Overview tab resolve to the same exported component reference;
+  clicking a character row opens the peek showing the same regions the
+  panel shows for that row (Storybook side by side at 440 px).
+- `Set as lead` on a non-lead character writes
+  `definition.leadEntityId`, the head switches to the badge without a
+  confirm, and the reader's `You` badge moves (E2E on desktop).
+- The action is absent on every non-character kind; on the current
+  lead the badge reads `You` in adventure mode and `Protagonist` in
+  creative (component test).
+- Collapsing the rail while a peek is open closes both; the peek
+  cannot be opened while collapsed (component test).
+- `Open in World panel →` lands World with the row selected on
+  desktop; pressing the Overview's visual line lands World on the
+  Identity tab; `Open in Plot panel →` from a happening peek lands Plot
+  with that row selected; on phone each lands in the detail state with
+  the first `←` returning to the list (E2E on desktop; manual on
+  Android).
+- On phone, a row tap morphs the Sheet to the peek at the tall
+  detent, `←` returns to the list, drag-down dismisses from the peek
+  state (component test on the C10 state machine; manual on Android).
+- Lore peek truncates a 40-line body at ~10 lines with an ellipsis and
+  hides `priority` (Storybook plus component test).
+- Every chrome string routes through `t()`; new compounds have stories.
+
+## Tests
+
+- Vitest: peek state machine (open / close / rail-collapse / phone
+  content swap), per-kind body selection, component-reference
+  identity.
+- Component tests: heads per lead state, foot routing, lore
+  truncation.
+- Storybook: the matrix above.
+- E2E (desktop): rail row → peek → Set as lead → Open in panel (both
+  panels).
+
+## Open questions
+
+- **Thread / happening peek content.** Canon says the peek-head is
+  unchanged for those kinds and defines no body; the summaries above
+  are the default assumption — confirm and, if kept, add a line to
+  `reader-composer.md`.
+
+## Implementation notes
+
+_Populated at finish: notable deviations from the plan and resolved
+developer decisions._

--- a/docs/implementation/milestones/04-world-plot-read-surfaces/slices/06-import-export.md
+++ b/docs/implementation/milestones/04-world-plot-read-surfaces/slices/06-import-export.md
@@ -1,0 +1,178 @@
+# Slice 4.6 — Per-row `.avts` import and export
+
+## Metadata
+
+- **Milestone:** [Milestone 4 — World + Plot read surfaces](../milestone.md)
+- **Depends on:** the build-independent half (envelope kinds, payload
+  schemas, import actions, export serializers — C9) is day-one; the
+  import wiring needs [Slice 4.1](./01-world-shell.md) and
+  [Slice 4.3](./03-plot-panel.md) (the `[+]` menus); the export wiring
+  needs [Slice 4.2a](./02a-entity-detail.md),
+  [Slice 4.2b](./02b-lore-history-delete.md) and
+  [Slice 4.3](./03-plot-panel.md) (the C11 menus)
+- **Blocks:** none in M4 (M8.3 vault calendars and M9.4 story import
+  reuse the wiring pattern)
+
+## Goal
+
+The shipped `ImportDialog` gets its first consumers: World and Plot
+`[+] From JSON file…` for entities (kind-narrowed), lore, threads and
+happenings, over the four per-row envelope kinds with Zod payload
+schemas (C9) and import actions that create rows through the existing
+arms. The matching export lands in the same slice: `⋯ → Export … as
+JSON` on every detail head writes the envelope to a file on desktop
+and hands it to the share sheet on native. Decided at promotion: one
+owner for both directions so the envelope has one writer and one
+reader.
+
+## Background
+
+`.avts` is one envelope for every kind — `format`, `formatVersion`,
+`exportedAt`, and a payload under the kind's key. Per-UI gating means
+each slot accepts only its kind; for entities the slot is per
+entity-kind, so the schema passed to the dialog is narrowed with a
+`.refine` on `kind` and a wrong-kind file surfaces as a payload error
+rather than a wrong-kind row. The dialog is pure View — read,
+meta-check, validate, emit — and self-closes; hosts own the trigger
+and run the success effect in `onValidated`. The roadmap's
+install-and-rebuild prerequisite is already satisfied:
+`expo-document-picker` and `expo-file-system` are installed and
+imported by the dialog. What native lacks is a way to hand an
+exported file to the user.
+
+## Required reading
+
+- [`data-model.md → Aventuras file format`](../../../../data-model.md#aventuras-file-format-avts)
+  — envelope, kinds table, version handling, per-UI gating, extension
+  policy.
+- [`patterns/import-dialog.md`](../../../../ui/patterns/import-dialog.md)
+  in full — props, validation pipeline, and especially
+  [`World per-row entity import`](../../../../ui/patterns/import-dialog.md#world-per-row-entity-import),
+  [`Plot per-row import`](../../../../ui/patterns/import-dialog.md#plot-per-row-import),
+  [`Host gating during in-flight generation`](../../../../ui/patterns/import-dialog.md#host-gating-during-in-flight-generation)
+  and [`Implementation prerequisites`](../../../../ui/patterns/import-dialog.md#implementation-prerequisites).
+- [`patterns/data.md → Import counterparts`](../../../../ui/patterns/data.md#import-counterparts--file-based--vault).
+- [`world.md → Per-row import`](../../../../ui/screens/world/world.md#per-row-import),
+  [`Detail head structure`](../../../../ui/screens/world/world.md#detail-head-structure)
+  (the export entry) and
+  [`Required body`](../../../../ui/screens/world/world.md#required-body--creation--edit-invariant)
+  (the import half of the invariant).
+- [`plot.md → Manual creation + per-row import`](../../../../ui/screens/plot/plot.md#manual-creation--per-row-import).
+- [`data-model.md → Happenings & character knowledge`](../../../../data-model.md#happenings--character-knowledge)
+  — the time-anchor exclusivity the happening schema refines, and why
+  entry refs cannot travel between stories.
+- [`data-model.md → Backup & export format`](../../../../data-model.md#backup--export-format)
+  — what the story-level export strips (the per-row export strips the
+  same server-owned fields).
+- [`memory/retrieval.md → Compute lifecycle`](../../../../memory/retrieval.md#compute-lifecycle)
+  — imported rows are `embedding_stale` until the drain embeds them.
+- [Milestone contracts C9, C11, C12](../milestone.md#slice-contracts).
+
+## Scope: in
+
+- **C9 module:** `EntityImportSchema` (discriminated union over the
+  four kinds, `state` per kind, server-owned columns excluded),
+  `LoreImportSchema` (body required), `ThreadImportSchema` (status
+  required; entry refs stripped), `HappeningImportSchema` (time-anchor
+  exclusivity; `occurred_at_entry_id` stripped since entry ids do not
+  travel; `temporal` kept; involvements and awareness **not**
+  imported — their ids are branch-local, and any such keys in a
+  hand-authored file are dropped); per-kind import actions creating
+  the row through the existing create arm with `source = 'user_edit'`,
+  `embedding_stale = 1`, keywords normalized through C12, a fresh
+  kind-prefixed id, returning it; per-kind export serializers
+  producing the envelope (`formatVersion` `1.0`, `exportedAt`,
+  server-owned fields and `app_settings` references stripped;
+  happening export carries the row alone — the raw JSON viewer, not
+  the file, is where links show).
+- **Import wiring:** the four hosts' `From JSON file…` entries enabled
+  and mounting `ImportDialog` with `format`, `supportedMajor`,
+  `payloadKey`, the schema (entity slot narrowed to the active kind),
+  `title`, and an `onValidated` that runs the import action and
+  selects the new row; the entry disabled while generation is in
+  flight per the host-gating rule.
+- **Export wiring:** the four C11 entries — one shared by the four
+  entity kinds in 4.2a's panes, one each on 4.2b's lore pane and 4.3's
+  thread and happening panes — enabled; desktop / web writes a
+  download named `<kind>-<slug>.avts`; native hands the file to the OS
+  share sheet.
+- **Native share path:** `expo-sharing` added (a native module — the
+  slice needs a dev-client rebuild before native runtime, per
+  [`lessons-learned/native-dep-expo-link.md`](../../../lessons-learned/native-dep-expo-link.md));
+  the file written under the app's cache directory via
+  `expo-file-system`.
+- **Storybook:** the dialog already has its matrix; add one story per
+  host title. **i18n:** the host copy in `world` / `plot`.
+
+## Scope: out
+
+- Story-level `.avts` export / import — M9.4.
+- Vault calendars import — M8.3.
+- Universal import dispatcher, legacy `.avt` migration, pre-import
+  preview, drag-and-drop, forward-compat field-loss advisory — parked.
+- Importing link rows (involvements, awareness, relationships) with a
+  happening or entity — not in v1; the payloads are single rows.
+
+## Acceptance criteria
+
+- Exporting a character produces an `aventuras-entity` envelope with
+  `entity.kind = 'character'`, no `id` / `branch_id` /
+  `embedding_stale` / `name_collision_flag`, and `formatVersion`
+  `1.0` (vitest on the serializer).
+- Importing that file on another story through the Characters slot
+  creates a row with a fresh id, `embedding_stale = 1`, one
+  `createEntity` delta, and selects it (vitest on the import action
+  against the in-memory test DB; component test on host selection);
+  through the Locations slot the dialog surfaces the payload-error
+  state with exactly one issue whose path is `kind` (vitest on the
+  narrowed schema; component test on the dialog's issue list).
+- A happening file with both `occurred_at_entry_id` and `temporal`
+  fails at Stage 3 naming the refine; a valid one imports with
+  `occurred_at_entry_id = null` and `temporal` intact; one
+  hand-authored with `involvements` / `awareness` keys imports the row
+  alone and drops them (vitest on schema and action).
+- A lore file with an empty `body` fails at Stage 3 (vitest).
+- A `formatVersion: "2.0"` file fails at Stage 2 with the newer-version
+  banner in every host (component test through the dialog's forced
+  seam).
+- `From JSON file…` is disabled with the in-flight tooltip during a
+  turn (component test).
+- The clipboard import path creates the row on desktop (E2E asserting
+  the new row in the DB — the one E2E, and only once the clipboard
+  permission seam is proven at planning; otherwise manual smoke).
+- On Android the export opens the share sheet with an `.avts` file
+  (manual smoke; dev client rebuilt).
+- `pnpm typecheck` passes with the new dependency, and if the desktop
+  export takes the IPC route, `tsc -p electron/tsconfig.json` passes
+  too; every chrome string routes through `t()`.
+
+## Tests
+
+- Vitest: four schemas (happy, wrong kind, stripped fields, refines,
+  dropped link keys), four import actions, four serializers,
+  round-trip equality on the portable fields.
+- Component tests: host wiring and gating, dialog issue list.
+- E2E (desktop): clipboard import round trip, if the permission seam
+  allows; export covered by vitest plus manual smoke.
+
+## Open questions
+
+- **Clipboard permission under Playwright plus Electron.** No existing
+  spec drives `navigator.clipboard.readText()`; prove the seam at
+  planning before committing to the E2E, else the import happy path is
+  manual smoke.
+- **Web download mechanics under Electron.** A data-URL anchor click
+  works in the renderer; confirm the Electron main process does not
+  intercept downloads, or route through a `dialog.showSaveDialog` IPC
+  if it does (nothing in the E2E harness can observe a download
+  either way).
+- **Export filename slug.** Name-derived, ASCII-folded, kind-prefixed
+  (`character-kael.avts`) is the default; the story export in M9.4
+  should match.
+- **Import of a `staged` entity.** Status travels; confirm a staged
+  import is what the user expects versus forcing `active`.
+
+## Implementation notes
+
+_Populated at finish: notable deviations from the plan and resolved
+developer decisions._

--- a/docs/implementation/milestones/README.md
+++ b/docs/implementation/milestones/README.md
@@ -26,3 +26,9 @@ directory (`NN-name/`) with a `milestone.md` definition and a
   retrieval + ranker, dev probe, full wizard World / Cast steps,
   suggestions, worldTime editing, batched undo, regenerate;
   fourteen slices, five day-one startable.
+- [Milestone 4 — World + Plot read surfaces](./04-world-plot-read-surfaces/milestone.md).
+  Memory-pipeline output becomes browsable and correctable: World panel
+  (shell, per-kind detail, lore, History, delete, collision review), Plot
+  panel, reader Browse rail and peek drawer, Story Settings basic surface,
+  per-row `.avts` import and export; nine slices, three day-one
+  startable.

--- a/docs/implementation/roadmap.md
+++ b/docs/implementation/roadmap.md
@@ -17,7 +17,8 @@ defined `milestone.md`.
   [M1.5 — Data foundation](./milestones/01b-data-foundation/milestone.md)
   (inserted between M1 and M2; no renumber),
   [M2 — First user loop](./milestones/02-first-user-loop/milestone.md),
-  and [M3 — Memory floor](./milestones/03-memory-floor/milestone.md).
+  [M3 — Memory floor](./milestones/03-memory-floor/milestone.md), and
+  [M4 — World + Plot read surfaces](./milestones/04-world-plot-read-surfaces/milestone.md).
   M1.5 front-loads
   the full relational schema, typed working-set stores, and Tier-1 CRUD
   arms, so the planned milestones below **no longer carry their own
@@ -147,208 +148,9 @@ M9.3.
 
 ### M4 — World + Plot read surfaces
 
-**Goal.** Users can browse and edit the entity graph the memory
-pipeline produces. World panel renders entities by kind with
-overview + state tabs; Plot panel renders happenings with
-awareness; story settings exposes the controls users need now
-that real data exists (model overrides, basic per-story config).
-
-**Why now.** M3 produces entity / lore / happening / awareness
-rows; without surfaces to browse + edit them, the memory pipeline
-is invisible. This milestone is read-heavy with light edit; full
-chapter-management is M5.
-
-**Likely slices.**
-
-- M4.1 — World panel shell + per-kind tabs (characters /
-  locations / items / factions / etc.) + entity list rows.
-- M4.2 — Entity detail surface: overview tab, state tab, per-kind
-  fields per
-  [`docs/ui/screens/world/world.md`](../ui/screens/world/world.md).
-  Collision-review + entity-merge driver wires the shipped
-  `CollisionResolveDialog` against `name_collision_flag` rows
-  per [`patterns/collision-resolve.md`](../ui/patterns/collision-resolve.md).
-  **The dialog's own `InjectionMode` is drifted** — `collision-resolve-diff.ts`
-  declares `'always' | 'on-relevance' | 'never'` against the shipped
-  enum `'always' | 'auto' | 'disabled'` (`lib/db/enums.ts`). Harmless
-  while the compound is unwired; a type error the moment the driver
-  passes it a real row, so fix it as the first step of wiring rather
-  than mid-way.
-  `LocationState.parent_location_id` cycle-guard (action-layer
-  pre-commit walk, depth-cap 100) per
-  [`data-model.md → LocationState`](../data-model.md#locationstate-shape).
-  Entity search scope across `state` JSON via `json_extract` /
-  `json_each` per
-  [`patterns/entity.md → Search scope`](../ui/patterns/entity.md#search-scope).
-  **Entity delete needs the cascade merge already specifies.** The
-  overflow menu carries `Delete entity` per
-  [`world.md → Detail head`](../ui/screens/world/world.md), and
-  `deleteEntity` (`lib/actions/entities/register.ts`) deletes the
-  `entities` row and nothing else — `happening_involvements.entity_id`,
-  `happening_awareness.character_id` and `character_relationships.a_id` /
-  `b_id` are all FK-less by necessity (composite PK), so SQLite enforces
-  nothing and the rows dangle silently. The write set is already canon for
-  the merge path
-  ([`world.md → Merge writes`](../ui/screens/world/world.md)) — link rows,
-  inverse `state` refs on other entities, translations — and delete wants
-  the same list minus the rewrite-to-canonical half. Open where merge is
-  silent: `metadata.sceneEntities`. Historical entries keep the id and
-  render it as an Unknown-entity chip
-  ([`entry-card.md → World-state panel`](../ui/patterns/entry-card.md#world-state-panel)),
-  but the tail's copy is live — it drives retrieval's
-  `sceneEntities ∩ characters` union and prompt injection — so the tail
-  wants the id dropped the way the scene editor drops it.
-- M4.3 — Plot panel shell + threads tab + happenings tab; happenings
-  list with awareness tab on detail per
-  [`docs/ui/screens/plot/plot.md`](../ui/screens/plot/plot.md).
-  Threads data may be sparse until M5's chapter-close populates it
-  reliably; the surface ships in M4. Entry-ref picker primitive
-  (for `triggered_at_entry_id` / `resolved_at_entry_id` /
-  `occurred_at_entry_id` / `learned_at_entry_id` fields) ships here as
-  the first consumer; pattern reused across later entry-ref
-  surfaces.
-- M4.4 — Story settings real (basic): model overrides + basic
-  per-story config — the settings depth users need with real data
-  flowing. Deep settings tabs land in M7.
-- M4.5 — Reader-composer awareness affordances: peek drawer +
-  awareness chips on entries per
-  [`reader-composer.md → Peek drawer`](../ui/screens/reader-composer/reader-composer.md#peek-drawer--lead-affordance-for-characters).
-  Gates on M3.3 awareness writes.
-- M4.6 — Per-row imports: first wiring of the already-built
-  `ImportDialog` compound — World / Plot per-row entity / lore /
-  thread / happening import per
-  [`patterns/import-dialog.md`](../ui/patterns/import-dialog.md);
-  adds the per-row `.avts` envelope kinds (`aventuras-entity`,
-  `aventuras-lore`, `aventuras-thread`, `aventuras-happening`)
-  with kind-narrowed Zod payload schemas per
-  [`data-model.md → Aventuras file format`](../data-model.md#aventuras-file-format-avts).
-  Implementation prerequisite: `expo-document-picker` +
-  `expo-file-system` install and a dev-client rebuild **before
-  the slice runs** (web has no native-build step). Pattern reused
-  by vault calendar import (M8.3) and story import (M9.4).
-
-**Parallel paths.** {M4.1, M4.2} || {M4.3} || {M4.4} || {M4.5};
-M4.6 once the M4.1 / M4.3 shells exist to host the import
-affordances.
-
-Carried deferrals, routed out of [`triage.md`](./triage.md)
-2026-08-18 and 2026-08-20, verified against the code first. Two more
-moved to [`followups.md`](../followups.md) 2026-09-05, wanting a design
-pass before any slice could own them: the story-open swap prompt came
-back 2026-09-09 with its suppression rule settled, and failed-turn text
-custody is still there. Entries below that name canon with no surface
-arrive from the other direction — spec that landed ahead of its screen,
-rather than a deferral routed out of implementation.
-
-- **M4.4 — The phone list state hides a dirty save bar.** `StorySettingsShell`
-  renders the bar inside the detail pane, and `MasterDetailLayout`
-  drops that pane on phone when no tab is selected. No data loss —
-  panels stay mounted, and `←` and window-close both route through
-  the guard — but the unsaved state is invisible. Canon argues
-  against the obvious fix:
-  [`save-sessions.md → Save bar`](../ui/patterns/save-sessions.md#save-bar--the-visible-ui)
-  says the bar "spans the editable pane only — never the rail," and
-  [`story-settings.md → Mobile expression`](../ui/screens/story-settings/story-settings.md#mobile-expression)
-  puts it at "the bottom edge of the detail-route's scroll region."
-  Accepted at M3.7b planning; the call belongs to M4.4, the surface's
-  real owner. Surfaced by M3.7b implementation (2026-07-31).
-- **M4.4 — M2.5's composer modes are unreachable on every real story.**
-  `composerModesEnabled` defaults to `false` in
-  `lib/db/stories/story-settings-defaults.ts`, and app-level
-  `defaultStorySettings` carries only `activePackId`, so no story is
-  ever created with it on and no UI can flip it — the same
-  dead-feature shape M3.7b just fixed for `suggestionsEnabled`. Canon
-  puts its toggle and wrap-POV in the same Authoring aids grouping
-  M3.7b's section lives in, so M4.4 completing that grouping is the
-  natural owner. Surfaced by M3.7b implementation (2026-07-31).
-- **M4.2 — The wizard commits `parent_location_id` without the documented
-  cycle guard.**
-  [`data-model.md → LocationState shape`](../data-model.md#locationstate-shape)
-  assigns cycle prevention to the action-layer mutator that writes
-  the field: walk the proposed parent chain, depth-cap 100, reject
-  with `reason: 'parent-cycle'`. Finish is such a writer and does no
-  walk, and neither authoring path blocks it — the editor's picker
-  and `cast-import.ts` each exclude only self, so `A → B` plus
-  `B → A` authors and commits cleanly. Inert today: nothing walks the
-  chain, and the only reader canon names is M4's prompt rendering
-  (`Aria is in [Shop in Town Square in City]`). Close by adopting M4's
-  shared guard rather than writing a wizard-local copy of it. Raised
-  2026-08-14.
-- **M4.2 — The first delete surface has to sweep the row's vectors.**
-  `deleteVecOps` (`lib/db/embeddings/ops.ts`) exists and is exported
-  through both barrels, but has **no production caller**, and there are
-  no SQL triggers in `lib/db/migrations/`, so nothing else reaches the
-  vec tables per row. Story delete is already covered — it calls the
-  branch-scoped `deleteBranchVecOps` — and `deleteEntity`, `deleteLore`,
-  `deleteHappening` and `deleteChapter` have no production caller yet, so
-  nothing leaks today; the leak starts with the first delete button.
-  Whichever slice ships that button owns wiring the four handlers, and it
-  is not only the delete arm: reverse-replay restores the row and
-  Slice 3.12a already forces it dirty so the drain re-embeds it, but
-  `applyRedo` re-applies the delete and would need to re-sweep. Retrieval
-  never serves orphans — its candidate pools are built from source rows —
-  so this is unbounded dead weight that survives an embedder swap, not
-  wrong results. Surfaced by Slice 3.12a review (2026-08-19), verified and
-  routed 2026-08-20.
-- **M4.2 — Entity and lore keyword editors are specced with no surface.**
-  The 2026-09-06 keyword-retrieval design added `keywords` and
-  `priority` to the entity Settings tab
-  ([`world.md → Settings`](../ui/screens/world/world.md#settings--entity-management-chrome))
-  and `keywords` to lore's
-  ([`world.md → Settings tab — lore`](../ui/screens/world/world.md#settings-tab--lore)),
-  both wireframed in `world.html`. The lore one is new scope rather than
-  a field added to an existing panel: lore had no documented edit
-  surface anywhere before that commit. Until they ship, entity keywords
-  reach the database only through the periodic classifier and lore
-  keywords only through seed data, so the user-authored half of a
-  pathway canon calls load-bearing has no way in. Introduced by the
-  keyword-retrieval design (2026-09-06).
-- **M4.4 — The Keyword retrieval settings panel is specced with no
-  surface.** Five `keywordRetrieval` knobs — `mode`, `budgetShare`,
-  `scanEntries`, `cascade`, `cascadeMaxDepth` — are specced and
-  wireframed at
-  [`story-settings.md → Keyword retrieval`](../ui/screens/story-settings/story-settings.md#keyword-retrieval)
-  and land in `stories.settings` ahead of the panel. Settings-only with
-  no UI is the established pattern here, not a gap — `piggybackMode` and
-  the composer modes both shipped that way — but `mode: 'inject'` is a
-  behaviour users will expect to reach, and the entry above is what
-  makes its keywords authorable in the first place, so the two want
-  sequencing together. Introduced by the keyword-retrieval design
-  (2026-09-06).
-- **M4.4 — The story-open upgrade prompt is specced with no surface.**
-  [`retrieval.md → The story-open upgrade prompt`](../memory/retrieval.md#the-story-open-upgrade-prompt)
-  specs the second swap entry point Slice 3.1b left unbuilt: an
-  app-level host beside `SwapResumeHost` (`app/_layout.tsx`), gated on
-  the swap marker being absent, the story's model differing from the
-  app default, and `embedding_upgrade_declined` not naming that
-  default. Three actions mirroring `SwapResumeDialog` — Upgrade fires
-  the shipped swap dialog, Keep on the current model writes the
-  declined key, Later defers for the session only. The swap dialog's
-  own Keep option writes that same key, so the Story Settings path is
-  part of this work rather than a separate follow-up. The key itself
-  already parses — `storySettingsSchema` carries it optional — so what
-  is missing is the host, the gate and the two write sites. Routed out
-  of [`followups.md`](../followups.md) 2026-09-09, once the suppression
-  rule was settled.
-
-**Gates.** M3 for real-data validation (no entities without the
-classifier; no awareness without it; no retrieval scores without
-retrieval). The UI build itself can look ahead against seeded mock
-rows — the entity / lore / happening / awareness shapes are frozen
-in [`data-model.md`](../data-model.md) — making M4 the strongest
-cross-milestone look-ahead candidate (see
-[Multi-contributor model](#multi-contributor-model)); surfaces
-ready mid-M3 also serve the human-inspection need named in
-[Milestones that may merge or split](#milestones-that-may-merge-or-split).
-M4's definition of done still requires rendering real classifier
-output.
-
-**Scope: out.** Bulk operations (parked); character-side awareness
-tab (parked); image generation; chapter-close UX (M5).
-
-**Note.** Entity / happening / thread history tabs render against
-raw delta-log queries in M4 — functional but uncached. Diff-cache
-acceleration lands in [M6.4](#m6--branches--diff-cache).
+**Promoted** — defined in
+[`milestones/04-world-plot-read-surfaces/`](./milestones/04-world-plot-read-surfaces/milestone.md)
+(milestone + nine slice docs).
 
 ---
 
@@ -1322,7 +1124,10 @@ the screen its goal requires; later milestones extend.
     per-entry worldTime click-to-edit + monotonicity flag (M3.8);
     CTRL-Z action-batched extension across classifier writes
     (M3.9).
-  - **M4** — Peek drawer + awareness chips on entries.
+  - **M4.5a / M4.5b** — Browse rail (collapsed strip, phone Browse
+    chip, rail-as-Sheet) and peek drawer. The earlier "awareness chips
+    on entries" phrase was dropped at promotion — no canonical doc
+    specs it.
   - **M5** — Chapter management affordances (insert break,
     navigate by chapter, chapter context badge); deep-rollback
     surface extends rollback-confirm with multi-chapter cascade
@@ -1331,8 +1136,10 @@ the screen its goal requires; later milestones extend.
   - **M7.2** — Era-flip reader affordances (time-chip popover,
     per-entry icon, Actions menu entry, flip-era modal).
 - **World panel** ([world.md](../ui/screens/world/world.md)).
-  - **M4.1 / M4.2** — Full v1 scope (shell, per-kind tabs, entity
-    detail overview + state tabs).
+  - **M4.1 / M4.2a–c** — Full v1 scope: shell and list pane (4.1),
+    per-kind detail panes (4.2a), lore detail, History and delete
+    (4.2b), collision review (4.2c) — except the Assets tab and
+    portrait slot, placeholders until the asset gallery pass.
 - **Plot panel** ([plot.md](../ui/screens/plot/plot.md)).
   - **M4.3** — Plot panel shell + threads tab + happenings tab +
     happening awareness tab. Threads data sparse until M5.2
@@ -1348,11 +1155,12 @@ the screen its goal requires; later milestones extend.
     surface yet.
 - **Story settings**
   ([story-settings.md](../ui/screens/story-settings/story-settings.md)).
-  - **M4.4** — Basic surface (model overrides, basic per-story
-    config).
-  - **M7.2** — Deep tabs (pack, definition, models, awareness,
-    calendar, translation, **Advanced**); era-flip surfaces
-    here.
+  - **M4.4** — Basic surface: Models tab (narrative and story-agent
+    overrides), About tab, Authoring aids completion, Memory knobs,
+    story-open upgrade prompt.
+  - **M7.2** — Deep tabs (pack, definition, classifier panel,
+    awareness, calendar, translation, **Advanced**); era-flip
+    surfaces here.
 - **Memory probe**
   ([memory-probe.md](../ui/screens/memory-probe/memory-probe.md)).
   - **M3.5** — Minimal developer-only inspector (logs / impl
@@ -1478,10 +1286,11 @@ explicit.
   the compound itself is already built (foundations, with
   stories). Consumers wire it:
   - **M4.6** — First consumer: World / Plot per-row entity / lore /
-    thread / happening import, the per-row `.avts` envelope kinds,
-    and the `expo-document-picker` + `expo-file-system` install
-    with its dev-client rebuild prerequisite (details in the M4.6
-    slice entry).
+    thread / happening import and export, the per-row `.avts`
+    envelope kinds. The picker and file-system modules are already
+    installed and imported by the dialog; what the slice adds on
+    native is `expo-sharing` for export, with its dev-client
+    rebuild.
   - **M8.3** — Vault calendars import.
   - **M9.4** — Story `.avts` import on the story list.
 

--- a/docs/parked.md
+++ b/docs/parked.md
@@ -2472,6 +2472,20 @@ overlay, a measurement mirror, a fade-through) must verify on hardware
 that the class resolves rather than assuming parity with RN-Web, which
 handles it correctly. Raised 2026-08-17.
 
+#### Peek quick-edits
+
+Pencil edits on single text fields in the reader's peek drawer,
+committing immediately as one-field sessions — the exception
+[`save-sessions.md → Quick-edit exception — peek drawer`](./ui/patterns/save-sessions.md#quick-edit-exception--peek-drawer)
+and
+[`collapse.md → Reader / composer`](./ui/foundations/mobile/collapse.md#reader--composer-narrative--rail--narrative--rail-strip)
+both spec. M4 ships the peek read-mostly with `Set as lead` as its only
+inline write, following
+[`reader-composer.md → State-field composition`](./ui/screens/reader-composer/reader-composer.md#state-field-composition--same-as-world-panel-overview);
+the three docs disagree and want reconciling when this is picked up.
+Parked until peek editing proves wanted over the `Open in World panel →`
+escalation. Filed at M4 promotion (2026-09-10).
+
 ### Code structure (parked)
 
 #### Unsaved-changes guard folder placement


### PR DESCRIPTION
Promotes the M4 roadmap entry with four decisions made at promotion: the reader Browse rail joins as Slice 4.5a because Slice 2.5 deferred it to "M4-era" and canon opens the peek only from rail rows; "awareness chips on entries" is dropped as having no canonical spec; the entity detail work splits into 4.2a/b/c on size; and the M4.4 basic surface takes Models, About, Authoring aids, the Memory knobs and the story-open upgrade prompt, leaving definitional fields, the classifier panel, Pack, Calendar, Translation, Advanced and Probe to M7.2. Twelve slice contracts pin the cross-slice seams the audit surfaced (delete cascade and vector sweep on the redo path, a both-perspective relationship action, deep links, pickers, the rail Sheet morph); the entity Assets tab and portrait ship as placeholders pending an entity-to-asset link. New parked entry: peek quick-edits.