### PR TITLE
Bind a generation to the branch it started on

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -108,8 +108,10 @@ The story is an append-only list of `StoryEntry` rows (`user_action`, `narration
   a **branch** as well as a story: it records the branch it was taken on, is offered only there,
   and is refused on any other. Positions are reused by sibling branches after a fork, so a
   snapshot applied to the wrong branch deletes rows that merely share a number - and the
-  world-state restore deletes the active branch's rows and re-inserts the snapshot's under
-  _their_ branch id. The per-branch entity queries match `branch_id` exactly and never fall back
+  world-state restore deletes the active branch's rows and re-inserts only those of the
+  snapshot's that belong to that branch — the delete is branch-scoped, so the insert must be,
+  or a snapshot resolved through the lineage carries ancestor rows the delete never removed and
+  collides with them on the primary key. The per-branch entity queries match `branch_id` exactly and never fall back
   to inherited rows, so that leaves the active branch with none of its own whatever the
   experimental settings say - main included, when the snapshot came from a branch. Lightweight
   branches only decide how total it is: a pre-snapshot COW branch still resolves its ancestors'

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -160,8 +160,14 @@ a switch is queued but unsettled, and `performBranchSwitch` refuses while a leas
 second check sits inside the queued body rather than at `switchBranch`'s entrance, because a switch
 accepted while idle reaches the front of the queue _after_ a generation may have begun.
 
-Two moments are distinct. **Drained** is when the generation's own writes have settled; **finished**
-is when a rewind deferred by Stop has run too, and only then is the branch given up. Stop registers
+Two moments are distinct. **Drained** is when the turn's own writes have settled; **finished**
+is when a rewind deferred by Stop has run too, and only then is the branch given up.
+
+The lease does **not** cover the post-turn background tasks — chapter creation and lore
+management are started un-awaited and outlive it. Lore management refuses a write whose branch
+has moved (`loreCallbacks.assertScope`); chapter creation does not, so a chapter finished after
+a switch takes its number from the branch now loaded. The row still carries the right branch,
+so this is a numbering fault rather than a misplaced chapter. Stop registers
 its rewind on the lease and waits for it rather than releasing — aborting the request to the model
 is not the completion of the generation's writes, and an `applyClassificationResult` already entered
 keeps going regardless. One release owner throughout, so the rewind cannot race the writes it

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -86,7 +86,7 @@ The story is an append-only list of `StoryEntry` rows (`user_action`, `narration
   clearing the first. Both are gone from the schema.
 
   **Presence is reported, departure is inferred.** The classifier answers one question about the
-  cast — `scene.presentCharacterNames`, every *other* character in the scene at the end of the
+  cast — `scene.presentCharacterNames`, every _other_ character in the scene at the end of the
   passage; the protagonist is in every scene by definition and is added by the consumers — and
   `resolveCharacterPresence` (`services/generation/characterPresence.ts`) turns the complement into
   `inactive`. Asking a model to name thirty absent characters produces nothing; asking it to name
@@ -104,12 +104,22 @@ The story is an append-only list of `StoryEntry` rows (`user_action`, `narration
   survive an app restart or a story switch. A checkpoint is anchored to its `lastEntryId` and is
   deleted with that entry - in the same transaction, alongside the chapters and embedded images
   that reference it. It is the fork point a branch would be created from, so an orphaned one
-  yields a branch pointing at an entry the database no longer holds.
+  yields a branch pointing at an entry the database no longer holds. A retry backup is scoped to
+  a **branch** as well as a story: it records the branch it was taken on, is offered only there,
+  and is refused on any other. Positions are reused by sibling branches after a fork, so a
+  snapshot applied to the wrong branch deletes rows that merely share a number - and the
+  world-state restore deletes the active branch's rows and re-inserts the snapshot's under
+  _their_ branch id. The per-branch entity queries match `branch_id` exactly and never fall back
+  to inherited rows, so that leaves the active branch with none of its own whatever the
+  experimental settings say - main included, when the snapshot came from a branch. Lightweight
+  branches only decide how total it is: a pre-snapshot COW branch still resolves its ancestors'
+  entities, while snapshot isolation and the legacy per-branch load both leave the panels empty.
 - **Removing an entry a branch forks from is refused**, and the check runs before anything else
   the operation would rewind - a rollback, or the lorebook activation a retry restores - because
   a refusal raised afterwards would leave that half applied. Editing and deleting are refused the
   same way while a generation or a retry restore is running: the store throws, and the caller is
-  expected to say so rather than treat the untouched story as a completed edit.
+  expected to say so rather than treat the untouched story as a completed edit. **Switching
+  branches is refused on the same grounds**, for as long as a generation holds the branch.
 
 ## Generation Pipeline
 
@@ -136,6 +146,43 @@ which is what keeps them testable.
 
 Alongside the pipeline, `BackgroundTaskRunner` handles what happens _after_ a turn — the chapter
 threshold check, lore management and the style review — on its own dependency object.
+
+### The generation lease
+
+A generation is bound to the branch it started on, by a lease the initiating handler takes before
+its first read or write and gives up after its last one. There are four such handlers, all in
+`ActionInput.svelte`: `handleSubmit`, `handleRetryLastMessage`, `handleRegenerateNarration` and
+`handleRetry`. `generateResponse` takes the lease as a required parameter, so a fifth cannot be
+added without acquiring one.
+
+The lease and a branch switch are mutually exclusive in both directions: acquiring is refused while
+a switch is queued but unsettled, and `performBranchSwitch` refuses while a lease is held. That
+second check sits inside the queued body rather than at `switchBranch`'s entrance, because a switch
+accepted while idle reaches the front of the queue _after_ a generation may have begun.
+
+Two moments are distinct. **Drained** is when the generation's own writes have settled; **finished**
+is when a rewind deferred by Stop has run too, and only then is the branch given up. Stop registers
+its rewind on the lease and waits for it rather than releasing — aborting the request to the model
+is not the completion of the generation's writes, and an `applyClassificationResult` already entered
+keeps going regardless. One release owner throughout, so the rewind cannot race the writes it
+exists to reverse.
+
+**Why the switch is refused rather than the writes redirected.** `applyClassificationResult` reads
+the active branch and mutates the in-memory `characters`/`locations`/`items`/`storyBeats` arrays,
+which hold _that_ branch's view. Pointing it at another branch means decoupling "the branch being
+written" from "the branch loaded in memory" — an architectural change, not a parameter. Redirecting
+only the entries would be worse than redirecting nothing: the narration would land on the branch
+that asked for it while the classification accounting for it did not, leaving that branch holding an
+entry its world state does not know about.
+
+**When the restriction can be lifted.** Once world-state application takes the branch to write to as
+an argument instead of reading the active one, **and** `addEntry` redirects to the bound branch
+rather than asserting against it. Both, not either — the entry half alone produces exactly the
+mismatch described above. Branch-scoping `isGenerating`, so Stop and the streaming placeholder
+follow the generating branch, belongs to that work too; while the restriction stands the reader
+cannot reach another branch to see them. `addEntry`'s assertion is the tripwire in the meantime: if
+the exclusion is ever holed, a write lands as a thrown error rather than as a row on the wrong
+branch.
 
 ### Activity reporting
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -108,14 +108,24 @@ The story is an append-only list of `StoryEntry` rows (`user_action`, `narration
   a **branch** as well as a story: it records the branch it was taken on, is offered only there,
   and is refused on any other. Positions are reused by sibling branches after a fork, so a
   snapshot applied to the wrong branch deletes rows that merely share a number - and the
-  world-state restore deletes the active branch's rows and re-inserts only those of the
-  snapshot's that belong to that branch — the delete is branch-scoped, so the insert must be,
-  or a snapshot resolved through the lineage carries ancestor rows the delete never removed and
-  collides with them on the primary key. The per-branch entity queries match `branch_id` exactly and never fall back
-  to inherited rows, so that leaves the active branch with none of its own whatever the
-  experimental settings say - main included, when the snapshot came from a branch. Lightweight
-  branches only decide how total it is: a pre-snapshot COW branch still resolves its ancestors'
-  entities, while snapshot isolation and the legacy per-branch load both leave the panels empty.
+  world-state restore deletes the active branch's rows and **re-inserts only the snapshot rows
+  belonging to that branch**. The delete is branch-scoped, so the insert has to be: a snapshot
+  taken on a branch that resolves its world state through the lineage carries ancestor rows too,
+  with their own `branch_id`, which the delete never touched. Re-inserting one collides on the
+  primary key — and since these statements cannot share a transaction (see
+  [persistence.md](persistence.md)), the deletes have already committed by then, so the branch
+  loses its entries _and_ its own world state and the restore dies with nothing put back.
+  Filtering makes the two halves symmetric whatever shape the branch is, which matters because
+  `snapshot_complete` no longer reliably says which shape that is. An override the undone
+  generation created is absent from the snapshot, so it is deleted and not restored — correct,
+  because the inherited row it stood in for shows through again.
+
+  That the branch ends up with nothing is not an experimental-settings matter: the per-branch
+  entity queries match `branch_id` exactly and never fall back to inherited rows, main included
+  when the snapshot came from a branch. Lightweight branches only decide how total it is — a
+  pre-snapshot COW branch still resolves its ancestors' entities, while snapshot isolation and
+  the legacy per-branch load both leave the panels empty.
+
 - **Removing an entry a branch forks from is refused**, and the check runs before anything else
   the operation would rewind - a rollback, or the lorebook activation a retry restores - because
   a refusal raised afterwards would leave that half applied. Editing and deleting are refused the

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -157,6 +157,11 @@ its first read or write and gives up after its last one. There are four such han
 `handleRetry`. `generateResponse` takes the lease as a required parameter, so a fifth cannot be
 added without acquiring one.
 
+Leaving the story is refused for the same reason, and so is opening another one: the
+classification that follows a narration writes through whatever story and branch are live, so
+swapping either out from under a generation sends its remaining writes to the wrong place. The
+Library button and the Android back press both report the refusal rather than navigating.
+
 The lease and a branch switch are mutually exclusive in both directions: acquiring is refused while
 a switch is queued but unsettled, and `performBranchSwitch` refuses while a lease is held. That
 second check sits inside the queued body rather than at `switchBranch`'s entrance, because a switch
@@ -183,7 +188,8 @@ only the entries would be worse than redirecting nothing: the narration would la
 that asked for it while the classification accounting for it did not, leaving that branch holding an
 entry its world state does not know about.
 
-**When the restriction can be lifted.** Once world-state application takes the branch to write to as
+**When the restriction can be lifted.** This covers the story guard too — it is the same
+stand-in, for the same reason. Once world-state application takes the branch to write to as
 an argument instead of reading the active one, **and** `addEntry` redirects to the bound branch
 rather than asserting against it. Both, not either — the entry half alone produces exactly the
 mismatch described above. Branch-scoping `isGenerating`, so Stop and the streaming placeholder

--- a/docs/architecture/persistence.md
+++ b/docs/architecture/persistence.md
@@ -30,6 +30,14 @@ The database, the native layer that moves bytes around it, and the settings blob
   their rows through `SELECT id FROM stories WHERE pack_id = ?` rather than resolving the ids first:
   the batch is atomic, the round trip that fed it was not, and a story assigned to the pack in
   between kept a variable the pack no longer had.
+- **`stories.retry_state` is a JSON blob**, so fields are added inside it rather than by migration —
+  `embeddedImageIds`, `characterSnapshots`, `timeTracker` and now `branchId` all arrived that way.
+  `branchId` names the branch the snapshot was taken on, and a restore onto any other branch is
+  refused. State written before it was recorded cannot be attributed to a branch, and is **discarded
+  on load** rather than assumed to belong to main: the readers most likely to hold such state are
+  precisely those whose last generation was on a branch, and restoring one branch's snapshot onto
+  another deletes rows there. The cost is one lost cross-session retry per story; the next
+  generation records an attributable snapshot and the ability returns.
 
 ## The Native (Rust) Layer
 

--- a/src/lib/components/branch/BranchPanel.svelte
+++ b/src/lib/components/branch/BranchPanel.svelte
@@ -17,6 +17,7 @@
   import { SvelteSet } from 'svelte/reactivity'
   import { untrack } from 'svelte'
   import { supportsHover } from '$lib/utils/platform'
+  import { errMessage } from '$lib/utils/error'
 
   // Track expanded branches in tree view
   let expandedBranches = $state<Set<string>>(new Set(['main']))
@@ -77,11 +78,17 @@
     return expandedBranches.has(branchId)
   }
 
+  // A generation writes against the branch loaded in memory, so it holds the branch until
+  // its last write lands. See docs/architecture/overview.md.
+  const switchingBlocked = $derived(story.isGenerationLeaseHeld)
+
   async function handleSwitchBranch(branchId: string | null) {
+    if (switchingBlocked) return
     try {
       await story.switchBranch(branchId)
     } catch (error) {
       console.error('Failed to switch branch:', error)
+      ui.showToast(errMessage(error), 'error')
     }
   }
 
@@ -341,14 +348,18 @@
     {@const children = getChildBranches(branch.id)}
     <div class="ml-4">
       <div
-        class="group flex cursor-pointer items-center gap-2 rounded-lg p-2 transition-colors {isCurrent(
-          branch.id,
-        )
+        class="group flex items-center gap-2 rounded-lg p-2 transition-colors {switchingBlocked
+          ? 'cursor-not-allowed opacity-50'
+          : 'cursor-pointer'} {isCurrent(branch.id)
           ? 'bg-accent-500/20 border-accent-500 border-l-2'
-          : 'hover:bg-surface-700/50'}"
+          : switchingBlocked
+            ? ''
+            : 'hover:bg-surface-700/50'}"
         onclick={() => handleSwitchBranch(branch.id)}
         role="button"
         tabindex="0"
+        aria-disabled={switchingBlocked}
+        title={switchingBlocked ? 'A generation is in progress' : undefined}
         onkeydown={(e) => e.key === 'Enter' && handleSwitchBranch(branch.id)}
       >
         {#if children.length > 0}
@@ -448,14 +459,18 @@
   <div class="space-y-1">
     <!-- Main Branch -->
     <div
-      class="flex cursor-pointer items-center gap-2 rounded-lg p-2 transition-colors {isCurrent(
-        null,
-      )
+      class="flex items-center gap-2 rounded-lg p-2 transition-colors {switchingBlocked
+        ? 'cursor-not-allowed opacity-50'
+        : 'cursor-pointer'} {isCurrent(null)
         ? 'bg-accent-500/20 border-accent-500 border-l-2'
-        : 'hover:bg-surface-700/50'}"
+        : switchingBlocked
+          ? ''
+          : 'hover:bg-surface-700/50'}"
       onclick={() => handleSwitchBranch(null)}
       role="button"
       tabindex="0"
+      aria-disabled={switchingBlocked}
+      title={switchingBlocked ? 'A generation is in progress' : undefined}
       onkeydown={(e) => e.key === 'Enter' && handleSwitchBranch(null)}
     >
       <button

--- a/src/lib/components/branch/BranchPanel.svelte
+++ b/src/lib/components/branch/BranchPanel.svelte
@@ -517,7 +517,12 @@
     >
       <Lock class="text-surface-300 h-6 w-6" />
       <p class="text-surface-300 max-w-[18rem] px-4 text-center text-xs">
-        A response is generating on this branch. Switching a branch mid-flight is not available.
+        {#if story.isGenerationLeaseForAnotherStory}
+          A response in another story is still finishing. Switching a branch mid-flight is not
+          available.
+        {:else}
+          A response is generating on this branch. Switching a branch mid-flight is not available.
+        {/if}
       </p>
     </div>
   {/if}

--- a/src/lib/components/branch/BranchPanel.svelte
+++ b/src/lib/components/branch/BranchPanel.svelte
@@ -12,6 +12,7 @@
     Check,
     X,
     LayerArrowUp,
+    Lock,
   } from '@lucide/svelte'
   import type { Branch, Checkpoint } from '$lib/types'
   import { SvelteSet } from 'svelte/reactivity'
@@ -281,236 +282,243 @@
   }
 </script>
 
-<div class="space-y-3">
-  <!-- Header -->
-  <div class="flex items-center justify-between">
-    <h3 class="text-surface-200 font-medium">Branches</h3>
-    <div class="flex items-center">
-      <button
-        class="btn-ghost flex min-h-[40px] min-w-[40px] items-center justify-center rounded p-2 sm:min-h-0 sm:min-w-0 sm:p-1.5 {canGoToForkPoint
-          ? 'text-surface-400 hover:text-surface-200'
-          : 'text-surface-600 cursor-not-allowed'}"
-        onclick={goToForkPoint}
-        disabled={!canGoToForkPoint}
-        title={forkPointTitle}
-      >
-        <LayerArrowUp class="h-5 w-5 sm:h-4 sm:w-4" />
-      </button>
-      <button
-        class="btn-ghost flex min-h-[40px] min-w-[40px] items-center justify-center rounded p-2 sm:min-h-0 sm:min-w-0 sm:p-1.5 {canCreateBranch
-          ? 'text-surface-400 hover:text-surface-200'
-          : 'text-surface-600 cursor-not-allowed'}"
-        onclick={() => canCreateBranch && (showCreateForm = !showCreateForm)}
-        disabled={!canCreateBranch}
-        title={createBranchTitle}
-      >
-        <Plus class="h-5 w-5 sm:h-4 sm:w-4" />
-      </button>
-    </div>
-  </div>
-
-  <!-- Create Branch Form -->
-  {#if showCreateForm && latestCheckpoint}
-    <div class="card space-y-2 p-3">
-      <p class="text-surface-400 text-xs">
-        Branch from: <span class="text-surface-300">{latestCheckpoint.name}</span>
-      </p>
-      <input
-        type="text"
-        class="input w-full"
-        placeholder="Branch name..."
-        bind:value={newBranchName}
-        onkeydown={(e) => e.key === 'Enter' && handleCreateBranch()}
-      />
-      <div class="flex justify-end gap-2">
+<div class="relative">
+  <!-- Unreachable rather than merely discouraged: a dimmed row with a tooltip says nothing on a
+       touch device, where there is no cursor to change and no hover to explain it. -->
+  <div class="space-y-3" inert={switchingBlocked}>
+    <!-- Header -->
+    <div class="flex items-center justify-between">
+      <h3 class="text-surface-200 font-medium">Branches</h3>
+      <div class="flex items-center">
         <button
-          class="btn-ghost min-h-[40px] rounded px-3 py-2 text-sm sm:min-h-0 sm:px-2 sm:py-1 sm:text-xs"
-          onclick={() => {
-            showCreateForm = false
-            newBranchName = ''
-          }}
+          class="btn-ghost flex min-h-[40px] min-w-[40px] items-center justify-center rounded p-2 sm:min-h-0 sm:min-w-0 sm:p-1.5 {canGoToForkPoint
+            ? 'text-surface-400 hover:text-surface-200'
+            : 'text-surface-600 cursor-not-allowed'}"
+          onclick={goToForkPoint}
+          disabled={!canGoToForkPoint}
+          title={forkPointTitle}
         >
-          Cancel
+          <LayerArrowUp class="h-5 w-5 sm:h-4 sm:w-4" />
         </button>
         <button
-          class="btn-primary min-h-[40px] rounded px-3 py-2 text-sm sm:min-h-0 sm:px-2 sm:py-1 sm:text-xs"
-          onclick={handleCreateBranch}
-          disabled={!newBranchName.trim()}
+          class="btn-ghost flex min-h-[40px] min-w-[40px] items-center justify-center rounded p-2 sm:min-h-0 sm:min-w-0 sm:p-1.5 {canCreateBranch
+            ? 'text-surface-400 hover:text-surface-200'
+            : 'text-surface-600 cursor-not-allowed'}"
+          onclick={() => canCreateBranch && (showCreateForm = !showCreateForm)}
+          disabled={!canCreateBranch}
+          title={createBranchTitle}
         >
-          Create
+          <Plus class="h-5 w-5 sm:h-4 sm:w-4" />
         </button>
       </div>
     </div>
-  {/if}
 
-  <!-- Recursive branch item snippet -->
-  {#snippet branchItem(branch: Branch)}
-    {@const children = getChildBranches(branch.id)}
-    <div class="ml-4">
-      <div
-        class="group flex items-center gap-2 rounded-lg p-2 transition-colors {switchingBlocked
-          ? 'cursor-not-allowed opacity-50'
-          : 'cursor-pointer'} {isCurrent(branch.id)
-          ? 'bg-accent-500/20 border-accent-500 border-l-2'
-          : switchingBlocked
-            ? ''
+    <!-- Create Branch Form -->
+    {#if showCreateForm && latestCheckpoint}
+      <div class="card space-y-2 p-3">
+        <p class="text-surface-400 text-xs">
+          Branch from: <span class="text-surface-300">{latestCheckpoint.name}</span>
+        </p>
+        <input
+          type="text"
+          class="input w-full"
+          placeholder="Branch name..."
+          bind:value={newBranchName}
+          onkeydown={(e) => e.key === 'Enter' && handleCreateBranch()}
+        />
+        <div class="flex justify-end gap-2">
+          <button
+            class="btn-ghost min-h-[40px] rounded px-3 py-2 text-sm sm:min-h-0 sm:px-2 sm:py-1 sm:text-xs"
+            onclick={() => {
+              showCreateForm = false
+              newBranchName = ''
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            class="btn-primary min-h-[40px] rounded px-3 py-2 text-sm sm:min-h-0 sm:px-2 sm:py-1 sm:text-xs"
+            onclick={handleCreateBranch}
+            disabled={!newBranchName.trim()}
+          >
+            Create
+          </button>
+        </div>
+      </div>
+    {/if}
+
+    <!-- Recursive branch item snippet -->
+    {#snippet branchItem(branch: Branch)}
+      {@const children = getChildBranches(branch.id)}
+      <div class="ml-4">
+        <div
+          class="group flex cursor-pointer items-center gap-2 rounded-lg p-2 transition-colors {isCurrent(
+            branch.id,
+          )
+            ? 'bg-accent-500/20 border-accent-500 border-l-2'
             : 'hover:bg-surface-700/50'}"
-        onclick={() => handleSwitchBranch(branch.id)}
-        role="button"
-        tabindex="0"
-        aria-disabled={switchingBlocked}
-        title={switchingBlocked ? 'A generation is in progress' : undefined}
-        onkeydown={(e) => e.key === 'Enter' && handleSwitchBranch(branch.id)}
-      >
-        {#if children.length > 0}
-          <button
-            class="text-surface-400 hover:text-surface-200 flex min-h-[32px] min-w-[32px] items-center justify-center p-1 sm:min-h-0 sm:min-w-0 sm:p-0.5"
-            onclick={(e) => {
-              e.stopPropagation()
-              toggleExpand(branch.id)
-            }}
-          >
-            {#if isExpanded(branch.id)}
-              <ChevronDown class="h-4 w-4 sm:h-3.5 sm:w-3.5" />
-            {:else}
-              <ChevronRight class="h-4 w-4 sm:h-3.5 sm:w-3.5" />
-            {/if}
-          </button>
-        {:else}
-          <span class="w-8 sm:w-5"></span>
-        {/if}
-        <GitBranch class="text-surface-400 h-4 w-4" />
-
-        {#if renamingBranchId === branch.id}
-          <input
-            type="text"
-            class="input flex-1 px-1 py-0.5 text-sm"
-            bind:value={renameValue}
-            onclick={(e) => e.stopPropagation()}
-            onkeydown={(e) => {
-              e.stopPropagation()
-              if (e.key === 'Enter') confirmRename()
-              if (e.key === 'Escape') cancelRename()
-            }}
-          />
-          <button
-            class="flex min-h-[32px] min-w-[32px] items-center justify-center p-1 text-green-400 hover:text-green-300 sm:min-h-0 sm:min-w-0 sm:p-0.5"
-            onclick={(e) => {
-              e.stopPropagation()
-              confirmRename()
-            }}
-          >
-            <Check class="h-4 w-4 sm:h-3.5 sm:w-3.5" />
-          </button>
-          <button
-            class="text-surface-400 hover:text-surface-200 flex min-h-[32px] min-w-[32px] items-center justify-center p-1 sm:min-h-0 sm:min-w-0 sm:p-0.5"
-            onclick={(e) => {
-              e.stopPropagation()
-              cancelRename()
-            }}
-          >
-            <X class="h-4 w-4 sm:h-3.5 sm:w-3.5" />
-          </button>
-        {:else}
-          <span class="text-surface-200 flex-1 truncate text-sm">{branch.name}</span>
-          <span class="text-surface-500 text-xs">{getBranchEntryCount(branch.id)}</span>
-          {#if isCurrent(branch.id)}
-            <span class="bg-accent-500 h-2 w-2 rounded-full" title="Current branch"></span>
-          {/if}
-          <button
-            class="text-surface-500 hover:text-surface-200 flex min-h-[32px] min-w-[32px] items-center justify-center p-1 transition-opacity sm:min-h-0 sm:min-w-0 sm:p-0.5 sm:opacity-0 sm:group-hover:opacity-100"
-            onclick={(e) => {
-              e.stopPropagation()
-              startRename(branch)
-            }}
-            title="Rename"
-          >
-            <Edit2 class="h-4 w-4 sm:h-3 sm:w-3" />
-          </button>
-          {#if !isCurrent(branch.id)}
+          onclick={() => handleSwitchBranch(branch.id)}
+          role="button"
+          tabindex="0"
+          onkeydown={(e) => e.key === 'Enter' && handleSwitchBranch(branch.id)}
+        >
+          {#if children.length > 0}
             <button
-              class="text-surface-500 flex min-h-[32px] min-w-[32px] items-center justify-center p-1 transition-opacity sm:min-h-0 sm:min-w-0 sm:p-0.5 {children.length >
-              0
-                ? 'cursor-not-allowed opacity-30'
-                : 'hover:text-red-400 sm:opacity-0 sm:group-hover:opacity-100'}"
+              class="text-surface-400 hover:text-surface-200 flex min-h-[32px] min-w-[32px] items-center justify-center p-1 sm:min-h-0 sm:min-w-0 sm:p-0.5"
               onclick={(e) => {
                 e.stopPropagation()
-                handleDeleteBranch(branch.id)
+                toggleExpand(branch.id)
               }}
-              disabled={children.length > 0}
-              title={children.length > 0 ? 'Cannot delete: has child branches' : 'Delete'}
             >
-              <Trash2 class="h-4 w-4 sm:h-3 sm:w-3" />
+              {#if isExpanded(branch.id)}
+                <ChevronDown class="h-4 w-4 sm:h-3.5 sm:w-3.5" />
+              {:else}
+                <ChevronRight class="h-4 w-4 sm:h-3.5 sm:w-3.5" />
+              {/if}
             </button>
+          {:else}
+            <span class="w-8 sm:w-5"></span>
           {/if}
+          <GitBranch class="text-surface-400 h-4 w-4" />
+
+          {#if renamingBranchId === branch.id}
+            <input
+              type="text"
+              class="input flex-1 px-1 py-0.5 text-sm"
+              bind:value={renameValue}
+              onclick={(e) => e.stopPropagation()}
+              onkeydown={(e) => {
+                e.stopPropagation()
+                if (e.key === 'Enter') confirmRename()
+                if (e.key === 'Escape') cancelRename()
+              }}
+            />
+            <button
+              class="flex min-h-[32px] min-w-[32px] items-center justify-center p-1 text-green-400 hover:text-green-300 sm:min-h-0 sm:min-w-0 sm:p-0.5"
+              onclick={(e) => {
+                e.stopPropagation()
+                confirmRename()
+              }}
+            >
+              <Check class="h-4 w-4 sm:h-3.5 sm:w-3.5" />
+            </button>
+            <button
+              class="text-surface-400 hover:text-surface-200 flex min-h-[32px] min-w-[32px] items-center justify-center p-1 sm:min-h-0 sm:min-w-0 sm:p-0.5"
+              onclick={(e) => {
+                e.stopPropagation()
+                cancelRename()
+              }}
+            >
+              <X class="h-4 w-4 sm:h-3.5 sm:w-3.5" />
+            </button>
+          {:else}
+            <span class="text-surface-200 flex-1 truncate text-sm">{branch.name}</span>
+            <span class="text-surface-500 text-xs">{getBranchEntryCount(branch.id)}</span>
+            {#if isCurrent(branch.id)}
+              <span class="bg-accent-500 h-2 w-2 rounded-full" title="Current branch"></span>
+            {/if}
+            <button
+              class="text-surface-500 hover:text-surface-200 flex min-h-[32px] min-w-[32px] items-center justify-center p-1 transition-opacity sm:min-h-0 sm:min-w-0 sm:p-0.5 sm:opacity-0 sm:group-hover:opacity-100"
+              onclick={(e) => {
+                e.stopPropagation()
+                startRename(branch)
+              }}
+              title="Rename"
+            >
+              <Edit2 class="h-4 w-4 sm:h-3 sm:w-3" />
+            </button>
+            {#if !isCurrent(branch.id)}
+              <button
+                class="text-surface-500 flex min-h-[32px] min-w-[32px] items-center justify-center p-1 transition-opacity sm:min-h-0 sm:min-w-0 sm:p-0.5 {children.length >
+                0
+                  ? 'cursor-not-allowed opacity-30'
+                  : 'hover:text-red-400 sm:opacity-0 sm:group-hover:opacity-100'}"
+                onclick={(e) => {
+                  e.stopPropagation()
+                  handleDeleteBranch(branch.id)
+                }}
+                disabled={children.length > 0}
+                title={children.length > 0 ? 'Cannot delete: has child branches' : 'Delete'}
+              >
+                <Trash2 class="h-4 w-4 sm:h-3 sm:w-3" />
+              </button>
+            {/if}
+          {/if}
+        </div>
+
+        <!-- Recursively render children -->
+        {#if isExpanded(branch.id) && children.length > 0}
+          {#each children as child (child.id)}
+            {@render branchItem(child)}
+          {/each}
+        {/if}
+      </div>
+    {/snippet}
+
+    <!-- Branch Tree -->
+    <div class="space-y-1">
+      <!-- Main Branch -->
+      <div
+        class="flex cursor-pointer items-center gap-2 rounded-lg p-2 transition-colors {isCurrent(
+          null,
+        )
+          ? 'bg-accent-500/20 border-accent-500 border-l-2'
+          : 'hover:bg-surface-700/50'}"
+        onclick={() => handleSwitchBranch(null)}
+        role="button"
+        tabindex="0"
+        onkeydown={(e) => e.key === 'Enter' && handleSwitchBranch(null)}
+      >
+        <button
+          class="text-surface-400 hover:text-surface-200 flex min-h-[32px] min-w-[32px] items-center justify-center p-1 sm:min-h-0 sm:min-w-0 sm:p-0.5"
+          onclick={(e) => {
+            e.stopPropagation()
+            toggleExpand('main')
+          }}
+        >
+          {#if isExpanded('main')}
+            <ChevronDown class="h-4 w-4 sm:h-3.5 sm:w-3.5" />
+          {:else}
+            <ChevronRight class="h-4 w-4 sm:h-3.5 sm:w-3.5" />
+          {/if}
+        </button>
+        <GitBranch class="text-surface-400 h-4 w-4" />
+        <span class="text-surface-200 flex-1 text-sm">Main</span>
+        <span class="text-surface-500 text-xs">{getBranchEntryCount(null)}</span>
+        {#if isCurrent(null)}
+          <span class="bg-accent-500 h-2 w-2 rounded-full" title="Current branch"></span>
         {/if}
       </div>
 
-      <!-- Recursively render children -->
-      {#if isExpanded(branch.id) && children.length > 0}
-        {#each children as child (child.id)}
-          {@render branchItem(child)}
+      <!-- Child branches of main (recursive) -->
+      {#if isExpanded('main')}
+        {#each getChildBranches(null) as branch (branch.id)}
+          {@render branchItem(branch)}
         {/each}
       {/if}
     </div>
-  {/snippet}
 
-  <!-- Branch Tree -->
-  <div class="space-y-1">
-    <!-- Main Branch -->
-    <div
-      class="flex items-center gap-2 rounded-lg p-2 transition-colors {switchingBlocked
-        ? 'cursor-not-allowed opacity-50'
-        : 'cursor-pointer'} {isCurrent(null)
-        ? 'bg-accent-500/20 border-accent-500 border-l-2'
-        : switchingBlocked
-          ? ''
-          : 'hover:bg-surface-700/50'}"
-      onclick={() => handleSwitchBranch(null)}
-      role="button"
-      tabindex="0"
-      aria-disabled={switchingBlocked}
-      title={switchingBlocked ? 'A generation is in progress' : undefined}
-      onkeydown={(e) => e.key === 'Enter' && handleSwitchBranch(null)}
-    >
-      <button
-        class="text-surface-400 hover:text-surface-200 flex min-h-[32px] min-w-[32px] items-center justify-center p-1 sm:min-h-0 sm:min-w-0 sm:p-0.5"
-        onclick={(e) => {
-          e.stopPropagation()
-          toggleExpand('main')
-        }}
-      >
-        {#if isExpanded('main')}
-          <ChevronDown class="h-4 w-4 sm:h-3.5 sm:w-3.5" />
+    <!-- Empty state -->
+    {#if story.branches.length === 0}
+      <p class="text-surface-400 py-4 text-center text-sm">
+        {#if canCreateBranch}
+          No branches yet. Create one to explore alternate storylines.
         {:else}
-          <ChevronRight class="h-4 w-4 sm:h-3.5 sm:w-3.5" />
+          Branches can be created from checkpoints. Checkpoints are automatically saved at chapter
+          boundaries.
         {/if}
-      </button>
-      <GitBranch class="text-surface-400 h-4 w-4" />
-      <span class="text-surface-200 flex-1 text-sm">Main</span>
-      <span class="text-surface-500 text-xs">{getBranchEntryCount(null)}</span>
-      {#if isCurrent(null)}
-        <span class="bg-accent-500 h-2 w-2 rounded-full" title="Current branch"></span>
-      {/if}
-    </div>
-
-    <!-- Child branches of main (recursive) -->
-    {#if isExpanded('main')}
-      {#each getChildBranches(null) as branch (branch.id)}
-        {@render branchItem(branch)}
-      {/each}
+      </p>
     {/if}
   </div>
 
-  <!-- Empty state -->
-  {#if story.branches.length === 0}
-    <p class="text-surface-400 py-4 text-center text-sm">
-      {#if canCreateBranch}
-        No branches yet. Create one to explore alternate storylines.
-      {:else}
-        Branches can be created from checkpoints. Checkpoints are automatically saved at chapter
-        boundaries.
-      {/if}
-    </p>
+  {#if switchingBlocked}
+    <div
+      class="bg-surface-900/60 absolute inset-0 z-10 flex flex-col items-center justify-center gap-2 rounded-lg backdrop-blur-[1px]"
+    >
+      <Lock class="text-surface-300 h-6 w-6" />
+      <p class="text-surface-300 max-w-[18rem] px-4 text-center text-xs">
+        A response is generating on this branch. Switching a branch mid-flight is not available.
+      </p>
+    </div>
   {/if}
 </div>

--- a/src/lib/components/layout/Header.svelte
+++ b/src/lib/components/layout/Header.svelte
@@ -49,7 +49,14 @@
   })
 
   function goToLibrary() {
-    story.closeStory()
+    try {
+      story.closeStory()
+    } catch (error) {
+      // Refused while a generation is writing to this story. Stay put and say why, rather
+      // than navigating away from a story the store has not finished with.
+      ui.showToast(errMessage(error), 'error')
+      return
+    }
     ui.setActivePanel('library')
   }
 

--- a/src/lib/components/layout/StoryNavPanel.svelte
+++ b/src/lib/components/layout/StoryNavPanel.svelte
@@ -263,6 +263,10 @@
     {/if}
   </div>
 
+  <!-- Not locked during a generation: this chooses what a landmark tap does, it does not
+       switch anything. Locking it would hide which mode is set and block the one useful
+       response — selecting "stay on current branch". The switch itself is refused in
+       goToLandmark. -->
   <div class="border-border border-t p-3">
     <p class="text-muted-foreground mb-2 text-xs font-medium tracking-wider uppercase">
       Landmark navigation

--- a/src/lib/components/layout/StoryNavPanel.svelte
+++ b/src/lib/components/layout/StoryNavPanel.svelte
@@ -79,6 +79,11 @@
   async function goToLandmark(landmark: Landmark) {
     const currentBranchId = story.currentStory?.currentBranchId ?? null
     if (landmarkNavigationMode === 'checkpoint-branch' && currentBranchId !== landmark.branchId) {
+      // Refused before the landing is claimed, so a blocked switch leaves no claim to clean up.
+      if (story.isGenerationLeaseHeld) {
+        ui.showToast('Cannot switch branches while a generation is in progress', 'error')
+        return
+      }
       // Claimed before the switch, because the event that triggers the story view's own
       // end-of-branch landing is emitted inside it.
       ui.claimBranchLanding(landmark.branchId)

--- a/src/lib/components/story/ActionInput.svelte
+++ b/src/lib/components/story/ActionInput.svelte
@@ -469,6 +469,32 @@
     }
   }
 
+  /**
+   * Run a generation under its own lease.
+   *
+   * Acquiring is the first thing a handler does, before it touches anything: a refusal then
+   * has nothing to undo, and every side effect written above the acquire would otherwise
+   * inherit an obligation to reverse itself that nothing enforces.
+   *
+   * `generateResponse` takes the lease as a required parameter, so a handler cannot skip
+   * acquiring one. This is the other half — releasing — which a handler copied from another
+   * can lose without the compiler noticing.
+   */
+  async function withGenerationLease(run: (lease: GenerationLease) => Promise<void>) {
+    let lease: GenerationLease
+    try {
+      lease = story.acquireGenerationLease()
+    } catch (error) {
+      ui.showToast(errMessage(error), 'error')
+      return
+    }
+    try {
+      await run(lease)
+    } finally {
+      await lease.finish()
+    }
+  }
+
   async function generateResponse(
     lease: GenerationLease,
     userActionEntryId: string,
@@ -1026,41 +1052,28 @@
 
   async function handleSubmit() {
     if (!inputValue.trim() || ui.isGenerating || !story.currentStory) return
+    const currentStory = story.currentStory
 
-    ui.clearGenerationError()
-    ui.resetScrollBreak()
-    ui.clearSuggestions(story.currentStory.id)
+    await withGenerationLease(async (lease) => {
+      ui.clearGenerationError()
+      ui.resetScrollBreak()
+      ui.clearSuggestions(currentStory.id)
 
-    const rawInput = inputValue.trim()
-    const wasRawActionChoice = isRawActionChoice
-    const forceFreeMode = settings.uiSettings.disableActionPrefixes
+      const rawInput = inputValue.trim()
+      const wasRawActionChoice = isRawActionChoice
+      const forceFreeMode = settings.uiSettings.disableActionPrefixes
 
-    let content: string
-    if (isCreativeMode || wasRawActionChoice || forceFreeMode) content = rawInput
-    else content = actionPrefixes[actionType] + rawInput + actionSuffixes[actionType]
+      let content: string
+      if (isCreativeMode || wasRawActionChoice || forceFreeMode) content = rawInput
+      else content = actionPrefixes[actionType] + rawInput + actionSuffixes[actionType]
 
-    isRawActionChoice = false
-    inputValue = ''
-    if (textareaRef) textareaRef.scrollTop = 0
+      isRawActionChoice = false
+      inputValue = ''
+      if (textareaRef) textareaRef.scrollTop = 0
 
-    // Claimed before the snapshot: everything below reads or writes on this generation's
-    // behalf, and the awaits between here and the narration are long enough to switch in.
-    let lease: GenerationLease
-    try {
-      lease = story.acquireGenerationLease()
-    } catch (error) {
-      // The box was cleared above on the assumption this would go ahead. Give the text back
-      // rather than making the reader retype it.
-      inputValue = rawInput
-      isRawActionChoice = wasRawActionChoice
-      ui.showToast(errMessage(error), 'error')
-      return
-    }
-
-    try {
-      const embeddedImageIds = await database.getEmbeddedImageIdsForStory(story.currentStory.id)
+      const embeddedImageIds = await database.getEmbeddedImageIdsForStory(currentStory.id)
       ui.createRetryBackup(
-        story.currentStory.id,
+        currentStory.id,
         lease.branchId,
         story.entries,
         story.characters,
@@ -1072,7 +1085,7 @@
         rawInput,
         actionType,
         wasRawActionChoice,
-        story.currentStory.timeTracker,
+        currentStory.timeTracker,
       )
 
       const {
@@ -1096,9 +1109,7 @@
       // retrieval and classification working from a different wording than the narration —
       // and the retry path already passes `promptContent`, so the two disagreed.
       await generateResponse(lease, userActionEntry.id, promptContent, { inputTranslation })
-    } finally {
-      await lease.finish()
-    }
+    })
   }
 
   async function handleStopGeneration() {
@@ -1188,15 +1199,7 @@
     const error = ui.lastGenerationError
     if (!error || ui.isGenerating) return
 
-    let lease: GenerationLease
-    try {
-      lease = story.acquireGenerationLease()
-    } catch (err) {
-      ui.showToast(errMessage(err), 'error')
-      return
-    }
-
-    try {
+    await withGenerationLease(async (lease) => {
       const userActionEntry = story.entries.find((e) => e.id === error.userActionEntryId)
       if (!userActionEntry) {
         ui.clearGenerationError()
@@ -1219,9 +1222,7 @@
         countStyleReview: false,
         styleReviewSource: 'retry-error',
       })
-    } finally {
-      await lease.finish()
-    }
+    })
   }
 
   function dismissError() {
@@ -1248,15 +1249,7 @@
 
     // Claimed before the undo, which is itself an asynchronous write on this generation's
     // behalf.
-    let lease: GenerationLease
-    try {
-      lease = story.acquireGenerationLease()
-    } catch (error) {
-      ui.showToast(errMessage(error), 'error')
-      return
-    }
-
-    try {
+    await withGenerationLease(async (lease) => {
       let undo: { entitiesUndone: boolean; timeUndone: boolean }
       try {
         undo = await story.undoNarrationForRegenerate(entryId, lease)
@@ -1285,9 +1278,7 @@
         styleReviewSource: 'regenerate',
         cachedRetrievalResult: cachedRetrieval ? ui.retrievalResultFor(cachedRetrieval) : null,
       })
-    } finally {
-      await lease.finish()
-    }
+    })
   }
 
   async function handleRetryLastMessage() {
@@ -1306,15 +1297,7 @@
 
     // Claimed before the rewind, which deletes entries and entities on this generation's
     // behalf before the model is ever called.
-    let lease: GenerationLease
-    try {
-      lease = story.acquireGenerationLease()
-    } catch (error) {
-      ui.showToast(errMessage(error), 'error')
-      return
-    }
-
-    try {
+    await withGenerationLease(async (lease) => {
       const result = await retryService.handleRetryLastMessage(
         backup,
         {
@@ -1335,7 +1318,7 @@
           clearSuggestions: () => ui.clearSuggestions(storyId),
           clearActionChoices: () => ui.clearActionChoices(storyId),
         },
-        { storyId, branchId: story.currentStory.currentBranchId ?? null },
+        lease,
       )
 
       if (!result.success) {
@@ -1375,9 +1358,7 @@
       } finally {
         ui.setRetryingLastMessage(false)
       }
-    } finally {
-      await lease.finish()
-    }
+    })
   }
 
   function handleKeydown(event: KeyboardEvent) {

--- a/src/lib/components/story/ActionInput.svelte
+++ b/src/lib/components/story/ActionInput.svelte
@@ -1198,7 +1198,9 @@
       }
 
       try {
-        await story.deleteEntry(error.errorEntryId)
+        // The lease is this generation's own, so the guard lets it through: clearing the
+        // failed entry before regenerating is the holder tidying up after itself.
+        await story.deleteEntry(error.errorEntryId, lease)
       } catch (err) {
         // Regenerating over an entry that could not be removed would leave the failed one
         // above the new narration, so the retry stops here.
@@ -1251,7 +1253,7 @@
     try {
       let undo: { entitiesUndone: boolean; timeUndone: boolean }
       try {
-        undo = await story.undoNarrationForRegenerate(entryId)
+        undo = await story.undoNarrationForRegenerate(entryId, lease)
       } catch (error) {
         ui.showToast(errMessage(error), 'error')
         return

--- a/src/lib/components/story/ActionInput.svelte
+++ b/src/lib/components/story/ActionInput.svelte
@@ -56,8 +56,10 @@
     type BackgroundTaskInput,
     type PipelineUICallbacks,
     type PipelineEventState,
+    type RestoreResult,
   } from '$lib/services/generation'
   import { InlineImageTracker } from '$lib/services/ai/image'
+  import type { GenerationLease } from '$lib/utils/generationLease'
 
   function log(...args: any[]) {
     console.log('[ActionInput]', ...args)
@@ -468,6 +470,7 @@
   }
 
   async function generateResponse(
+    lease: GenerationLease,
     userActionEntryId: string,
     userActionContent: string,
     options?: {
@@ -509,6 +512,9 @@
     ui.startStreaming(visualProseMode, streamingEntryId)
 
     const currentStoryRef = story.currentStory
+    // The branch this generation is bound to. Read from the lease, not the live store: the
+    // store's value is what the lease exists to stop moving.
+    const leasedBranchId = lease.branchId
 
     let inlineImageTracker: InlineImageTracker | null = null
     if (inlineImageMode) {
@@ -681,7 +687,7 @@
             ) ?? undefined
           ui.setLastRetrievalResult(retrievalResult ?? null, {
             storyId: currentStoryRef.id,
-            branchId: currentStoryRef.currentBranchId ?? null,
+            branchId: leasedBranchId,
             position: storyPosition,
             actionContent: userActionContent,
           })
@@ -702,6 +708,7 @@
           narrationEntry = await story.addEntry(
             'narration',
             fullResponse,
+            leasedBranchId,
             generationMeta,
             fullReasoning || undefined,
             narrationEntryId,
@@ -794,7 +801,7 @@
 
       if (!fullResponse.trim()) {
         const errorMessage = 'The AI returned an empty response after 3 attempts. Please try again.'
-        const errorEntry = await story.addEntry('system', errorMessage)
+        const errorEntry = await story.addEntry('system', errorMessage, leasedBranchId)
         ui.setGenerationError({
           message: errorMessage,
           errorEntryId: errorEntry.id,
@@ -822,7 +829,7 @@
       // Deliberately not awaited — but the flag has to outlive the call, or the Memory
       // view will offer to create a chapter while this one is being created.
       const bgStoryId = currentStoryRef.id
-      const bgBranchId = currentStoryRef.currentBranchId ?? null
+      const bgBranchId = leasedBranchId
       ui.setBackgroundTasksActive(bgStoryId, bgBranchId, true)
       coordinator
         .runBackgroundTasks(input)
@@ -850,7 +857,11 @@
       const errorMessage = ui.wasBackgroundedDuringGeneration
         ? `Generation may have been interrupted while the app was in the background. ${baseMessage}`
         : baseMessage
-      const errorEntry = await story.addEntry('system', `Generation failed: ${errorMessage}`)
+      const errorEntry = await story.addEntry(
+        'system',
+        `Generation failed: ${errorMessage}`,
+        leasedBranchId,
+      )
       ui.setGenerationError({
         message: errorMessage,
         errorEntryId: errorEntry.id,
@@ -1023,43 +1034,58 @@
     inputValue = ''
     if (textareaRef) textareaRef.scrollTop = 0
 
-    const embeddedImageIds = await database.getEmbeddedImageIdsForStory(story.currentStory.id)
-    ui.createRetryBackup(
-      story.currentStory.id,
-      story.entries,
-      story.characters,
-      story.locations,
-      story.items,
-      story.storyBeats,
-      embeddedImageIds,
-      content,
-      rawInput,
-      actionType,
-      wasRawActionChoice,
-      story.currentStory.timeTracker,
-    )
-
-    const {
-      promptContent,
-      originalInput,
-      timing: inputTranslation,
-    } = await translateUserInput(content, settings.translationSettings)
-
-    const userActionEntry = await story.addEntry('user_action', promptContent)
-
-    if (originalInput) {
-      await database.updateStoryEntry(userActionEntry.id, { originalInput })
-      await story.refreshEntry(userActionEntry.id)
+    // Claimed before the snapshot: everything below reads or writes on this generation's
+    // behalf, and the awaits between here and the narration are long enough to switch in.
+    let lease: GenerationLease
+    try {
+      lease = story.acquireGenerationLease()
+    } catch (error) {
+      ui.showToast(errMessage(error), 'error')
+      return
     }
 
-    emitUserInput(content, isCreativeMode ? 'direction' : forceFreeMode ? 'free' : actionType)
-    await tick()
+    try {
+      const embeddedImageIds = await database.getEmbeddedImageIdsForStory(story.currentStory.id)
+      ui.createRetryBackup(
+        story.currentStory.id,
+        lease.branchId,
+        story.entries,
+        story.characters,
+        story.locations,
+        story.items,
+        story.storyBeats,
+        embeddedImageIds,
+        content,
+        rawInput,
+        actionType,
+        wasRawActionChoice,
+        story.currentStory.timeTracker,
+      )
 
-    // `promptContent`, not the raw `content`: with translation on the two differ, and the
-    // entry the narrator reads holds `promptContent`. Passing the raw text here left
-    // retrieval and classification working from a different wording than the narration —
-    // and the retry path already passes `promptContent`, so the two disagreed.
-    await generateResponse(userActionEntry.id, promptContent, { inputTranslation })
+      const {
+        promptContent,
+        originalInput,
+        timing: inputTranslation,
+      } = await translateUserInput(content, settings.translationSettings)
+
+      const userActionEntry = await story.addEntry('user_action', promptContent, lease.branchId)
+
+      if (originalInput) {
+        await database.updateStoryEntry(userActionEntry.id, { originalInput })
+        await story.refreshEntry(userActionEntry.id)
+      }
+
+      emitUserInput(content, isCreativeMode ? 'direction' : forceFreeMode ? 'free' : actionType)
+      await tick()
+
+      // `promptContent`, not the raw `content`: with translation on the two differ, and the
+      // entry the narrator reads holds `promptContent`. Passing the raw text here left
+      // retrieval and classification working from a different wording than the narration —
+      // and the retry path already passes `promptContent`, so the two disagreed.
+      await generateResponse(lease, userActionEntry.id, promptContent, { inputTranslation })
+    } finally {
+      await lease.finish()
+    }
   }
 
   async function handleStopGeneration() {
@@ -1079,27 +1105,50 @@
     ui.setLastLorebookRetrieval(null)
     ui.setLastRetrievalResult(null)
 
-    const result = await retryService.handleStopGeneration(
-      backup,
-      {
-        restoreFromRetryBackup: story.restoreFromRetryBackup.bind(story),
-        deleteEntriesFromPosition: story.deleteEntriesFromPosition.bind(story),
-        deleteEntitiesCreatedAfterBackup: story.deleteEntitiesCreatedAfterBackup.bind(story),
-        restoreCharacterSnapshots: story.restoreCharacterSnapshots.bind(story),
-        restoreTimeTrackerSnapshot: story.restoreTimeTrackerSnapshot.bind(story),
-        assertEntriesRemovable: story.assertEntriesRemovable.bind(story),
-        lockRetryInProgress: story.lockRetryInProgress.bind(story),
-        unlockRetryInProgress: story.unlockRetryInProgress.bind(story),
-        restoreActivationData: ui.restoreActivationData.bind(ui),
-        clearActivationData: () => ui.clearActivationData(),
-        setLastLorebookRetrieval: ui.setLastLorebookRetrieval.bind(ui),
-      },
-      {
-        clearGenerationError: () => ui.clearGenerationError(),
-        clearSuggestions: () => ui.clearSuggestions(story.currentStory!.id),
-        clearActionChoices: () => ui.clearActionChoices(story.currentStory!.id),
-      },
-    )
+    const activeBranchId = story.currentStory.currentBranchId ?? null
+    const runRestore = () =>
+      retryService.handleStopGeneration(
+        backup,
+        {
+          restoreFromRetryBackup: story.restoreFromRetryBackup.bind(story),
+          deleteEntriesFromPosition: story.deleteEntriesFromPosition.bind(story),
+          deleteEntitiesCreatedAfterBackup: story.deleteEntitiesCreatedAfterBackup.bind(story),
+          restoreCharacterSnapshots: story.restoreCharacterSnapshots.bind(story),
+          restoreTimeTrackerSnapshot: story.restoreTimeTrackerSnapshot.bind(story),
+          assertEntriesRemovable: story.assertEntriesRemovable.bind(story),
+          lockRetryInProgress: story.lockRetryInProgress.bind(story),
+          unlockRetryInProgress: story.unlockRetryInProgress.bind(story),
+          restoreActivationData: ui.restoreActivationData.bind(ui),
+          clearActivationData: () => ui.clearActivationData(),
+          setLastLorebookRetrieval: ui.setLastLorebookRetrieval.bind(ui),
+        },
+        {
+          clearGenerationError: () => ui.clearGenerationError(),
+          clearSuggestions: () => ui.clearSuggestions(story.currentStory!.id),
+          clearActionChoices: () => ui.clearActionChoices(story.currentStory!.id),
+        },
+        activeBranchId,
+      )
+
+    // Aborting the request is not the end of the generation's writes: a classification
+    // already entered keeps going. Hand the rewind to the lease, which runs it once those
+    // have drained and only then gives the branch up. The lease's holder releases, not this.
+    let result: RestoreResult
+    const lease = story.currentGenerationLease
+    if (lease) {
+      let deferred: RestoreResult | undefined
+      const settled = lease.deferRestore(async () => {
+        deferred = await runRestore()
+      })
+      if (settled) {
+        await settled
+        result = deferred ?? { success: false, error: 'The restore did not run' }
+      } else {
+        result = await runRestore()
+      }
+    } else {
+      result = await runRestore()
+    }
 
     if (!result.success) {
       // The backup is the only way back to the pre-action story, so a refused restore keeps it.
@@ -1118,26 +1167,38 @@
     const error = ui.lastGenerationError
     if (!error || ui.isGenerating) return
 
-    const userActionEntry = story.entries.find((e) => e.id === error.userActionEntryId)
-    if (!userActionEntry) {
-      ui.clearGenerationError()
+    let lease: GenerationLease
+    try {
+      lease = story.acquireGenerationLease()
+    } catch (err) {
+      ui.showToast(errMessage(err), 'error')
       return
     }
 
     try {
-      await story.deleteEntry(error.errorEntryId)
-    } catch (err) {
-      // Regenerating over an entry that could not be removed would leave the failed one above
-      // the new narration, so the retry stops here.
-      ui.showToast(errMessage(err), 'error')
-      return
-    }
-    ui.clearGenerationError()
+      const userActionEntry = story.entries.find((e) => e.id === error.userActionEntryId)
+      if (!userActionEntry) {
+        ui.clearGenerationError()
+        return
+      }
 
-    await generateResponse(userActionEntry.id, userActionEntry.content, {
-      countStyleReview: false,
-      styleReviewSource: 'retry-error',
-    })
+      try {
+        await story.deleteEntry(error.errorEntryId)
+      } catch (err) {
+        // Regenerating over an entry that could not be removed would leave the failed one
+        // above the new narration, so the retry stops here.
+        ui.showToast(errMessage(err), 'error')
+        return
+      }
+      ui.clearGenerationError()
+
+      await generateResponse(lease, userActionEntry.id, userActionEntry.content, {
+        countStyleReview: false,
+        styleReviewSource: 'retry-error',
+      })
+    } finally {
+      await lease.finish()
+    }
   }
 
   function dismissError() {
@@ -1162,34 +1223,48 @@
     const userActionEntry = findPrecedingUserAction(story.entries, entryId)
     if (!userActionEntry) return
 
-    let undo: { entitiesUndone: boolean; timeUndone: boolean }
+    // Claimed before the undo, which is itself an asynchronous write on this generation's
+    // behalf.
+    let lease: GenerationLease
     try {
-      undo = await story.undoNarrationForRegenerate(entryId)
+      lease = story.acquireGenerationLease()
     } catch (error) {
       ui.showToast(errMessage(error), 'error')
       return
     }
 
-    // Entity changes are only reversible when stateTracking recorded a delta for the
-    // entry. Say so rather than leaving the user to notice a stray character later.
-    if (!undo.entitiesUndone) {
-      ui.showToast(
-        'Regenerating: story time was restored, but characters, locations or items the ' +
-          'previous response added could not be undone. Enable State Tracking in ' +
-          'Experimental Features to make these reversible.',
-        'warning',
-      )
-    }
+    try {
+      let undo: { entitiesUndone: boolean; timeUndone: boolean }
+      try {
+        undo = await story.undoNarrationForRegenerate(entryId)
+      } catch (error) {
+        ui.showToast(errMessage(error), 'error')
+        return
+      }
 
-    // The rewind above put the story back exactly where the previous turn's retrieval was
-    // computed, so that result is still the right one — same branch, same position, same
-    // action. Read after the undo, since the key is position-sensitive.
-    const cachedRetrieval = retrievalKeyFor(userActionEntry.content)
-    await generateResponse(userActionEntry.id, userActionEntry.content, {
-      countStyleReview: false,
-      styleReviewSource: 'regenerate',
-      cachedRetrievalResult: cachedRetrieval ? ui.retrievalResultFor(cachedRetrieval) : null,
-    })
+      // Entity changes are only reversible when stateTracking recorded a delta for the
+      // entry. Say so rather than leaving the user to notice a stray character later.
+      if (!undo.entitiesUndone) {
+        ui.showToast(
+          'Regenerating: story time was restored, but characters, locations or items the ' +
+            'previous response added could not be undone. Enable State Tracking in ' +
+            'Experimental Features to make these reversible.',
+          'warning',
+        )
+      }
+
+      // The rewind above put the story back exactly where the previous turn's retrieval was
+      // computed, so that result is still the right one — same branch, same position, same
+      // action. Read after the undo, since the key is position-sensitive.
+      const cachedRetrieval = retrievalKeyFor(userActionEntry.content)
+      await generateResponse(lease, userActionEntry.id, userActionEntry.content, {
+        countStyleReview: false,
+        styleReviewSource: 'regenerate',
+        cachedRetrievalResult: cachedRetrieval ? ui.retrievalResultFor(cachedRetrieval) : null,
+      })
+    } finally {
+      await lease.finish()
+    }
   }
 
   async function handleRetryLastMessage() {
@@ -1206,64 +1281,79 @@
 
     const storyId = story.currentStory.id
 
-    const result = await retryService.handleRetryLastMessage(
-      backup,
-      {
-        restoreFromRetryBackup: story.restoreFromRetryBackup.bind(story),
-        deleteEntriesFromPosition: story.deleteEntriesFromPosition.bind(story),
-        deleteEntitiesCreatedAfterBackup: story.deleteEntitiesCreatedAfterBackup.bind(story),
-        restoreCharacterSnapshots: story.restoreCharacterSnapshots.bind(story),
-        restoreTimeTrackerSnapshot: story.restoreTimeTrackerSnapshot.bind(story),
-        assertEntriesRemovable: story.assertEntriesRemovable.bind(story),
-        lockRetryInProgress: story.lockRetryInProgress.bind(story),
-        unlockRetryInProgress: story.unlockRetryInProgress.bind(story),
-        restoreActivationData: ui.restoreActivationData.bind(ui),
-        clearActivationData: () => ui.clearActivationData(),
-        setLastLorebookRetrieval: ui.setLastLorebookRetrieval.bind(ui),
-      },
-      {
-        clearGenerationError: () => ui.clearGenerationError(),
-        clearSuggestions: () => ui.clearSuggestions(storyId),
-        clearActionChoices: () => ui.clearActionChoices(storyId),
-      },
-    )
-
-    if (!result.success) {
-      ui.showToast(result.error ?? 'Could not restore the story', 'error')
+    // Claimed before the rewind, which deletes entries and entities on this generation's
+    // behalf before the model is ever called.
+    let lease: GenerationLease
+    try {
+      lease = story.acquireGenerationLease()
+    } catch (error) {
+      ui.showToast(errMessage(error), 'error')
       return
     }
 
-    await tick()
-
-    const {
-      promptContent,
-      originalInput,
-      timing: inputTranslation,
-    } = await translateUserInput(backup.userActionContent, settings.translationSettings)
-    const userActionEntry = await story.addEntry('user_action', promptContent)
-
-    if (originalInput) {
-      await database.updateStoryEntry(userActionEntry.id, { originalInput })
-      await story.refreshEntry(userActionEntry.id)
-    }
-
-    emitUserInput(backup.userActionContent, isCreativeMode ? 'direction' : backup.actionType)
-    await tick()
-
-    // Read here rather than before the rewind: the key carries the position, so it only
-    // matches once the restore has put the story back where retrieval ran.
-    const cacheKey = retrievalKeyFor(promptContent)
-
-    ui.setRetryingLastMessage(true)
     try {
-      await generateResponse(userActionEntry.id, promptContent, {
-        countStyleReview: false,
-        styleReviewSource: 'retry-last-message',
-        cachedRetrievalResult: cacheKey ? ui.retrievalResultFor(cacheKey) : null,
-        inputTranslation,
-      })
+      const result = await retryService.handleRetryLastMessage(
+        backup,
+        {
+          restoreFromRetryBackup: story.restoreFromRetryBackup.bind(story),
+          deleteEntriesFromPosition: story.deleteEntriesFromPosition.bind(story),
+          deleteEntitiesCreatedAfterBackup: story.deleteEntitiesCreatedAfterBackup.bind(story),
+          restoreCharacterSnapshots: story.restoreCharacterSnapshots.bind(story),
+          restoreTimeTrackerSnapshot: story.restoreTimeTrackerSnapshot.bind(story),
+          assertEntriesRemovable: story.assertEntriesRemovable.bind(story),
+          lockRetryInProgress: story.lockRetryInProgress.bind(story),
+          unlockRetryInProgress: story.unlockRetryInProgress.bind(story),
+          restoreActivationData: ui.restoreActivationData.bind(ui),
+          clearActivationData: () => ui.clearActivationData(),
+          setLastLorebookRetrieval: ui.setLastLorebookRetrieval.bind(ui),
+        },
+        {
+          clearGenerationError: () => ui.clearGenerationError(),
+          clearSuggestions: () => ui.clearSuggestions(storyId),
+          clearActionChoices: () => ui.clearActionChoices(storyId),
+        },
+        lease.branchId,
+      )
+
+      if (!result.success) {
+        ui.showToast(result.error ?? 'Could not restore the story', 'error')
+        return
+      }
+
+      await tick()
+
+      const {
+        promptContent,
+        originalInput,
+        timing: inputTranslation,
+      } = await translateUserInput(backup.userActionContent, settings.translationSettings)
+      const userActionEntry = await story.addEntry('user_action', promptContent, lease.branchId)
+
+      if (originalInput) {
+        await database.updateStoryEntry(userActionEntry.id, { originalInput })
+        await story.refreshEntry(userActionEntry.id)
+      }
+
+      emitUserInput(backup.userActionContent, isCreativeMode ? 'direction' : backup.actionType)
+      await tick()
+
+      // Read here rather than before the rewind: the key carries the position, so it only
+      // matches once the restore has put the story back where retrieval ran.
+      const cacheKey = retrievalKeyFor(promptContent)
+
+      ui.setRetryingLastMessage(true)
+      try {
+        await generateResponse(lease, userActionEntry.id, promptContent, {
+          countStyleReview: false,
+          styleReviewSource: 'retry-last-message',
+          cachedRetrievalResult: cacheKey ? ui.retrievalResultFor(cacheKey) : null,
+          inputTranslation,
+        })
+      } finally {
+        ui.setRetryingLastMessage(false)
+      }
     } finally {
-      ui.setRetryingLastMessage(false)
+      await lease.finish()
     }
   }
 

--- a/src/lib/components/story/ActionInput.svelte
+++ b/src/lib/components/story/ActionInput.svelte
@@ -1115,7 +1115,13 @@
       return
     }
 
-    const activeBranchId = story.currentStory.currentBranchId ?? null
+    // Read when the rewind actually runs, not now: it is deferred until the generation
+    // drains, and another story can be opened in between. Capturing here would hand the
+    // service a scope that was true only at the moment Stop was pressed.
+    const activeScope = () => ({
+      storyId: story.currentStory?.id ?? '',
+      branchId: story.currentStory?.currentBranchId ?? null,
+    })
     const runRestore = () =>
       retryService.handleStopGeneration(
         backup,
@@ -1137,7 +1143,7 @@
           clearSuggestions: () => ui.clearSuggestions(story.currentStory!.id),
           clearActionChoices: () => ui.clearActionChoices(story.currentStory!.id),
         },
-        activeBranchId,
+        activeScope(),
       )
 
     // Aborting the request is not the end of the generation's writes: a classification
@@ -1329,7 +1335,7 @@
           clearSuggestions: () => ui.clearSuggestions(storyId),
           clearActionChoices: () => ui.clearActionChoices(storyId),
         },
-        lease.branchId,
+        { storyId, branchId: story.currentStory.currentBranchId ?? null },
       )
 
       if (!result.success) {

--- a/src/lib/components/story/ActionInput.svelte
+++ b/src/lib/components/story/ActionInput.svelte
@@ -708,7 +708,7 @@
           narrationEntry = await story.addEntry(
             'narration',
             fullResponse,
-            leasedBranchId,
+            lease,
             generationMeta,
             fullReasoning || undefined,
             narrationEntryId,
@@ -801,7 +801,7 @@
 
       if (!fullResponse.trim()) {
         const errorMessage = 'The AI returned an empty response after 3 attempts. Please try again.'
-        const errorEntry = await story.addEntry('system', errorMessage, leasedBranchId)
+        const errorEntry = await story.addEntry('system', errorMessage, lease)
         ui.setGenerationError({
           message: errorMessage,
           errorEntryId: errorEntry.id,
@@ -857,11 +857,7 @@
       const errorMessage = ui.wasBackgroundedDuringGeneration
         ? `Generation may have been interrupted while the app was in the background. ${baseMessage}`
         : baseMessage
-      const errorEntry = await story.addEntry(
-        'system',
-        `Generation failed: ${errorMessage}`,
-        leasedBranchId,
-      )
+      const errorEntry = await story.addEntry('system', `Generation failed: ${errorMessage}`, lease)
       ui.setGenerationError({
         message: errorMessage,
         errorEntryId: errorEntry.id,
@@ -1040,6 +1036,10 @@
     try {
       lease = story.acquireGenerationLease()
     } catch (error) {
+      // The box was cleared above on the assumption this would go ahead. Give the text back
+      // rather than making the reader retype it.
+      inputValue = rawInput
+      isRawActionChoice = wasRawActionChoice
       ui.showToast(errMessage(error), 'error')
       return
     }
@@ -1068,7 +1068,7 @@
         timing: inputTranslation,
       } = await translateUserInput(content, settings.translationSettings)
 
-      const userActionEntry = await story.addEntry('user_action', promptContent, lease.branchId)
+      const userActionEntry = await story.addEntry('user_action', promptContent, lease)
 
       if (originalInput) {
         await database.updateStoryEntry(userActionEntry.id, { originalInput })
@@ -1327,7 +1327,7 @@
         originalInput,
         timing: inputTranslation,
       } = await translateUserInput(backup.userActionContent, settings.translationSettings)
-      const userActionEntry = await story.addEntry('user_action', promptContent, lease.branchId)
+      const userActionEntry = await story.addEntry('user_action', promptContent, lease)
 
       if (originalInput) {
         await database.updateStoryEntry(userActionEntry.id, { originalInput })

--- a/src/lib/components/story/ActionInput.svelte
+++ b/src/lib/components/story/ActionInput.svelte
@@ -857,13 +857,26 @@
       const errorMessage = ui.wasBackgroundedDuringGeneration
         ? `Generation may have been interrupted while the app was in the background. ${baseMessage}`
         : baseMessage
-      const errorEntry = await story.addEntry('system', `Generation failed: ${errorMessage}`, lease)
-      ui.setGenerationError({
-        message: errorMessage,
-        errorEntryId: errorEntry.id,
-        userActionEntryId,
-        timestamp: Date.now(),
-      })
+      // The fallback must not be able to trip the same wire that brought us here. If the
+      // story or branch moved under the generation, `addEntry` refuses — and throwing again
+      // from the handler would lose the error entirely, leaving an unhandled rejection and
+      // no Retry affordance.
+      try {
+        const errorEntry = await story.addEntry(
+          'system',
+          `Generation failed: ${errorMessage}`,
+          lease,
+        )
+        ui.setGenerationError({
+          message: errorMessage,
+          errorEntryId: errorEntry.id,
+          userActionEntryId,
+          timestamp: Date.now(),
+        })
+      } catch (recordError) {
+        console.error('[ActionInput] Could not record the failure entry:', recordError)
+        ui.showToast(errorMessage, 'error')
+      }
 
       await notifyFailureIfBackgrounded()
     } finally {
@@ -1102,9 +1115,6 @@
       return
     }
 
-    ui.setLastLorebookRetrieval(null)
-    ui.setLastRetrievalResult(null)
-
     const activeBranchId = story.currentStory.currentBranchId ?? null
     const runRestore = () =>
       retryService.handleStopGeneration(
@@ -1155,6 +1165,11 @@
       ui.showToast(result.error ?? 'Could not restore the story', 'error')
       return
     }
+
+    // Cleared only now: a refused restore leaves the story untouched, so wiping lorebook
+    // stickiness and the retrieval cache on the way in would be the one thing preflight
+    // exists to prevent. RetryService clears the lorebook debug state itself once it commits.
+    ui.setLastRetrievalResult(null)
 
     await tick()
     actionType = (result.restoredActionType as ActionType) ?? actionType

--- a/src/lib/components/story/StoryEntry.svelte
+++ b/src/lib/components/story/StoryEntry.svelte
@@ -375,11 +375,14 @@
   )
 
   // Show regeneration hint when editing the last user_action and retry is available
+  // Same scope check as `canRetry`: the two derive availability from one value and must not
+  // disagree about what makes it usable.
   const canSaveAndRegenerate = $derived(
     isLastUserAction &&
       !!ui.retryBackup &&
       !!story.currentStory &&
-      ui.retryBackup.storyId === story.currentStory.id,
+      ui.retryBackup.storyId === story.currentStory.id &&
+      (ui.retryBackup.branchId ?? null) === (story.currentStory.currentBranchId ?? null),
   )
 
   async function handleCreateCheckpoint() {

--- a/src/lib/components/story/StoryEntry.svelte
+++ b/src/lib/components/story/StoryEntry.svelte
@@ -58,6 +58,7 @@
   import { formatDuration, turnDuration } from '$lib/services/activity'
   import { countTokens } from '$lib/services/tokenizer'
   import { errMessage } from '$lib/utils/error'
+  import { sameBranchScope } from '$lib/utils/branchScope'
   import { Button } from '$lib/components/ui/button'
   import * as Popover from '$lib/components/ui/popover'
   import * as DropdownMenu from '$lib/components/ui/dropdown-menu'
@@ -187,9 +188,8 @@
   const canRetry = $derived(
     isLatestNarration &&
       ui.retryBackup &&
-      story.currentStory &&
-      ui.retryBackup.storyId === story.currentStory.id &&
-      (ui.retryBackup.branchId ?? null) === (story.currentStory.currentBranchId ?? null) &&
+      story.currentScope &&
+      sameBranchScope(ui.retryBackup, story.currentScope) &&
       !entriesLocked &&
       !ui.lastGenerationError,
   )
@@ -387,9 +387,8 @@
   const canSaveAndRegenerate = $derived(
     isLastUserAction &&
       !!ui.retryBackup &&
-      !!story.currentStory &&
-      ui.retryBackup.storyId === story.currentStory.id &&
-      (ui.retryBackup.branchId ?? null) === (story.currentStory.currentBranchId ?? null),
+      !!story.currentScope &&
+      sameBranchScope(ui.retryBackup, story.currentScope),
   )
 
   async function handleCreateCheckpoint() {

--- a/src/lib/components/story/StoryEntry.svelte
+++ b/src/lib/components/story/StoryEntry.svelte
@@ -174,6 +174,14 @@
   })
 
   // Check if retry is available for this entry
+  // One notion of busy for every affordance in this file, so none of them offers what the
+  // store will refuse. The lease, not just `isGenerating`: that flag is unset for the
+  // preparation before a turn and for the drain after Stop, and the store refuses across
+  // both. A retry restore rewrites the same entries a generation does, so it counts too.
+  const entriesLocked = $derived(
+    ui.isGenerating || story.isRetryInProgress || story.isGenerationLeaseHeld,
+  )
+
   // Branch as well as story: a snapshot taken elsewhere would be refused on restore, and
   // offering it here hides the regenerate that does work on this branch.
   const canRetry = $derived(
@@ -182,7 +190,7 @@
       story.currentStory &&
       ui.retryBackup.storyId === story.currentStory.id &&
       (ui.retryBackup.branchId ?? null) === (story.currentStory.currentBranchId ?? null) &&
-      !ui.isGenerating &&
+      !entriesLocked &&
       !ui.lastGenerationError,
   )
 
@@ -203,16 +211,9 @@
     isLatestNarration &&
       isLastEntry &&
       !canRetry &&
-      !ui.isGenerating &&
+      !entriesLocked &&
       !ui.lastGenerationError &&
       !!findPrecedingUserAction(story.entries, entry.id),
-  )
-
-  // A retry restore rewrites the same entries a generation does, and the store refuses both.
-  // The lease, not just `isGenerating`: the store refuses on the same terms, and the flag is
-  // unset for the preparation before a turn and for the drain after Stop.
-  const entriesLocked = $derived(
-    ui.isGenerating || story.isRetryInProgress || story.isGenerationLeaseHeld,
   )
 
   /**

--- a/src/lib/components/story/StoryEntry.svelte
+++ b/src/lib/components/story/StoryEntry.svelte
@@ -174,11 +174,14 @@
   })
 
   // Check if retry is available for this entry
+  // Branch as well as story: a snapshot taken elsewhere would be refused on restore, and
+  // offering it here hides the regenerate that does work on this branch.
   const canRetry = $derived(
     isLatestNarration &&
       ui.retryBackup &&
       story.currentStory &&
       ui.retryBackup.storyId === story.currentStory.id &&
+      (ui.retryBackup.branchId ?? null) === (story.currentStory.currentBranchId ?? null) &&
       !ui.isGenerating &&
       !ui.lastGenerationError,
   )

--- a/src/lib/components/story/StoryEntry.svelte
+++ b/src/lib/components/story/StoryEntry.svelte
@@ -371,7 +371,9 @@
   )
 
   // Can create checkpoint: latest entry, not a system entry, and no checkpoint exists yet
-  const canCreateCheckpoint = $derived(isLatestEntry && entry.type !== 'system' && !entryCheckpoint)
+  const canCreateCheckpoint = $derived(
+    isLatestEntry && entry.type !== 'system' && !entryCheckpoint && !entriesLocked,
+  )
 
   // Is this the last user_action in the story? (used for the regeneration hint)
   const isLastUserAction = $derived(

--- a/src/lib/components/story/StoryEntry.svelte
+++ b/src/lib/components/story/StoryEntry.svelte
@@ -209,7 +209,11 @@
   )
 
   // A retry restore rewrites the same entries a generation does, and the store refuses both.
-  const entriesLocked = $derived(ui.isGenerating || story.isRetryInProgress)
+  // The lease, not just `isGenerating`: the store refuses on the same terms, and the flag is
+  // unset for the preparation before a turn and for the drain after Stop.
+  const entriesLocked = $derived(
+    ui.isGenerating || story.isRetryInProgress || story.isGenerationLeaseHeld,
+  )
 
   /**
    * Dismiss/delete this error entry from the story.

--- a/src/lib/services/database.ts
+++ b/src/lib/services/database.ts
@@ -1730,23 +1730,38 @@ class DatabaseService {
 
     // Restore entries not necessary as we are only deleting redundant entries since backup
 
+    // The insert has to cover exactly what the delete above covered, and the delete is scoped
+    // to this branch. A snapshot taken on a branch that resolves its world state through the
+    // lineage holds ancestor rows too — rows carrying their own branch_id, which the delete
+    // never touched. Re-inserting one collides on the primary key, and because these
+    // statements cannot share a transaction the deletes have already committed by then: the
+    // branch loses its entries and its own world state, and the restore dies with nothing put
+    // back. Filtering to the branch's own rows makes the two halves symmetric, whatever shape
+    // the branch is.
+    //
+    // An override the undone generation created is absent from the snapshot, so it is deleted
+    // and not restored — which is correct: the inherited row it was standing in for shows
+    // through again.
+    const ownedByBranch = <T extends { branchId: string | null }>(rows: T[]): T[] =>
+      rows.filter((row) => (row.branchId ?? null) === branchId)
+
     // Restore characters
-    for (const character of characters) {
+    for (const character of ownedByBranch(characters)) {
       await this.addCharacter(character)
     }
 
     // Restore locations
-    for (const location of locations) {
+    for (const location of ownedByBranch(locations)) {
       await this.addLocation(location)
     }
 
     // Restore items
-    for (const item of items) {
+    for (const item of ownedByBranch(items)) {
       await this.addItem(item)
     }
 
     // Restore story beats
-    for (const beat of storyBeats) {
+    for (const beat of ownedByBranch(storyBeats)) {
       await this.addStoryBeat(beat)
     }
 

--- a/src/lib/services/database.ts
+++ b/src/lib/services/database.ts
@@ -1730,18 +1730,8 @@ class DatabaseService {
 
     // Restore entries not necessary as we are only deleting redundant entries since backup
 
-    // The insert has to cover exactly what the delete above covered, and the delete is scoped
-    // to this branch. A snapshot taken on a branch that resolves its world state through the
-    // lineage holds ancestor rows too — rows carrying their own branch_id, which the delete
-    // never touched. Re-inserting one collides on the primary key, and because these
-    // statements cannot share a transaction the deletes have already committed by then: the
-    // branch loses its entries and its own world state, and the restore dies with nothing put
-    // back. Filtering to the branch's own rows makes the two halves symmetric, whatever shape
-    // the branch is.
-    //
-    // An override the undone generation created is absent from the snapshot, so it is deleted
-    // and not restored — which is correct: the inherited row it was standing in for shows
-    // through again.
+    // The insert covers exactly what the delete covered — see the retry-backup bullet under
+    // Data Model in docs/architecture/overview.md for what a wider one destroys.
     const ownedByBranch = <T extends { branchId: string | null }>(rows: T[]): T[] =>
       rows.filter((row) => (row.branchId ?? null) === branchId)
 

--- a/src/lib/services/generation/RetryService.test.ts
+++ b/src/lib/services/generation/RetryService.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { RetryService, type RetryBackupData, type RetryStoreCallbacks } from './RetryService'
+
+function makeBackup(overrides: Partial<RetryBackupData> = {}): RetryBackupData {
+  return {
+    storyId: 'story-1',
+    branchId: 'branch-a',
+    timestamp: 1,
+    entries: [],
+    characters: [],
+    locations: [],
+    items: [],
+    storyBeats: [],
+    userActionContent: 'I open the door',
+    rawInput: 'open the door',
+    actionType: 'do',
+    wasRawActionChoice: false,
+    activationData: {},
+    storyPosition: 0,
+    entryCountBeforeAction: 12,
+    hasFullState: true,
+    hasEntityIds: true,
+    characterIds: [],
+    locationIds: [],
+    itemIds: [],
+    storyBeatIds: [],
+    timeTracker: null,
+    ...overrides,
+  }
+}
+
+function makeCallbacks() {
+  return {
+    restoreFromRetryBackup: vi.fn(async () => {}),
+    deleteEntriesFromPosition: vi.fn(async () => {}),
+    deleteEntitiesCreatedAfterBackup: vi.fn(async () => {}),
+    restoreCharacterSnapshots: vi.fn(async () => {}),
+    restoreTimeTrackerSnapshot: vi.fn(async () => {}),
+    assertEntriesRemovable: vi.fn(() => {}),
+    lockRetryInProgress: vi.fn(() => {}),
+    unlockRetryInProgress: vi.fn(() => {}),
+    restoreActivationData: vi.fn(() => {}),
+    clearActivationData: vi.fn(() => {}),
+    setLastLorebookRetrieval: vi.fn(() => {}),
+  } satisfies RetryStoreCallbacks
+}
+
+const uiCleanup = () => ({
+  clearGenerationError: vi.fn(),
+  clearSuggestions: vi.fn(),
+  clearActionChoices: vi.fn(),
+})
+
+/** Every callback that changes stored state. None may run when a restore is refused. */
+function mutatingCalls(callbacks: ReturnType<typeof makeCallbacks>) {
+  return [
+    callbacks.restoreFromRetryBackup,
+    callbacks.deleteEntriesFromPosition,
+    callbacks.deleteEntitiesCreatedAfterBackup,
+    callbacks.restoreCharacterSnapshots,
+    callbacks.restoreTimeTrackerSnapshot,
+    callbacks.restoreActivationData,
+    callbacks.clearActivationData,
+  ]
+}
+
+describe('RetryService branch enforcement', () => {
+  let service: RetryService
+  let callbacks: ReturnType<typeof makeCallbacks>
+
+  beforeEach(() => {
+    service = new RetryService()
+    callbacks = makeCallbacks()
+  })
+
+  describe('restoreFromBackup, entered directly', () => {
+    it('refuses a snapshot from another branch without touching state', async () => {
+      const result = await service.restoreFromBackup(makeBackup(), callbacks, 'branch-b')
+
+      expect(result.success).toBe(false)
+      expect(result.error).toMatch(/another branch/i)
+      for (const call of mutatingCalls(callbacks)) expect(call).not.toHaveBeenCalled()
+    })
+
+    it('proceeds on a matching branch', async () => {
+      const result = await service.restoreFromBackup(makeBackup(), callbacks, 'branch-a')
+
+      expect(result.success).toBe(true)
+      expect(callbacks.restoreFromRetryBackup).toHaveBeenCalledTimes(1)
+    })
+
+    it('refuses the ID-based path from another branch too', async () => {
+      const backup = makeBackup({ hasFullState: false })
+
+      const result = await service.restoreFromBackup(backup, callbacks, 'branch-b')
+
+      expect(result.success).toBe(false)
+      expect(callbacks.deleteEntriesFromPosition).not.toHaveBeenCalled()
+      expect(callbacks.deleteEntitiesCreatedAfterBackup).not.toHaveBeenCalled()
+      expect(callbacks.lockRetryInProgress).not.toHaveBeenCalled()
+    })
+
+    it('proceeds on the ID-based path when the branch matches', async () => {
+      const backup = makeBackup({ hasFullState: false })
+
+      const result = await service.restoreFromBackup(backup, callbacks, 'branch-a')
+
+      expect(result.success).toBe(true)
+      expect(callbacks.deleteEntriesFromPosition).toHaveBeenCalledWith(12)
+    })
+
+    it('passes the snapshot branch to the store so it can backstop the check', async () => {
+      await service.restoreFromBackup(makeBackup(), callbacks, 'branch-a')
+
+      expect(callbacks.restoreFromRetryBackup).toHaveBeenCalledWith(
+        expect.objectContaining({ branchId: 'branch-a' }),
+      )
+    })
+  })
+
+  describe('main branch is not conflated with a named branch', () => {
+    it('refuses a main-branch snapshot while a named branch is active', async () => {
+      const result = await service.restoreFromBackup(
+        makeBackup({ branchId: null }),
+        callbacks,
+        'branch-a',
+      )
+
+      expect(result.success).toBe(false)
+      for (const call of mutatingCalls(callbacks)) expect(call).not.toHaveBeenCalled()
+    })
+
+    it('refuses a named-branch snapshot while main is active', async () => {
+      const result = await service.restoreFromBackup(makeBackup(), callbacks, null)
+
+      expect(result.success).toBe(false)
+      for (const call of mutatingCalls(callbacks)) expect(call).not.toHaveBeenCalled()
+    })
+
+    it('proceeds when both are main', async () => {
+      const result = await service.restoreFromBackup(
+        makeBackup({ branchId: null }),
+        callbacks,
+        null,
+      )
+
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('handleRetryLastMessage', () => {
+    it('refuses before the preflight touches anything', async () => {
+      const cleanup = uiCleanup()
+
+      const result = await service.handleRetryLastMessage(
+        makeBackup(),
+        callbacks,
+        cleanup,
+        'branch-b',
+      )
+
+      expect(result.success).toBe(false)
+      expect(callbacks.assertEntriesRemovable).not.toHaveBeenCalled()
+      expect(callbacks.setLastLorebookRetrieval).not.toHaveBeenCalled()
+      expect(cleanup.clearSuggestions).not.toHaveBeenCalled()
+      for (const call of mutatingCalls(callbacks)) expect(call).not.toHaveBeenCalled()
+    })
+
+    it('proceeds on a matching branch', async () => {
+      const result = await service.handleRetryLastMessage(
+        makeBackup(),
+        callbacks,
+        uiCleanup(),
+        'branch-a',
+      )
+
+      expect(result.success).toBe(true)
+      expect(callbacks.restoreFromRetryBackup).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('handleStopGeneration', () => {
+    it('refuses a snapshot from another branch and leaves the active branch alone', async () => {
+      const cleanup = uiCleanup()
+
+      const result = await service.handleStopGeneration(
+        makeBackup(),
+        callbacks,
+        cleanup,
+        'branch-b',
+      )
+
+      expect(result.success).toBe(false)
+      expect(cleanup.clearGenerationError).not.toHaveBeenCalled()
+      for (const call of mutatingCalls(callbacks)) expect(call).not.toHaveBeenCalled()
+    })
+
+    it('proceeds on a matching branch', async () => {
+      const result = await service.handleStopGeneration(
+        makeBackup(),
+        callbacks,
+        uiCleanup(),
+        'branch-a',
+      )
+
+      expect(result.success).toBe(true)
+    })
+  })
+
+  it('still refuses on a branch mismatch when the entries are otherwise removable', async () => {
+    callbacks.assertEntriesRemovable = vi.fn(() => {
+      throw new Error('should not be consulted')
+    })
+
+    const result = await service.handleRetryLastMessage(
+      makeBackup(),
+      callbacks,
+      uiCleanup(),
+      'branch-b',
+    )
+
+    expect(result.error).toMatch(/another branch/i)
+  })
+})

--- a/src/lib/services/generation/RetryService.test.ts
+++ b/src/lib/services/generation/RetryService.test.ts
@@ -75,7 +75,10 @@ describe('RetryService branch enforcement', () => {
 
   describe('restoreFromBackup, entered directly', () => {
     it('refuses a snapshot from another branch without touching state', async () => {
-      const result = await service.restoreFromBackup(makeBackup(), callbacks, 'branch-b')
+      const result = await service.restoreFromBackup(makeBackup(), callbacks, {
+        storyId: 'story-1',
+        branchId: 'branch-b',
+      })
 
       expect(result.success).toBe(false)
       expect(result.error).toMatch(/another branch/i)
@@ -83,7 +86,10 @@ describe('RetryService branch enforcement', () => {
     })
 
     it('proceeds on a matching branch', async () => {
-      const result = await service.restoreFromBackup(makeBackup(), callbacks, 'branch-a')
+      const result = await service.restoreFromBackup(makeBackup(), callbacks, {
+        storyId: 'story-1',
+        branchId: 'branch-a',
+      })
 
       expect(result.success).toBe(true)
       expect(callbacks.restoreFromRetryBackup).toHaveBeenCalledTimes(1)
@@ -92,7 +98,10 @@ describe('RetryService branch enforcement', () => {
     it('refuses the ID-based path from another branch too', async () => {
       const backup = makeBackup({ hasFullState: false })
 
-      const result = await service.restoreFromBackup(backup, callbacks, 'branch-b')
+      const result = await service.restoreFromBackup(backup, callbacks, {
+        storyId: 'story-1',
+        branchId: 'branch-b',
+      })
 
       expect(result.success).toBe(false)
       expect(callbacks.deleteEntriesFromPosition).not.toHaveBeenCalled()
@@ -103,14 +112,20 @@ describe('RetryService branch enforcement', () => {
     it('proceeds on the ID-based path when the branch matches', async () => {
       const backup = makeBackup({ hasFullState: false })
 
-      const result = await service.restoreFromBackup(backup, callbacks, 'branch-a')
+      const result = await service.restoreFromBackup(backup, callbacks, {
+        storyId: 'story-1',
+        branchId: 'branch-a',
+      })
 
       expect(result.success).toBe(true)
       expect(callbacks.deleteEntriesFromPosition).toHaveBeenCalledWith(12)
     })
 
     it('passes the snapshot branch to the store so it can backstop the check', async () => {
-      await service.restoreFromBackup(makeBackup(), callbacks, 'branch-a')
+      await service.restoreFromBackup(makeBackup(), callbacks, {
+        storyId: 'story-1',
+        branchId: 'branch-a',
+      })
 
       expect(callbacks.restoreFromRetryBackup).toHaveBeenCalledWith(
         expect.objectContaining({ branchId: 'branch-a' }),
@@ -118,31 +133,59 @@ describe('RetryService branch enforcement', () => {
     })
   })
 
+  describe('the story is checked as well as the branch', () => {
+    it('refuses a snapshot from another story on the same branch name', async () => {
+      // Both on main, so the branch alone cannot tell the two apart. A deferred rewind runs
+      // after Stop, by which time another story may be open.
+      const result = await service.restoreFromBackup(
+        makeBackup({ storyId: 'story-1', branchId: null }),
+        callbacks,
+        { storyId: 'story-2', branchId: null },
+      )
+
+      expect(result.success).toBe(false)
+      expect(result.error).toMatch(/another story/i)
+      for (const call of mutatingCalls(callbacks)) expect(call).not.toHaveBeenCalled()
+    })
+
+    it('passes the snapshot story to the store so it can backstop the check', async () => {
+      await service.restoreFromBackup(makeBackup(), callbacks, {
+        storyId: 'story-1',
+        branchId: 'branch-a',
+      })
+
+      expect(callbacks.restoreFromRetryBackup).toHaveBeenCalledWith(
+        expect.objectContaining({ storyId: 'story-1', branchId: 'branch-a' }),
+      )
+    })
+  })
+
   describe('main branch is not conflated with a named branch', () => {
     it('refuses a main-branch snapshot while a named branch is active', async () => {
-      const result = await service.restoreFromBackup(
-        makeBackup({ branchId: null }),
-        callbacks,
-        'branch-a',
-      )
+      const result = await service.restoreFromBackup(makeBackup({ branchId: null }), callbacks, {
+        storyId: 'story-1',
+        branchId: 'branch-a',
+      })
 
       expect(result.success).toBe(false)
       for (const call of mutatingCalls(callbacks)) expect(call).not.toHaveBeenCalled()
     })
 
     it('refuses a named-branch snapshot while main is active', async () => {
-      const result = await service.restoreFromBackup(makeBackup(), callbacks, null)
+      const result = await service.restoreFromBackup(makeBackup(), callbacks, {
+        storyId: 'story-1',
+        branchId: null,
+      })
 
       expect(result.success).toBe(false)
       for (const call of mutatingCalls(callbacks)) expect(call).not.toHaveBeenCalled()
     })
 
     it('proceeds when both are main', async () => {
-      const result = await service.restoreFromBackup(
-        makeBackup({ branchId: null }),
-        callbacks,
-        null,
-      )
+      const result = await service.restoreFromBackup(makeBackup({ branchId: null }), callbacks, {
+        storyId: 'story-1',
+        branchId: null,
+      })
 
       expect(result.success).toBe(true)
     })
@@ -152,12 +195,10 @@ describe('RetryService branch enforcement', () => {
     it('refuses before the preflight touches anything', async () => {
       const cleanup = uiCleanup()
 
-      const result = await service.handleRetryLastMessage(
-        makeBackup(),
-        callbacks,
-        cleanup,
-        'branch-b',
-      )
+      const result = await service.handleRetryLastMessage(makeBackup(), callbacks, cleanup, {
+        storyId: 'story-1',
+        branchId: 'branch-b',
+      })
 
       expect(result.success).toBe(false)
       expect(callbacks.assertEntriesRemovable).not.toHaveBeenCalled()
@@ -167,12 +208,10 @@ describe('RetryService branch enforcement', () => {
     })
 
     it('proceeds on a matching branch', async () => {
-      const result = await service.handleRetryLastMessage(
-        makeBackup(),
-        callbacks,
-        uiCleanup(),
-        'branch-a',
-      )
+      const result = await service.handleRetryLastMessage(makeBackup(), callbacks, uiCleanup(), {
+        storyId: 'story-1',
+        branchId: 'branch-a',
+      })
 
       expect(result.success).toBe(true)
       expect(callbacks.restoreFromRetryBackup).toHaveBeenCalledTimes(1)
@@ -183,12 +222,10 @@ describe('RetryService branch enforcement', () => {
     it('refuses a snapshot from another branch and leaves the active branch alone', async () => {
       const cleanup = uiCleanup()
 
-      const result = await service.handleStopGeneration(
-        makeBackup(),
-        callbacks,
-        cleanup,
-        'branch-b',
-      )
+      const result = await service.handleStopGeneration(makeBackup(), callbacks, cleanup, {
+        storyId: 'story-1',
+        branchId: 'branch-b',
+      })
 
       expect(result.success).toBe(false)
       expect(cleanup.clearGenerationError).not.toHaveBeenCalled()
@@ -196,12 +233,10 @@ describe('RetryService branch enforcement', () => {
     })
 
     it('proceeds on a matching branch', async () => {
-      const result = await service.handleStopGeneration(
-        makeBackup(),
-        callbacks,
-        uiCleanup(),
-        'branch-a',
-      )
+      const result = await service.handleStopGeneration(makeBackup(), callbacks, uiCleanup(), {
+        storyId: 'story-1',
+        branchId: 'branch-a',
+      })
 
       expect(result.success).toBe(true)
     })
@@ -212,12 +247,10 @@ describe('RetryService branch enforcement', () => {
       throw new Error('should not be consulted')
     })
 
-    const result = await service.handleRetryLastMessage(
-      makeBackup(),
-      callbacks,
-      uiCleanup(),
-      'branch-b',
-    )
+    const result = await service.handleRetryLastMessage(makeBackup(), callbacks, uiCleanup(), {
+      storyId: 'story-1',
+      branchId: 'branch-b',
+    })
 
     expect(result.error).toMatch(/another branch/i)
   })

--- a/src/lib/services/generation/RetryService.ts
+++ b/src/lib/services/generation/RetryService.ts
@@ -26,6 +26,8 @@ const log = createLogger('RetryService')
  */
 export interface RetryBackupData {
   storyId: string
+  /** The branch the snapshot was taken on. It may only be restored onto that branch. */
+  branchId: string | null
   timestamp: number
   entries: StoryEntry[]
   characters: Character[]
@@ -56,6 +58,7 @@ export interface RetryBackupData {
 export interface RetryStoreCallbacks {
   // Story store operations
   restoreFromRetryBackup: (backup: {
+    branchId: string | null
     entries: StoryEntry[]
     characters: Character[]
     locations: Location[]
@@ -111,12 +114,19 @@ export class RetryService {
   async restoreFromBackup(
     backup: RetryBackupData,
     callbacks: RetryStoreCallbacks,
+    activeBranchId: string | null,
   ): Promise<RestoreResult> {
     log('restoreFromBackup called', {
       hasFullState: backup.hasFullState,
       hasEntityIds: backup.hasEntityIds,
       entryCountBeforeAction: backup.entryCountBeforeAction,
     })
+
+    // Enforced here rather than only in preflight: this method is public, and a rewind
+    // reachable without the check is a rewind without the check. Positions are reused across
+    // sibling branches, so a foreign snapshot deletes rows that merely share a number.
+    const refusedForBranch = this.refuseForeignBranch(backup, activeBranchId)
+    if (refusedForBranch) return refusedForBranch
 
     try {
       if (backup.hasFullState) {
@@ -142,12 +152,35 @@ export class RetryService {
     }
   }
 
+  private refuseForeignBranch(
+    backup: RetryBackupData,
+    activeBranchId: string | null,
+  ): RestoreResult | null {
+    if ((backup.branchId ?? null) === (activeBranchId ?? null)) return null
+    log('Restore refused: snapshot belongs to another branch', {
+      snapshotBranchId: backup.branchId,
+      activeBranchId,
+    })
+    return {
+      success: false,
+      error:
+        'This snapshot was taken on another branch. Switch back to it to retry, or ' +
+        'regenerate the last response on this branch instead.',
+    }
+  }
+
   /**
    * Both entry points run this before they touch anything: the restore paths rewind lorebook
    * activation and clear the suggestions before they reach the entries, and a refusal that
    * surfaced later would leave all of that applied with nothing undone.
    */
-  private preflight(backup: RetryBackupData, callbacks: RetryStoreCallbacks): RestoreResult | null {
+  private preflight(
+    backup: RetryBackupData,
+    callbacks: RetryStoreCallbacks,
+    activeBranchId: string | null,
+  ): RestoreResult | null {
+    const refusedForBranch = this.refuseForeignBranch(backup, activeBranchId)
+    if (refusedForBranch) return refusedForBranch
     try {
       callbacks.assertEntriesRemovable(backup.entryCountBeforeAction)
       return null
@@ -174,6 +207,7 @@ export class RetryService {
 
     // Restore story state (this handles locking internally)
     await callbacks.restoreFromRetryBackup({
+      branchId: backup.branchId,
       entries: backup.entries,
       characters: backup.characters,
       locations: backup.locations,
@@ -251,10 +285,11 @@ export class RetryService {
       clearSuggestions: () => void
       clearActionChoices: () => void
     },
+    activeBranchId: string | null,
   ): Promise<RestoreResult> {
     log('handleStopGeneration called')
 
-    const refused = this.preflight(backup, callbacks)
+    const refused = this.preflight(backup, callbacks, activeBranchId)
     if (refused) return refused
 
     // Clear UI state first
@@ -266,7 +301,7 @@ export class RetryService {
     callbacks.setLastLorebookRetrieval(null)
 
     // Perform restore
-    return this.restoreFromBackup(backup, callbacks)
+    return this.restoreFromBackup(backup, callbacks, activeBranchId)
   }
 
   /**
@@ -280,13 +315,14 @@ export class RetryService {
       clearSuggestions: () => void
       clearActionChoices: () => void
     },
+    activeBranchId: string | null,
   ): Promise<RestoreResult> {
     log('handleRetryLastMessage called', {
       hasFullState: backup.hasFullState,
       entryCountBeforeAction: backup.entryCountBeforeAction,
     })
 
-    const refused = this.preflight(backup, callbacks)
+    const refused = this.preflight(backup, callbacks, activeBranchId)
     if (refused) return refused
 
     // Clear UI state
@@ -298,7 +334,7 @@ export class RetryService {
     callbacks.setLastLorebookRetrieval(null)
 
     // Perform restore
-    return this.restoreFromBackup(backup, callbacks)
+    return this.restoreFromBackup(backup, callbacks, activeBranchId)
   }
 }
 

--- a/src/lib/services/generation/RetryService.ts
+++ b/src/lib/services/generation/RetryService.ts
@@ -58,6 +58,7 @@ export interface RetryBackupData {
 export interface RetryStoreCallbacks {
   // Story store operations
   restoreFromRetryBackup: (backup: {
+    storyId: string
     branchId: string | null
     entries: StoryEntry[]
     characters: Character[]
@@ -88,6 +89,12 @@ export interface RetryStoreCallbacks {
   setLastLorebookRetrieval: (result: null) => void
 }
 
+/** The story and branch a restore is allowed to touch. */
+export interface RestoreScope {
+  storyId: string
+  branchId: string | null
+}
+
 /**
  * Result of a restore operation
  */
@@ -114,7 +121,7 @@ export class RetryService {
   async restoreFromBackup(
     backup: RetryBackupData,
     callbacks: RetryStoreCallbacks,
-    activeBranchId: string | null,
+    active: RestoreScope,
   ): Promise<RestoreResult> {
     log('restoreFromBackup called', {
       hasFullState: backup.hasFullState,
@@ -125,7 +132,7 @@ export class RetryService {
     // Enforced here rather than only in preflight: this method is public, and a rewind
     // reachable without the check is a rewind without the check. Positions are reused across
     // sibling branches, so a foreign snapshot deletes rows that merely share a number.
-    const refusedForBranch = this.refuseForeignBranch(backup, activeBranchId)
+    const refusedForBranch = this.refuseForeignScope(backup, active)
     if (refusedForBranch) return refusedForBranch
 
     try {
@@ -152,20 +159,20 @@ export class RetryService {
     }
   }
 
-  private refuseForeignBranch(
-    backup: RetryBackupData,
-    activeBranchId: string | null,
-  ): RestoreResult | null {
-    if ((backup.branchId ?? null) === (activeBranchId ?? null)) return null
-    log('Restore refused: snapshot belongs to another branch', {
-      snapshotBranchId: backup.branchId,
-      activeBranchId,
+  private refuseForeignScope(backup: RetryBackupData, active: RestoreScope): RestoreResult | null {
+    const sameStory = backup.storyId === active.storyId
+    const sameBranch = (backup.branchId ?? null) === (active.branchId ?? null)
+    if (sameStory && sameBranch) return null
+    log('Restore refused: snapshot belongs elsewhere', {
+      snapshot: { storyId: backup.storyId, branchId: backup.branchId },
+      active,
     })
     return {
       success: false,
-      error:
-        'This snapshot was taken on another branch. Switch back to it to retry, or ' +
-        'regenerate the last response on this branch instead.',
+      error: sameStory
+        ? 'This snapshot was taken on another branch. Switch back to it to retry, or ' +
+          'regenerate the last response on this branch instead.'
+        : 'This snapshot was taken in another story, which is no longer the open one.',
     }
   }
 
@@ -177,9 +184,9 @@ export class RetryService {
   private preflight(
     backup: RetryBackupData,
     callbacks: RetryStoreCallbacks,
-    activeBranchId: string | null,
+    active: RestoreScope,
   ): RestoreResult | null {
-    const refusedForBranch = this.refuseForeignBranch(backup, activeBranchId)
+    const refusedForBranch = this.refuseForeignScope(backup, active)
     if (refusedForBranch) return refusedForBranch
     try {
       callbacks.assertEntriesRemovable(backup.entryCountBeforeAction)
@@ -207,6 +214,7 @@ export class RetryService {
 
     // Restore story state (this handles locking internally)
     await callbacks.restoreFromRetryBackup({
+      storyId: backup.storyId,
       branchId: backup.branchId,
       entries: backup.entries,
       characters: backup.characters,
@@ -285,11 +293,11 @@ export class RetryService {
       clearSuggestions: () => void
       clearActionChoices: () => void
     },
-    activeBranchId: string | null,
+    active: RestoreScope,
   ): Promise<RestoreResult> {
     log('handleStopGeneration called')
 
-    const refused = this.preflight(backup, callbacks, activeBranchId)
+    const refused = this.preflight(backup, callbacks, active)
     if (refused) return refused
 
     // Clear UI state first
@@ -301,7 +309,7 @@ export class RetryService {
     callbacks.setLastLorebookRetrieval(null)
 
     // Perform restore
-    return this.restoreFromBackup(backup, callbacks, activeBranchId)
+    return this.restoreFromBackup(backup, callbacks, active)
   }
 
   /**
@@ -315,14 +323,14 @@ export class RetryService {
       clearSuggestions: () => void
       clearActionChoices: () => void
     },
-    activeBranchId: string | null,
+    active: RestoreScope,
   ): Promise<RestoreResult> {
     log('handleRetryLastMessage called', {
       hasFullState: backup.hasFullState,
       entryCountBeforeAction: backup.entryCountBeforeAction,
     })
 
-    const refused = this.preflight(backup, callbacks, activeBranchId)
+    const refused = this.preflight(backup, callbacks, active)
     if (refused) return refused
 
     // Clear UI state
@@ -334,7 +342,7 @@ export class RetryService {
     callbacks.setLastLorebookRetrieval(null)
 
     // Perform restore
-    return this.restoreFromBackup(backup, callbacks, activeBranchId)
+    return this.restoreFromBackup(backup, callbacks, active)
   }
 }
 

--- a/src/lib/services/generation/RetryService.ts
+++ b/src/lib/services/generation/RetryService.ts
@@ -18,6 +18,7 @@ import type {
   PersistentCharacterSnapshot,
 } from '$lib/types'
 import { createLogger } from '$lib/log'
+import { sameBranchScope, type BranchScope } from '$lib/utils/branchScope'
 
 const log = createLogger('RetryService')
 
@@ -90,10 +91,7 @@ export interface RetryStoreCallbacks {
 }
 
 /** The story and branch a restore is allowed to touch. */
-export interface RestoreScope {
-  storyId: string
-  branchId: string | null
-}
+export type RestoreScope = BranchScope
 
 /**
  * Result of a restore operation
@@ -160,9 +158,8 @@ export class RetryService {
   }
 
   private refuseForeignScope(backup: RetryBackupData, active: RestoreScope): RestoreResult | null {
+    if (sameBranchScope(backup, active)) return null
     const sameStory = backup.storyId === active.storyId
-    const sameBranch = (backup.branchId ?? null) === (active.branchId ?? null)
-    if (sameStory && sameBranch) return null
     log('Restore refused: snapshot belongs elsewhere', {
       snapshot: { storyId: backup.storyId, branchId: backup.branchId },
       active,

--- a/src/lib/services/generation/loreCallbacks.ts
+++ b/src/lib/services/generation/loreCallbacks.ts
@@ -12,6 +12,7 @@
  */
 
 import { story } from '$lib/stores/story.svelte'
+import { sameBranchScope, type BranchScope } from '$lib/utils/branchScope'
 import { ui } from '$lib/stores/ui.svelte'
 import { aiService } from '$lib/services/ai'
 import { database } from '$lib/services/database'
@@ -27,10 +28,7 @@ import type {
  * The callbacks write through the `story` store, which always means the story open *now*,
  * while a session outlives the turn that started it.
  */
-export interface LoreCallbackScope {
-  storyId: string
-  branchId: string | null
-}
+export type LoreCallbackScope = BranchScope
 
 /**
  * Refuse a write meant for a branch that is no longer open.
@@ -39,8 +37,8 @@ export interface LoreCallbackScope {
  * than reporting a tidy-up that wrote nothing.
  */
 function assertScope(scope: LoreCallbackScope, action: string): void {
-  const current = story.currentStory
-  if (current?.id === scope.storyId && current.currentBranchId === scope.branchId) return
+  const current = story.currentScope
+  if (current && sameBranchScope(current, scope)) return
   throw new Error(
     `Lore management: refusing to ${action}. The session was started for story ${scope.storyId}` +
       ` (branch ${scope.branchId ?? 'main'}), which is no longer the open one.`,

--- a/src/lib/stores/story.svelte.ts
+++ b/src/lib/stores/story.svelte.ts
@@ -3703,6 +3703,15 @@ class StoryStore {
   ): Promise<Branch> {
     if (!this.currentStory) throw new Error('No story loaded')
 
+    // Creating a branch ends by switching to it, so it is a branch switch with a write in
+    // front. Refused here rather than at that switch, which would leave the branch created
+    // and the story still on the old one.
+    if (this.generationLease) {
+      throw new Error(
+        'Cannot create a branch while a generation is in progress: creating one switches to it.',
+      )
+    }
+
     // Verify the checkpoint exists in memory
     const checkpoint = this.checkpoints.find((cp) => cp.id === checkpointId)
     if (!checkpoint) {

--- a/src/lib/stores/story.svelte.ts
+++ b/src/lib/stores/story.svelte.ts
@@ -3636,6 +3636,11 @@ class StoryStore {
   async createCheckpoint(name: string): Promise<Checkpoint> {
     if (!this.currentStory) throw new Error('No story loaded')
 
+    // A checkpoint is a full snapshot, and a branch created from one copies it wholesale. Taken
+    // mid-turn it would freeze a half-written turn — the user action in, the narration or its
+    // world state not yet — and hand that to every branch made from it afterwards.
+    this.assertNotBusy('create a checkpoint')
+
     const lastEntry = this.entries[this.entries.length - 1]
     if (!lastEntry) throw new Error('No entries to checkpoint')
 
@@ -4566,6 +4571,7 @@ class StoryStore {
    * and allow regeneration.
    */
   async restoreFromRetryBackup(backup: {
+    storyId: string
     branchId: string | null
     entries: StoryEntry[]
     characters: Character[]
@@ -4579,14 +4585,13 @@ class StoryStore {
     if (!this.currentStory) throw new Error('No story loaded')
 
     // Backstop for a caller that bypasses RetryService: this deletes the active branch's
-    // world state and re-inserts the snapshot's rows, which carry their own branch_id.
-    if ((backup.branchId ?? null) !== (this.currentStory.currentBranchId ?? null)) {
-      throw new Error('Cannot restore a retry backup taken on another branch')
+    // world state and re-inserts the snapshot's rows. The story is checked as well as the
+    // branch — a deferred rewind runs after Stop, by which time another story may be open,
+    // and two stories' main branches are both null.
+    const scope = { storyId: backup.storyId, branchId: backup.branchId ?? null }
+    if (!this.isOpen(scope)) {
+      throw new Error('Cannot restore a retry backup taken in another story or branch')
     }
-
-    // Captured here for the same reason addEntry captures its own: the rewind is many awaits
-    // long and a story load during it would point the database work at the wrong story.
-    const scope = { storyId: this.currentStory.id, branchId: backup.branchId ?? null }
 
     // Lock editing during retry restore to prevent race conditions
     this._isRetryInProgress = true

--- a/src/lib/stores/story.svelte.ts
+++ b/src/lib/stores/story.svelte.ts
@@ -842,7 +842,7 @@ class StoryStore {
   async addEntry(
     type: StoryEntry['type'],
     content: string,
-    expectedBranchId: string | null,
+    expected: { storyId: string; branchId: string | null },
     metadata?: StoryEntry['metadata'],
     reasoning?: string,
     id?: string,
@@ -852,12 +852,16 @@ class StoryStore {
     }
 
     // Unreachable while the generation lease holds the branch, and that is the point: it
-    // catches a switch path that bypasses the lease, rather than writing to whichever branch
-    // happens to be active on arrival.
-    if (expectedBranchId !== (this.currentStory.currentBranchId ?? null)) {
+    // catches a path that bypasses the lease, rather than writing to whatever happens to be
+    // open on arrival. The story is checked too — two stories' main branches are both null,
+    // so the branch alone would let a write cross between them.
+    if (
+      expected.storyId !== this.currentStory.id ||
+      expected.branchId !== (this.currentStory.currentBranchId ?? null)
+    ) {
       throw new Error(
-        'The active branch changed while a generation was writing to it. This is a bug in ' +
-          'the generation lease, not something you did — the entry was not saved.',
+        'The open story or branch changed while a generation was writing to it. This is a ' +
+          'bug in the generation lease, not something you did — the entry was not saved.',
       )
     }
 
@@ -3704,13 +3708,31 @@ class StoryStore {
     if (!this.currentStory) throw new Error('No story loaded')
 
     // Creating a branch ends by switching to it, so it is a branch switch with a write in
-    // front. Refused here rather than at that switch, which would leave the branch created
-    // and the story still on the old one.
+    // front. Refused before that write: the alternative leaves the branch created and the
+    // story still on the old one.
     if (this.generationLease) {
       throw new Error(
         'Cannot create a branch while a generation is in progress: creating one switches to it.',
       )
     }
+
+    // Counted as a pending switch for the whole operation, not just checked once at the top.
+    // The copy below is many awaits long, and a lease taken during it would strand the final
+    // switch with the branch already written.
+    this.pendingBranchSwitches++
+    try {
+      return await this.performBranchCreation(name, forkEntryId, checkpointId)
+    } finally {
+      this.pendingBranchSwitches--
+    }
+  }
+
+  private async performBranchCreation(
+    name: string,
+    forkEntryId: string,
+    checkpointId: string,
+  ): Promise<Branch> {
+    if (!this.currentStory) throw new Error('No story loaded')
 
     // Verify the checkpoint exists in memory
     const checkpoint = this.checkpoints.find((cp) => cp.id === checkpointId)
@@ -4043,11 +4065,15 @@ class StoryStore {
     }
     if (!this.currentStory) throw new Error('No story loaded')
 
-    const lease = new GenerationLease(this.currentStory.currentBranchId ?? null, () => {
-      if (this.generationLease === lease) this.generationLease = null
-    })
+    const lease = new GenerationLease(
+      this.currentStory.id,
+      this.currentStory.currentBranchId ?? null,
+      () => {
+        if (this.generationLease === lease) this.generationLease = null
+      },
+    )
     this.generationLease = lease
-    log('Generation lease acquired', { branchId: lease.branchId })
+    log('Generation lease acquired', { storyId: lease.storyId, branchId: lease.branchId })
     return lease
   }
 

--- a/src/lib/stores/story.svelte.ts
+++ b/src/lib/stores/story.svelte.ts
@@ -1066,15 +1066,29 @@ class StoryStore {
    * `isRetryInProgress` and `ui.isGenerating` let the UI disable the affordance up front; this
    * refuses the ones that get through, rather than returning as if the work had been done.
    */
-  private assertNotBusy(action: string): void {
+  /**
+   * Refuse while the story is mid-turn.
+   *
+   * `ui.isGenerating` is not enough on its own: it is set inside `generateResponse`, after
+   * the initiating handler has already taken a snapshot and written the user action, and it
+   * is cleared by Stop while the classification is still writing. The lease covers both of
+   * those, so an edit or a delete in either window can no longer slip past.
+   *
+   * `holder` is the generation's own lease, for the two paths that legitimately edit under
+   * one — the error retry's delete of the failed entry, and the regenerate's undo.
+   */
+  private assertNotBusy(action: string, holder?: GenerationLease): void {
     if (this._isRetryInProgress || ui.isGenerating) {
       throw new Error(`Cannot ${action} while a generation or retry is in progress`)
+    }
+    if (this.generationLease && this.generationLease !== holder) {
+      throw new Error(`Cannot ${action} while a generation is in progress`)
     }
   }
 
   /** Every precondition for removing an entry, in one place. Returns the validated entry. */
-  private assertEntryDeletable(entryId: string): StoryEntry {
-    this.assertNotBusy('delete an entry')
+  private assertEntryDeletable(entryId: string, holder?: GenerationLease): StoryEntry {
+    this.assertNotBusy('delete an entry', holder)
 
     const entry = this.entries.find((e) => e.id === entryId)
     if (!entry) throw new Error('Entry not found')
@@ -1100,10 +1114,10 @@ class StoryStore {
   }
 
   // Delete a story entry
-  async deleteEntry(entryId: string): Promise<void> {
+  async deleteEntry(entryId: string, holder?: GenerationLease): Promise<void> {
     if (!this.currentStory) throw new Error('No story loaded')
 
-    const existingEntry = this.assertEntryDeletable(entryId)
+    const existingEntry = this.assertEntryDeletable(entryId, holder)
     const currentBranchId = this.currentStory.currentBranchId
 
     // Phase 2: Rollback on delete — cascade delete from this position with world state undo
@@ -1204,9 +1218,10 @@ class StoryStore {
    */
   async undoNarrationForRegenerate(
     entryId: string,
+    holder?: GenerationLease,
   ): Promise<{ entitiesUndone: boolean; timeUndone: boolean }> {
     if (!this.currentStory) throw new Error('No story loaded')
-    this.assertNotBusy('regenerate')
+    this.assertNotBusy('regenerate', holder)
 
     const entry = this.entries.find((e) => e.id === entryId)
     if (!entry) throw new Error('Entry not found')

--- a/src/lib/stores/story.svelte.ts
+++ b/src/lib/stores/story.svelte.ts
@@ -58,6 +58,7 @@ import { sameEntityName } from '$lib/utils/text'
 import { grammarService } from '$lib/services/grammar'
 import { clearTier3SelectionCache } from '$lib/services/ai'
 import { clearImageMarkerCache } from '$lib/services/image'
+import { GenerationLease } from '$lib/utils/generationLease'
 
 const log = createLogger('StoryStore')
 
@@ -677,8 +678,8 @@ class StoryStore {
     // Clear stale lorebook retrieval from previous story to prevent cross-story contamination
     ui.setLastLorebookRetrieval(null)
 
-    // Set current story ID for retry backup tracking
-    ui.setCurrentRetryStoryId(storyId)
+    // Point retry tracking at this story and its active branch
+    ui.setCurrentRetryScope(storyId, story.currentBranchId ?? null)
 
     // Load retry state from DB if we don't have an in-memory backup for this story
     if (story.retryState) {
@@ -841,12 +842,23 @@ class StoryStore {
   async addEntry(
     type: StoryEntry['type'],
     content: string,
+    expectedBranchId: string | null,
     metadata?: StoryEntry['metadata'],
     reasoning?: string,
     id?: string,
   ): Promise<StoryEntry> {
     if (!this.currentStory) {
       throw new Error('No story loaded')
+    }
+
+    // Unreachable while the generation lease holds the branch, and that is the point: it
+    // catches a switch path that bypasses the lease, rather than writing to whichever branch
+    // happens to be active on arrival.
+    if (expectedBranchId !== (this.currentStory.currentBranchId ?? null)) {
+      throw new Error(
+        'The active branch changed while a generation was writing to it. This is a bug in ' +
+          'the generation lease, not something you did — the entry was not saved.',
+      )
     }
 
     // Count tokens for accurate auto-summarize threshold detection
@@ -3074,8 +3086,8 @@ class StoryStore {
     this.storyLoadSeq++
     this.resetStoryState()
 
-    // Clear current retry story ID (backups are kept per-story)
-    ui.setCurrentRetryStoryId(null)
+    // Clear the retry scope (backups are kept per story and branch)
+    ui.setCurrentRetryScope(null, null)
 
     // Clear all generation caches (style review, retrieval, lorebook debug)
     ui.clearGenerationCaches()
@@ -3990,6 +4002,50 @@ class StoryStore {
   private branchSwitchChain: Promise<unknown> = Promise.resolve()
   /** Sequence of the most recently requested switch; older queued ones are superseded. */
   private branchSwitchSeq = 0
+  /** Switches requested but not yet settled. A lease may not be taken against one. */
+  private pendingBranchSwitches = $state(0)
+
+  private generationLease = $state<GenerationLease | null>(null)
+
+  /** True while a generation holds the branch. Drives the switch affordances. */
+  get isGenerationLeaseHeld(): boolean {
+    return this.generationLease !== null
+  }
+
+  /**
+   * Claim the current branch for a generation, from before its first read or write until
+   * after its last one.
+   *
+   * A generation writes entries and world state against whichever branch is loaded in
+   * memory, so the branch must not move under it. `ui.isGenerating` cannot express that: it
+   * is set inside `generateResponse`, after the initiating handler has already taken a
+   * snapshot and written the user action.
+   *
+   * Refuses against an unsettled switch as well as a held lease — a switch accepted while
+   * idle lands after `setStoryCurrentBranch` resolves, which is after a generation could
+   * otherwise have begun.
+   */
+  acquireGenerationLease(): GenerationLease {
+    if (this.generationLease) {
+      throw new Error('A generation is already in progress')
+    }
+    if (this.pendingBranchSwitches > 0) {
+      throw new Error('A branch switch is still in progress')
+    }
+    if (!this.currentStory) throw new Error('No story loaded')
+
+    const lease = new GenerationLease(this.currentStory.currentBranchId ?? null, () => {
+      if (this.generationLease === lease) this.generationLease = null
+    })
+    this.generationLease = lease
+    log('Generation lease acquired', { branchId: lease.branchId })
+    return lease
+  }
+
+  /** The lease a stop or a late write must check itself against, if one is held. */
+  get currentGenerationLease(): GenerationLease | null {
+    return this.generationLease
+  }
 
   /**
    * Switch to a different branch.
@@ -4012,11 +4068,18 @@ class StoryStore {
     // of the queue the user may have opened a different story, and a null branchId
     // would sail past the branch validation and write onto that story instead.
     const storyId = this.currentStory?.id ?? null
-    const run = this.branchSwitchChain.then(
-      () => this.performBranchSwitch(branchId, seq, storyId),
-      // Run regardless of whether the previous switch settled or threw
-      () => this.performBranchSwitch(branchId, seq, storyId),
-    )
+    // Counted from the request, not from the front of the queue: a lease taken while this
+    // one is still queued would be bound to a branch that is about to move.
+    this.pendingBranchSwitches++
+    const run = this.branchSwitchChain
+      .then(
+        () => this.performBranchSwitch(branchId, seq, storyId),
+        // Run regardless of whether the previous switch settled or threw
+        () => this.performBranchSwitch(branchId, seq, storyId),
+      )
+      .finally(() => {
+        this.pendingBranchSwitches--
+      })
     // Keep the chain resolved so one failure can't poison later switches; the
     // caller still observes the error through `run`.
     this.branchSwitchChain = run.catch(() => {})
@@ -4036,6 +4099,14 @@ class StoryStore {
     // The story changed under a queued switch; it no longer refers to anything current
     if (this.currentStory?.id !== storyId) return
 
+    // Checked here rather than at switchBranch's entrance: a switch accepted while idle
+    // reaches this point after a generation has begun. Stands in for world-state application
+    // being unable to target a branch other than the one loaded — see "The generation lease"
+    // in docs/architecture/overview.md for why, and for when this can be lifted.
+    if (this.generationLease) {
+      throw new Error('Cannot switch branches while a generation is in progress')
+    }
+
     if (!this.currentStory) throw new Error('No story loaded')
 
     // Validate branch exists (if not null)
@@ -4047,6 +4118,9 @@ class StoryStore {
     // Update story's current branch in database
     await database.setStoryCurrentBranch(this.currentStory.id, branchId)
     this.currentStory = { ...this.currentStory, currentBranchId: branchId }
+
+    // Follow the branch: each keeps its own snapshot, offered only on itself.
+    ui.setCurrentRetryScope(this.currentStory.id, branchId)
 
     // Reload entries from the database for the target branch
     await this.reloadEntriesForCurrentBranch()
@@ -4412,6 +4486,7 @@ class StoryStore {
    * and allow regeneration.
    */
   async restoreFromRetryBackup(backup: {
+    branchId: string | null
     entries: StoryEntry[]
     characters: Character[]
     locations: Location[]
@@ -4422,6 +4497,12 @@ class StoryStore {
     entryCountBeforeAction: number
   }): Promise<void> {
     if (!this.currentStory) throw new Error('No story loaded')
+
+    // Backstop for a caller that bypasses RetryService: this deletes the active branch's
+    // world state and re-inserts the snapshot's rows, which carry their own branch_id.
+    if ((backup.branchId ?? null) !== (this.currentStory.currentBranchId ?? null)) {
+      throw new Error('Cannot restore a retry backup taken on another branch')
+    }
 
     // Lock editing during retry restore to prevent race conditions
     this._isRetryInProgress = true

--- a/src/lib/stores/story.svelte.ts
+++ b/src/lib/stores/story.svelte.ts
@@ -1084,25 +1084,25 @@ class StoryStore {
 
   /**
    * Editing and deleting race with a generation or a retry restore rewriting the same entries.
-   * `isRetryInProgress` and `ui.isGenerating` let the UI disable the affordance up front; this
-   * refuses the ones that get through, rather than returning as if the work had been done.
-   */
-  /**
-   * Refuse while the story is mid-turn.
+   * The UI disables the affordance up front; this refuses the ones that get through, rather
+   * than returning as if the work had been done.
    *
-   * `ui.isGenerating` is not enough on its own: it is set inside `generateResponse`, after
-   * the initiating handler has already taken a snapshot and written the user action, and it
-   * is cleared by Stop while the classification is still writing. The lease covers both of
-   * those, so an edit or a delete in either window can no longer slip past.
+   * `ui.isGenerating` is not enough on its own: it is set inside `generateResponse`, after the
+   * initiating handler has already taken a snapshot and written the user action, and it is
+   * cleared by Stop while the classification is still writing. The lease covers both windows.
    *
-   * `holder` is the generation's own lease, for the two paths that legitimately edit under
-   * one — the error retry's delete of the failed entry, and the regenerate's undo.
+   * `holder` is the generation's own lease, for the two paths that legitimately edit under one
+   * — the error retry's delete of the failed entry, and the regenerate's undo.
    */
   private assertNotBusy(action: string, holder?: GenerationLease): void {
-    if (this._isRetryInProgress || ui.isGenerating) {
+    // A restore is rewriting these very entries, which refuses everyone — holder included.
+    if (this._isRetryInProgress) {
       throw new Error(`Cannot ${action} while a generation or retry is in progress`)
     }
-    if (this.generationLease && this.generationLease !== holder) {
+    // The lease and `ui.isGenerating` describe one generation, so the holder clears both or
+    // neither. Testing them apart let it through one and be refused by the other.
+    if (holder && this.generationLease === holder) return
+    if (ui.isGenerating || this.generationLease) {
       throw new Error(`Cannot ${action} while a generation is in progress`)
     }
   }

--- a/src/lib/stores/story.svelte.ts
+++ b/src/lib/stores/story.svelte.ts
@@ -875,32 +875,43 @@ class StoryStore {
       : { years: 0, days: 0, hours: 0, minutes: 0 }
     const timeEnd = { ...timeStart }
 
-    const position = await database.getNextEntryPosition(
-      this.currentStory.id,
-      this.currentStory.currentBranchId,
-    )
+    // The validated identity, not the live one: the check above is a moment, and the awaits
+    // below are not. Nothing refuses a story load mid-generation, so reading the store again
+    // here would file the row against whatever had since been opened.
+    const position = await database.getNextEntryPosition(expected.storyId, expected.branchId)
     const entry = await database.addStoryEntry({
       id: id ?? crypto.randomUUID(),
-      storyId: this.currentStory.id,
+      storyId: expected.storyId,
       type,
       content,
       parentId: null,
       position,
       metadata: { ...metadata, tokenCount, timeStart, timeEnd },
-      branchId: this.currentStory.currentBranchId,
+      branchId: expected.branchId,
       reasoning,
     })
 
-    this.entries = [...this.entries, entry]
-
-    // Invalidate caches
-    this.invalidateWordCountCache()
-    this.invalidateChapterCache()
+    // `entries` is the open branch's view. The row belongs to the branch it was written for
+    // either way, but pushing it into a view it does not belong to is the on-screen half of
+    // the bug this guards against.
+    if (this.isOpen(expected)) {
+      this.entries = [...this.entries, entry]
+      this.invalidateWordCountCache()
+      this.invalidateChapterCache()
+    }
 
     // Update story's updatedAt
-    await database.updateStory(this.currentStory.id, {})
+    await database.updateStory(expected.storyId, {})
 
     return entry
+  }
+
+  /** Whether the given story and branch are still the ones loaded in memory. */
+  private isOpen(scope: { storyId: string; branchId: string | null }): boolean {
+    return (
+      this.currentStory?.id === scope.storyId &&
+      (this.currentStory.currentBranchId ?? null) === scope.branchId
+    )
   }
 
   // Update a story entry
@@ -4558,6 +4569,10 @@ class StoryStore {
       throw new Error('Cannot restore a retry backup taken on another branch')
     }
 
+    // Captured here for the same reason addEntry captures its own: the rewind is many awaits
+    // long and a story load during it would point the database work at the wrong story.
+    const scope = { storyId: this.currentStory.id, branchId: backup.branchId ?? null }
+
     // Lock editing during retry restore to prevent race conditions
     this._isRetryInProgress = true
     log('Retry restore started - editing locked')
@@ -4594,8 +4609,8 @@ class StoryStore {
       // Restore to database (branch-aware: only delete/restore world state for current branch)
       await database.restoreRetryBackup(
         entryIdsToDelete,
-        this.currentStory.id,
-        this.currentStory.currentBranchId,
+        scope.storyId,
+        scope.branchId,
         backup.characters,
         backup.locations,
         backup.items,
@@ -4629,8 +4644,11 @@ class StoryStore {
         finalCharDescriptors,
       })
 
-      // Restore time tracker if provided (null clears)
-      await this.restoreTimeTrackerSnapshot(backup.timeTracker)
+      // Restore time tracker if provided (null clears). Skipped when the story moved under
+      // the rewind — the tracker is a live-state write, and it would land on the new one.
+      if (this.isOpen(scope)) {
+        await this.restoreTimeTrackerSnapshot(backup.timeTracker)
+      }
 
       log('Retry backup restored', {
         entries: this.entries.length,

--- a/src/lib/stores/story.svelte.ts
+++ b/src/lib/stores/story.svelte.ts
@@ -531,7 +531,23 @@ class StoryStore {
   }
 
   // Close the current story and reset state
+  /**
+   * Leave the story.
+   *
+   * Refused while a generation holds the store. The classification that follows a narration
+   * writes through the live story and branch, so opening another story under it would apply
+   * one story's world state to the next. See "The generation lease" in
+   * docs/architecture/overview.md for why that cannot simply be redirected.
+   */
   closeStory(): void {
+    if (this.generationLease) {
+      throw new Error(this.generationBusyMessage('leave the story'))
+    }
+    this.forceCloseStory()
+  }
+
+  /** Close without the guard, for the load path's own cleanup. */
+  private forceCloseStory(): void {
     this.storyLoadSeq++
     this.resetStoryState()
     this.currentBgImage = null
@@ -551,6 +567,11 @@ class StoryStore {
 
   // Load a specific story with all its data
   async loadStory(storyId: string): Promise<void> {
+    // Same reason as closeStory: a generation in flight writes through whatever story is
+    // open, so swapping it out from under one sends its remaining writes to the new story.
+    if (this.generationLease) {
+      throw new Error(this.generationBusyMessage('open another story'))
+    }
     const seq = ++this.storyLoadSeq
     const run = this.storyLoadChain.then(
       () => this.performStoryLoad(storyId, seq),
@@ -588,7 +609,7 @@ class StoryStore {
       // A load that failed *after* publishing leaves the store naming a story whose entries and
       // world state it never loaded. The caller shows the library, so the mismatch is invisible
       // but latent — tear it down rather than leave it for the next reader of the store.
-      if (this.currentStory?.id === storyId) this.closeStory()
+      if (this.currentStory?.id === storyId) this.forceCloseStory()
       throw error
     }
   }

--- a/src/lib/stores/story.svelte.ts
+++ b/src/lib/stores/story.svelte.ts
@@ -59,6 +59,7 @@ import { grammarService } from '$lib/services/grammar'
 import { clearTier3SelectionCache } from '$lib/services/ai'
 import { clearImageMarkerCache } from '$lib/services/image'
 import { GenerationLease } from '$lib/utils/generationLease'
+import { sameBranchScope, type BranchScope } from '$lib/utils/branchScope'
 
 const log = createLogger('StoryStore')
 
@@ -863,7 +864,7 @@ class StoryStore {
   async addEntry(
     type: StoryEntry['type'],
     content: string,
-    expected: { storyId: string; branchId: string | null },
+    expected: BranchScope,
     metadata?: StoryEntry['metadata'],
     reasoning?: string,
     id?: string,
@@ -876,10 +877,7 @@ class StoryStore {
     // catches a path that bypasses the lease, rather than writing to whatever happens to be
     // open on arrival. The story is checked too — two stories' main branches are both null,
     // so the branch alone would let a write cross between them.
-    if (
-      expected.storyId !== this.currentStory.id ||
-      expected.branchId !== (this.currentStory.currentBranchId ?? null)
-    ) {
+    if (!this.isOpen(expected)) {
       throw new Error(
         'The open story or branch changed while a generation was writing to it. This is a ' +
           'bug in the generation lease, not something you did — the entry was not saved.',
@@ -927,12 +925,16 @@ class StoryStore {
     return entry
   }
 
+  /** The story and branch currently loaded, for anything that must check it still is. */
+  get currentScope(): BranchScope | null {
+    if (!this.currentStory) return null
+    return { storyId: this.currentStory.id, branchId: this.currentStory.currentBranchId ?? null }
+  }
+
   /** Whether the given story and branch are still the ones loaded in memory. */
-  private isOpen(scope: { storyId: string; branchId: string | null }): boolean {
-    return (
-      this.currentStory?.id === scope.storyId &&
-      (this.currentStory.currentBranchId ?? null) === scope.branchId
-    )
+  private isOpen(scope: BranchScope): boolean {
+    const current = this.currentScope
+    return !!current && sameBranchScope(current, scope)
   }
 
   // Update a story entry

--- a/src/lib/stores/story.svelte.ts
+++ b/src/lib/stores/story.svelte.ts
@@ -4044,6 +4044,25 @@ class StoryStore {
   }
 
   /**
+   * True when the lease belongs to a story that is no longer the open one.
+   *
+   * Closing a story does not release the lease — the generation is still writing through
+   * this store — so the next story opened is locked too. It is locked for a different
+   * reason, and saying so is the difference between an explanation and a lie.
+   */
+  get isGenerationLeaseForAnotherStory(): boolean {
+    const lease = this.generationLease
+    return !!lease && lease.storyId !== (this.currentStory?.id ?? null)
+  }
+
+  /** Why a switch or a new generation is being refused, in terms the reader can act on. */
+  private generationBusyMessage(action: string): string {
+    return this.isGenerationLeaseForAnotherStory
+      ? `Cannot ${action}: a generation in another story is still finishing.`
+      : `Cannot ${action} while a generation is in progress`
+  }
+
+  /**
    * Claim the current branch for a generation, from before its first read or write until
    * after its last one.
    *
@@ -4058,7 +4077,7 @@ class StoryStore {
    */
   acquireGenerationLease(): GenerationLease {
     if (this.generationLease) {
-      throw new Error('A generation is already in progress')
+      throw new Error(this.generationBusyMessage('start a generation'))
     }
     if (this.pendingBranchSwitches > 0) {
       throw new Error('A branch switch is still in progress')
@@ -4139,7 +4158,7 @@ class StoryStore {
     // being unable to target a branch other than the one loaded — see "The generation lease"
     // in docs/architecture/overview.md for why, and for when this can be lifted.
     if (this.generationLease) {
-      throw new Error('Cannot switch branches while a generation is in progress')
+      throw new Error(this.generationBusyMessage('switch branches'))
     }
 
     if (!this.currentStory) throw new Error('No story loaded')

--- a/src/lib/stores/ui.svelte.ts
+++ b/src/lib/stores/ui.svelte.ts
@@ -920,7 +920,10 @@ class UIStore {
     // guess restores one branch's snapshot onto another. Discard it: the reader loses retry
     // across a restart once, and the next generation records an attributable snapshot.
     if (!Object.prototype.hasOwnProperty.call(retryState, 'branchId')) {
+      // Cleared as well as ignored. The branch-aware clear below can never match a row with
+      // no branch, so leaving it would have it re-read and re-discarded on every story load.
       console.log('[UI] Discarding persistent retry state that names no branch', { storyId })
+      this.queueRetryStateWrite(() => database.clearRetryState(storyId), 'clear')
       return
     }
     const branchId = retryState.branchId ?? null

--- a/src/lib/stores/ui.svelte.ts
+++ b/src/lib/stores/ui.svelte.ts
@@ -866,7 +866,14 @@ class UIStore {
 
       // Only clear from database if explicitly requested (user dismissed or used retry)
       if (clearFromDb) {
-        this.queueRetryStateWrite(() => database.clearRetryState(scope.storyId), 'clear')
+        this.queueRetryStateWrite(async () => {
+          // One persisted slot per story, so clearing it for this branch would take whichever
+          // branch's state is actually in it. Clear only when it is this branch's.
+          const stored = (await database.getStory(scope.storyId))?.retryState
+          if (!stored || (stored.branchId ?? null) === scope.branchId) {
+            await database.clearRetryState(scope.storyId)
+          }
+        }, 'clear')
       }
     }
 

--- a/src/lib/stores/ui.svelte.ts
+++ b/src/lib/stores/ui.svelte.ts
@@ -49,6 +49,10 @@ export type VaultTab = 'characters' | 'lorebooks' | 'scenarios' | 'prompts'
 // Backup for retry functionality - captures state before each user message
 export interface RetryBackup {
   storyId: string
+  // The branch the generation was bound to. A snapshot is only ever offered, or restored, on
+  // its own branch: positions are reused across siblings, so applying one elsewhere deletes
+  // rows that happen to share a number.
+  branchId: string | null
   timestamp: number
   // State snapshots (captured BEFORE user action is added)
   // These may be empty if loaded from persistent storage (entry-only restore)
@@ -167,27 +171,28 @@ class UIStore {
   // Error state for retry
   lastGenerationError = $state<GenerationError | null>(null)
 
-  // Retry backups - per-story backups for "retry last message" feature
-  // Stored by storyId so they persist across story switches within a session
+  // Retry backups, keyed by story *and* branch so they survive a story or branch switch
+  // within a session. Branch is part of the key because a snapshot restored onto another
+  // branch deletes rows there: positions are reused across siblings after a fork.
   private retryBackups = new SvelteMap<string, RetryBackup>()
-  private currentRetryStoryId = $state<string | null>(null)
+  private currentRetryScope = $state<{ storyId: string; branchId: string | null } | null>(null)
   retryStateWrite = Promise.resolve()
 
-  // Computed getter for current story's retry backup
+  // Computed getter for the current story and branch's retry backup
   get retryBackup(): RetryBackup | null {
-    if (!this.currentRetryStoryId) {
+    if (!this.currentRetryScope) {
       return null
     }
-    const backup = this.retryBackups.get(this.currentRetryStoryId) ?? null
-    return backup
+    const key = branchScopeKey(this.currentRetryScope.storyId, this.currentRetryScope.branchId)
+    return this.retryBackups.get(key) ?? null
   }
 
   /**
-   * Set the current story ID for retry backup tracking.
-   * Called when switching stories to ensure the correct backup is returned.
+   * Point retry tracking at a story and branch.
+   * Called when switching stories and when switching branches.
    */
-  setCurrentRetryStoryId(storyId: string | null) {
-    this.currentRetryStoryId = storyId
+  setCurrentRetryScope(storyId: string | null, branchId: string | null) {
+    this.currentRetryScope = storyId ? { storyId, branchId } : null
   }
 
   // Gallery image cache methods
@@ -672,6 +677,7 @@ class UIStore {
    */
   createRetryBackup(
     storyId: string,
+    branchId: string | null,
     entries: StoryEntry[],
     characters: Character[],
     locations: Location[],
@@ -735,6 +741,7 @@ class UIStore {
 
     const backup: RetryBackup = {
       storyId,
+      branchId,
       timestamp,
       // Large data - shallow copy to break potential proxy chains
       entries: [...entries],
@@ -781,11 +788,11 @@ class UIStore {
         JSON.stringify(charDescriptorsAtBackup) === JSON.stringify(charDescriptorsInBackup),
     })
 
-    this.retryBackups.set(storyId, backup)
-    this.currentRetryStoryId = storyId
+    this.retryBackups.set(branchScopeKey(storyId, branchId), backup)
+    this.currentRetryScope = { storyId, branchId }
 
     // Debug: Verify the stored backup is correct immediately after storing
-    const storedBackup = this.retryBackups.get(storyId)
+    const storedBackup = this.retryBackups.get(branchScopeKey(storyId, branchId))
     if (storedBackup) {
       const storedCharDescriptors = storedBackup.characters.map((c) => ({
         name: c.name,
@@ -803,6 +810,7 @@ class UIStore {
       () =>
         database.saveRetryState(storyId, {
           timestamp,
+          branchId,
           entryCountBeforeAction: nextEntryPosition,
           userActionContent,
           rawInput,
@@ -839,18 +847,30 @@ class UIStore {
    * @param storyId - Optional story ID. If not provided, clears the current story's backup.
    */
   clearRetryBackup(clearFromDb: boolean = false, storyId?: string) {
-    const targetStoryId = storyId ?? this.currentRetryStoryId
+    // A story-scoped clear drops every branch's backup for it: the caller is dismissing the
+    // story's retry state, and the persisted blob it clears is a single per-story slot.
+    if (storyId) {
+      for (const key of [...this.retryBackups.keys()]) {
+        if (key.startsWith(`${storyId}:`)) this.retryBackups.delete(key)
+      }
+      if (clearFromDb) {
+        this.queueRetryStateWrite(() => database.clearRetryState(storyId), 'clear')
+      }
+      console.log('[UI] Retry backups cleared for story', { clearFromDb, storyId })
+      return
+    }
 
-    if (targetStoryId) {
-      this.retryBackups.delete(targetStoryId)
+    const scope = this.currentRetryScope
+    if (scope) {
+      this.retryBackups.delete(branchScopeKey(scope.storyId, scope.branchId))
 
       // Only clear from database if explicitly requested (user dismissed or used retry)
       if (clearFromDb) {
-        this.queueRetryStateWrite(() => database.clearRetryState(targetStoryId), 'clear')
+        this.queueRetryStateWrite(() => database.clearRetryState(scope.storyId), 'clear')
       }
     }
 
-    console.log('[UI] Retry backup cleared', { clearFromDb, storyId: targetStoryId })
+    console.log('[UI] Retry backup cleared', { clearFromDb, scope })
   }
 
   private queueRetryStateWrite(task: () => Promise<void>, label: string) {
@@ -886,18 +906,33 @@ class UIStore {
       timeTracker?: TimeTracker | null
       activationData?: Record<string, number>
       storyPosition?: number
+      branchId?: string | null
     },
   ) {
-    // Skip if we already have an in-memory backup for this story (it's more complete)
-    if (this.retryBackups.has(storyId)) {
-      const existing = this.retryBackups.get(storyId)
+    // State written before the branch was recorded cannot be attributed to one, and a wrong
+    // guess restores one branch's snapshot onto another. Discard it: the reader loses retry
+    // across a restart once, and the next generation records an attributable snapshot.
+    if (!Object.prototype.hasOwnProperty.call(retryState, 'branchId')) {
+      console.log('[UI] Discarding persistent retry state that names no branch', { storyId })
+      return
+    }
+    const branchId = retryState.branchId ?? null
+    const key = branchScopeKey(storyId, branchId)
+
+    // Skip if we already have an in-memory backup for it (it's more complete)
+    if (this.retryBackups.has(key)) {
+      const existing = this.retryBackups.get(key)
       console.log('[UI] Skipping persistent retry state load - in-memory backup exists', {
         storyId,
+        branchId,
         existingHasFullState: existing?.hasFullState,
       })
       return
     }
-    console.log('[UI] Loading persistent retry backup (no in-memory backup found)', { storyId })
+    console.log('[UI] Loading persistent retry backup (no in-memory backup found)', {
+      storyId,
+      branchId,
+    })
 
     // Validate required fields exist
     if (
@@ -920,6 +955,7 @@ class UIStore {
 
     const backup: RetryBackup = {
       storyId,
+      branchId,
       timestamp: retryState.timestamp,
       // Empty state arrays - will use ID-based restore
       entries: [],
@@ -951,9 +987,10 @@ class UIStore {
         ? (retryState.timeTracker ?? null)
         : undefined,
     }
-    this.retryBackups.set(storyId, backup)
+    this.retryBackups.set(key, backup)
     console.log('[UI] *** PERSISTENT BACKUP LOADED (hasFullState: false) ***', {
       storyId,
+      branchId,
       entryCountBeforeAction: retryState.entryCountBeforeAction,
       userAction: retryState.userActionContent.substring(0, 50),
       characterSnapshotsCount: backup.characterSnapshots?.length ?? 0,
@@ -1000,20 +1037,22 @@ class UIStore {
    */
   updateRetryBackupContent(newContent: string) {
     const backup = this.retryBackup
-    if (backup && this.currentRetryStoryId) {
+    const scope = this.currentRetryScope
+    if (backup && scope) {
       const updatedBackup: RetryBackup = {
         ...backup,
         userActionContent: newContent,
         rawInput: newContent,
       }
-      this.retryBackups.set(this.currentRetryStoryId, updatedBackup)
+      this.retryBackups.set(branchScopeKey(scope.storyId, scope.branchId), updatedBackup)
 
       // Also persist the updated content to the database
-      const storyId = this.currentRetryStoryId
+      const storyId = scope.storyId
       this.queueRetryStateWrite(
         () =>
           database.saveRetryState(storyId, {
             timestamp: backup.timestamp,
+            branchId: backup.branchId,
             entryCountBeforeAction: backup.entryCountBeforeAction,
             userActionContent: newContent,
             rawInput: newContent,

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -66,6 +66,9 @@ export interface PersistentRetryState {
   // Lorebook activation data for stickiness preservation (optional for backwards compatibility)
   activationData?: Record<string, number>
   storyPosition?: number
+  // The branch the generation was bound to. Absent in state written before it was recorded;
+  // such state cannot be attributed to a branch and is discarded rather than guessed at.
+  branchId?: string | null
 }
 
 export interface PersistentCharacterSnapshot {

--- a/src/lib/utils/branchScope.ts
+++ b/src/lib/utils/branchScope.ts
@@ -9,3 +9,20 @@
 export function branchScopeKey(storyId: string, branchId: string | null): string {
   return `${storyId}:${branchId ?? 'main'}`
 }
+
+/** A story and one of its branches. `null` is the main branch. */
+export interface BranchScope {
+  storyId: string
+  branchId: string | null
+}
+
+/**
+ * Whether two scopes name the same branch of the same story.
+ *
+ * Normalises the branch on both sides. A missing branch reaches this as `null` from the store
+ * and as `undefined` from anything spread out of a partial record, and a comparison that tells
+ * those apart reports one branch as two — the same divergence `branchScopeKey` exists to stop.
+ */
+export function sameBranchScope(a: BranchScope, b: BranchScope): boolean {
+  return a.storyId === b.storyId && (a.branchId ?? null) === (b.branchId ?? null)
+}

--- a/src/lib/utils/generationLease.test.ts
+++ b/src/lib/utils/generationLease.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi } from 'vitest'
+import { GenerationLease } from './generationLease'
+
+function deferred<T = void>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+describe('GenerationLease', () => {
+  it('releases through its holder when nothing was deferred', async () => {
+    const onRelease = vi.fn()
+    const lease = new GenerationLease('branch-a', onRelease)
+
+    expect(lease.branchId).toBe('branch-a')
+    expect(onRelease).not.toHaveBeenCalled()
+
+    await lease.finish()
+
+    expect(onRelease).toHaveBeenCalledTimes(1)
+    expect(lease.isFinished).toBe(true)
+  })
+
+  it('carries a null branch for the main branch without conflating it', () => {
+    expect(new GenerationLease(null, vi.fn()).branchId).toBeNull()
+  })
+
+  it('runs a deferred restore before releasing, never after', async () => {
+    const order: string[] = []
+    const lease = new GenerationLease(null, () => order.push('release'))
+
+    lease.deferRestore(async () => {
+      order.push('restore')
+    })
+    await lease.finish()
+
+    expect(order).toEqual(['restore', 'release'])
+  })
+
+  it('does not release while a deferred restore is still running', async () => {
+    const onRelease = vi.fn()
+    const lease = new GenerationLease(null, onRelease)
+    const restoring = deferred()
+
+    lease.deferRestore(() => restoring.promise)
+    const finishing = lease.finish()
+
+    await Promise.resolve()
+    expect(onRelease).not.toHaveBeenCalled()
+
+    restoring.resolve()
+    await finishing
+    expect(onRelease).toHaveBeenCalledTimes(1)
+  })
+
+  it('settles the waiter once the deferred restore has run', async () => {
+    const lease = new GenerationLease(null, vi.fn())
+    const settled = lease.deferRestore(async () => {})
+    expect(settled).not.toBeNull()
+
+    await lease.finish()
+    await expect(settled).resolves.toBeUndefined()
+  })
+
+  it('releases even when the deferred restore throws, and reports it to the waiter', async () => {
+    const onRelease = vi.fn()
+    const lease = new GenerationLease(null, onRelease)
+    const boom = new Error('restore refused')
+
+    const settled = lease.deferRestore(async () => {
+      throw boom
+    })
+    const waiting = expect(settled).rejects.toThrow('restore refused')
+
+    await lease.finish()
+    await waiting
+
+    // A leaked lease would leave branch switching dead with no generation to explain it.
+    expect(onRelease).toHaveBeenCalledTimes(1)
+  })
+
+  it('is idempotent: a second finish neither re-releases nor re-runs the restore', async () => {
+    const onRelease = vi.fn()
+    const restore = vi.fn(async () => {})
+    const lease = new GenerationLease(null, onRelease)
+
+    lease.deferRestore(restore)
+    await lease.finish()
+    await lease.finish()
+
+    expect(restore).toHaveBeenCalledTimes(1)
+    expect(onRelease).toHaveBeenCalledTimes(1)
+  })
+
+  it('refuses to defer onto a finished lease, so the caller acts directly instead', async () => {
+    const lease = new GenerationLease(null, vi.fn())
+    await lease.finish()
+
+    const restore = vi.fn(async () => {})
+    expect(lease.deferRestore(restore)).toBeNull()
+    expect(restore).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/utils/generationLease.test.ts
+++ b/src/lib/utils/generationLease.test.ts
@@ -105,6 +105,24 @@ describe('GenerationLease', () => {
     expect(onRelease).toHaveBeenCalledTimes(1)
   })
 
+  it('keeps the first deferred restore, so its waiter cannot be stranded', async () => {
+    const onRelease = vi.fn()
+    const lease = new GenerationLease('story-1', null, onRelease)
+    const first = vi.fn(async () => {})
+    const second = vi.fn(async () => {})
+
+    const firstWaiter = lease.deferRestore(first)
+    const secondWaiter = lease.deferRestore(second)
+
+    // Replacing it would leave firstWaiter pending forever.
+    expect(secondWaiter).toBe(firstWaiter)
+
+    await lease.finish()
+    await expect(firstWaiter).resolves.toBeUndefined()
+    expect(first).toHaveBeenCalledTimes(1)
+    expect(second).not.toHaveBeenCalled()
+  })
+
   it('refuses to defer onto a finished lease, so the caller acts directly instead', async () => {
     const lease = new GenerationLease('story-1', null, vi.fn())
     await lease.finish()

--- a/src/lib/utils/generationLease.test.ts
+++ b/src/lib/utils/generationLease.test.ts
@@ -14,7 +14,7 @@ function deferred<T = void>() {
 describe('GenerationLease', () => {
   it('releases through its holder when nothing was deferred', async () => {
     const onRelease = vi.fn()
-    const lease = new GenerationLease('branch-a', onRelease)
+    const lease = new GenerationLease('story-1', 'branch-a', onRelease)
 
     expect(lease.branchId).toBe('branch-a')
     expect(onRelease).not.toHaveBeenCalled()
@@ -26,12 +26,21 @@ describe('GenerationLease', () => {
   })
 
   it('carries a null branch for the main branch without conflating it', () => {
-    expect(new GenerationLease(null, vi.fn()).branchId).toBeNull()
+    expect(new GenerationLease('story-1', null, vi.fn()).branchId).toBeNull()
+  })
+
+  it('carries the story too, so two stories on main are distinguishable', () => {
+    const a = new GenerationLease('story-1', null, vi.fn())
+    const b = new GenerationLease('story-2', null, vi.fn())
+
+    // Both are on main, so the branch alone says nothing about which story a write belongs to.
+    expect(a.branchId).toBe(b.branchId)
+    expect(a.storyId).not.toBe(b.storyId)
   })
 
   it('runs a deferred restore before releasing, never after', async () => {
     const order: string[] = []
-    const lease = new GenerationLease(null, () => order.push('release'))
+    const lease = new GenerationLease('story-1', null, () => order.push('release'))
 
     lease.deferRestore(async () => {
       order.push('restore')
@@ -43,7 +52,7 @@ describe('GenerationLease', () => {
 
   it('does not release while a deferred restore is still running', async () => {
     const onRelease = vi.fn()
-    const lease = new GenerationLease(null, onRelease)
+    const lease = new GenerationLease('story-1', null, onRelease)
     const restoring = deferred()
 
     lease.deferRestore(() => restoring.promise)
@@ -58,7 +67,7 @@ describe('GenerationLease', () => {
   })
 
   it('settles the waiter once the deferred restore has run', async () => {
-    const lease = new GenerationLease(null, vi.fn())
+    const lease = new GenerationLease('story-1', null, vi.fn())
     const settled = lease.deferRestore(async () => {})
     expect(settled).not.toBeNull()
 
@@ -68,7 +77,7 @@ describe('GenerationLease', () => {
 
   it('releases even when the deferred restore throws, and reports it to the waiter', async () => {
     const onRelease = vi.fn()
-    const lease = new GenerationLease(null, onRelease)
+    const lease = new GenerationLease('story-1', null, onRelease)
     const boom = new Error('restore refused')
 
     const settled = lease.deferRestore(async () => {
@@ -86,7 +95,7 @@ describe('GenerationLease', () => {
   it('is idempotent: a second finish neither re-releases nor re-runs the restore', async () => {
     const onRelease = vi.fn()
     const restore = vi.fn(async () => {})
-    const lease = new GenerationLease(null, onRelease)
+    const lease = new GenerationLease('story-1', null, onRelease)
 
     lease.deferRestore(restore)
     await lease.finish()
@@ -97,7 +106,7 @@ describe('GenerationLease', () => {
   })
 
   it('refuses to defer onto a finished lease, so the caller acts directly instead', async () => {
-    const lease = new GenerationLease(null, vi.fn())
+    const lease = new GenerationLease('story-1', null, vi.fn())
     await lease.finish()
 
     const restore = vi.fn(async () => {})

--- a/src/lib/utils/generationLease.ts
+++ b/src/lib/utils/generationLease.ts
@@ -1,0 +1,70 @@
+/**
+ * A generation's claim on the branch it started against.
+ *
+ * Two moments are distinct and both matter. *Drained* is when the generation's own writes
+ * have settled; a rewind must not begin before it, or it races the writes it exists to
+ * reverse. *Finished* is when the deferred rewind has run too, and only then is the claim
+ * given up — so a switch or a new generation cannot slip in between.
+ *
+ * Release has exactly one owner: the holder that acquired it. Stop registers a rewind here
+ * and waits for it, rather than releasing, which is what keeps the two from racing.
+ *
+ * A leaf module rather than part of the rune store, so its ordering can be tested.
+ */
+export class GenerationLease {
+  private deferredRestore: (() => Promise<void>) | null = null
+  private restoreSettled: ((result: { error?: unknown }) => void) | null = null
+  private finished = false
+
+  constructor(
+    readonly branchId: string | null,
+    private readonly onRelease: () => void,
+  ) {}
+
+  get isFinished(): boolean {
+    return this.finished
+  }
+
+  /**
+   * Register work to run once the generation has drained, and get back a promise that
+   * settles when it has. The holder runs it; the caller only waits.
+   *
+   * Returns null if the generation has already finished, in which case there is nothing
+   * left to wait for and the caller should act directly.
+   */
+  deferRestore(restore: () => Promise<void>): Promise<void> | null {
+    if (this.finished) return null
+    this.deferredRestore = restore
+    return new Promise<void>((resolve, reject) => {
+      this.restoreSettled = ({ error }) => (error ? reject(error) : resolve())
+    })
+  }
+
+  /**
+   * Mark the generation drained, run any deferred rewind, then release.
+   *
+   * Idempotent, and releases even when the rewind throws: a leaked lease would leave branch
+   * switching dead for the session with no generation left to explain it.
+   */
+  async finish(): Promise<void> {
+    if (this.finished) return
+    this.finished = true
+
+    const restore = this.deferredRestore
+    this.deferredRestore = null
+
+    try {
+      if (restore) {
+        try {
+          await restore()
+          this.restoreSettled?.({})
+        } catch (error) {
+          this.restoreSettled?.({ error })
+        }
+      }
+    } finally {
+      this.restoreSettled = null
+      this.onRelease()
+    }
+  }
+}

--- a/src/lib/utils/generationLease.ts
+++ b/src/lib/utils/generationLease.ts
@@ -17,6 +17,7 @@
 export class GenerationLease {
   private deferredRestore: (() => Promise<void>) | null = null
   private restoreSettled: ((result: { error?: unknown }) => void) | null = null
+  private pendingRestore: Promise<void> | null = null
   private finished = false
 
   constructor(
@@ -38,10 +39,14 @@ export class GenerationLease {
    */
   deferRestore(restore: () => Promise<void>): Promise<void> | null {
     if (this.finished) return null
+    // Replacing a registered restore would strand its waiter forever — the promise handed
+    // out for it would never settle. One rewind per lease; a second caller gets the first's.
+    if (this.deferredRestore) return this.pendingRestore
     this.deferredRestore = restore
-    return new Promise<void>((resolve, reject) => {
+    this.pendingRestore = new Promise<void>((resolve, reject) => {
       this.restoreSettled = ({ error }) => (error ? reject(error) : resolve())
     })
+    return this.pendingRestore
   }
 
   /**
@@ -68,6 +73,7 @@ export class GenerationLease {
       }
     } finally {
       this.restoreSettled = null
+      this.pendingRestore = null
       this.onRelease()
     }
   }

--- a/src/lib/utils/generationLease.ts
+++ b/src/lib/utils/generationLease.ts
@@ -9,6 +9,9 @@
  * Release has exactly one owner: the holder that acquired it. Stop registers a rewind here
  * and waits for it, rather than releasing, which is what keeps the two from racing.
  *
+ * Carries the story as well as the branch: two stories' main branches are both `null`, so a
+ * branch alone cannot tell a write meant for one from a write meant for the other.
+ *
  * A leaf module rather than part of the rune store, so its ordering can be tested.
  */
 export class GenerationLease {
@@ -17,6 +20,7 @@ export class GenerationLease {
   private finished = false
 
   constructor(
+    readonly storyId: string,
     readonly branchId: string | null,
     private readonly onRelease: () => void,
   ) {}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -5,6 +5,7 @@
   import { ui } from '$lib/stores/ui.svelte'
   import { story } from '$lib/stores/story.svelte'
   import { isAndroid } from '$lib/utils/platform'
+  import { errMessage } from '$lib/utils/error'
 
   let { children } = $props()
 
@@ -48,7 +49,16 @@
         ) {
           ui.setActivePanel('story')
         } else {
-          if (story.currentStory) story.closeStory()
+          if (story.currentStory) {
+            try {
+              story.closeStory()
+            } catch (error) {
+              // A generation is still writing to this story. Back out of the navigation
+              // rather than the story, and say so — otherwise the press looks ignored.
+              ui.showToast(errMessage(error), 'error')
+              return
+            }
+          }
           ui.setActivePanel('library')
         }
         return


### PR DESCRIPTION
## The bug

Reported twice. Navigate between branches a few times without generating, then press Regenerate on the last message of the branch you land on. The branch is clipped by a dozen entries, the regeneration answers a prompt from a branch you left, and the Characters, Inventory and Story beats panels come up empty.

The panels are not merely blank — the rows have been deleted from the database and re-inserted under a different branch's id.

## Why

A retry snapshot recorded no branch. `RetryBackup` was keyed by story alone and `canRetry` compared only `storyId`, so a snapshot taken on branch A was offered, and restored, on branch B.

The damage follows from two things:

- **Positions are reused by sibling branches after a fork.** The rewind deletes `position >= entryCountBeforeAction`, so A's cut point lands mid-way through B.
- **`database.restoreRetryBackup` deletes the active branch's world-state rows and re-inserts the snapshot's**, which carry their own `branch_id`. The per-branch entity queries match `branch_id` exactly and never fall back to inherited rows, so B is left with none of its own.

That last part does not depend on the experimental settings: the legacy per-branch load and snapshot isolation both empty out, and main does too when the snapshot came from a branch. Lightweight branches only decide how total it is — a pre-snapshot COW branch still resolves its ancestors'.

## What changed

**Snapshots carry their branch.** `RetryBackup` and `PersistentRetryState` gain `branchId`; backups are keyed by story *and* branch, so each branch keeps its own and switching back restores the offer.

**Foreign snapshots are refused** in `RetryService.restoreFromBackup` — which is public and was reachable without any check — as well as in `preflight`, which keeps refusing earlier and with a better message. `restoreFromRetryBackup` asserts too, now that its payload carries a branch.

**Retry state persisted before this change is discarded on load.** It cannot be attributed to a branch, and guessing "main" is wrong for exactly the people who hit this bug. One lost cross-session retry per story; the next generation records an attributable snapshot.

**A generation and a branch switch are made mutually exclusive** by a lease held from before the snapshot is taken until after the last write settles. `ui.isGenerating` could not do this:

- it is set inside `generateResponse`, after the initiating handler has already taken a snapshot, translated input and written the user action;
- it is checked at `switchBranch`'s entrance, which a switch accepted while idle passes before a generation begins — `performBranchSwitch` awaits a database write before it assigns anything;
- Stop clears it without awaiting the pipeline, while a classification already entered keeps writing.

The lease is acquired by all four initiating handlers (`handleSubmit`, `handleRetryLastMessage`, `handleRegenerateNarration`, `handleRetry`) and passed into `generateResponse` as a required parameter, so a fifth caller cannot be added without one. Stop registers its rewind on the lease and waits for it rather than releasing, so the rewind cannot race the writes it exists to reverse.

**`addEntry` takes the branch to write to and throws on a mismatch.** Unreachable while the lease holds — that is the point. It is the tripwire if the exclusion is ever holed: a write lands as a thrown error rather than as a row on the wrong branch.

## The restriction, and when it can be lifted

Branch switching is refused for the duration of a generation. This stands in for something, and should not be removed on the grounds that it looks like unexplained caution.

`applyClassificationResult` reads the active branch and mutates the in-memory `characters`/`locations`/`items`/`storyBeats` arrays, which hold *that* branch's view. Pointing it at another branch means decoupling "the branch being written" from "the branch loaded in memory" — an architectural change, not a parameter. Redirecting only the entries would be worse than redirecting nothing: the narration would land on the branch that asked for it while the classification accounting for it did not.

**It can be lifted once world-state application takes the branch to write to as an argument instead of reading the active one, *and* `addEntry` redirects to the bound branch. Both, not either** — the entry half alone produces exactly the mismatch above. Branch-scoping `isGenerating` belongs to that work too.

This is recorded in `docs/architecture/overview.md` under "The generation lease", so it does not depend on this description surviving.

## Notes for review

- **No migration.** `stories.retry_state` is a JSON blob; `branchId` is added inside it, as `embeddedImageIds`, `characterSnapshots` and `timeTracker` were.
- **`BranchPanel.svelte` is mostly reindentation** from a new wrapper element — read it with `git diff -w` (23 insertions, 15 deletions of real change).
- The branch panel is covered and made `inert` rather than dimmed with a tooltip: on Android there is no cursor to change and no hover to read. Rename and delete become unreachable with it, which is accepted — both are decisions worth making against a branch you can still inspect.

## Testing

- `npm run check`, `npm test`, `npm run lint` all clean.
- 21 new unit tests: `RetryService.test.ts` covers both restore paths and direct entry through `restoreFromBackup`, that main and a named branch are not conflated, and that no state-mutating callback runs on refusal. `generationLease.test.ts` covers the drain/restore/release ordering, release after a throwing restore, and idempotent finish.
- **Manual verification of the concurrency orderings is still outstanding** — the delayed-switch, delayed-translation and delayed-classification cases, and the reported repro end to end. There is no DOM in the test environment, so the store and component work is only exercised by running the app.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Branch switching and cross-branch landmark navigation are blocked while story generation is active, with clear lock or error messaging.
  * Generation and retry actions remain tied to the story branch where they began.

* **Bug Fixes**
  * Prevented generation results, edits, deletions, and retry restores from affecting the wrong story or branch.
  * Retry options and checkpoint creation are unavailable when saved state is out of scope or generation is active.
  * Stopping or retrying generation now safely restores state after pending updates complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->