### PR TITLE
Default generation activity to the status line, and retire the pack mapping opt-in

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -163,6 +163,11 @@ Reporting never alters a turn. Every write is guarded, the display sits inside a
 narrative retry loop is reported but unchanged. Records are session-only, bounded by `RETAINED_TURNS`,
 and never persisted or exported.
 
+`activityReporting` defaults to `line`, so an install that has never touched the setting reports the
+running step rather than the ellipsis. `activity_reporting` is written only by `setActivityReporting`
+and the interface reset, so a stored `off` is a choice and is read back as one — the default reaches
+absent keys only.
+
 ## Images
 
 Nine backends live under `src/lib/services/ai/image/providers/` — NanoGPT, OpenAI, OpenRouter,

--- a/src/lib/components/settings/ExperimentalSettings.svelte
+++ b/src/lib/components/settings/ExperimentalSettings.svelte
@@ -27,7 +27,6 @@
     Smartphone,
     Bell,
     Eye,
-    Package,
   } from '@lucide/svelte'
   import { Switch } from '$lib/components/ui/switch'
   import { Label } from '$lib/components/ui/label'
@@ -272,10 +271,6 @@
     await settings.updateExperimentalFeatures({ notificationPreview: checked })
   }
 
-  async function handleLegacyImportPackMappingToggle(checked: boolean) {
-    await settings.updateExperimentalFeatures({ legacyImportPackMapping: checked })
-  }
-
   async function handleResetAll() {
     await settings.resetExperimentalFeatures()
     stateTrackingChecked = settings.experimentalFeatures.stateTracking
@@ -472,35 +467,6 @@
       <span class="text-muted-foreground w-12 text-right font-mono text-sm">
         {settings.experimentalFeatures.autoSnapshotInterval}
       </span>
-    </div>
-  </div>
-
-  <Separator />
-
-  <!-- Pack mapping for older story files -->
-  <div class="space-y-5">
-    <div class="flex items-center gap-2">
-      <Package class="text-muted-foreground h-4 w-4" />
-      <Label class="text-sm font-medium">Story Import</Label>
-    </div>
-
-    <div class="flex flex-row items-center justify-between">
-      <div class="space-y-0.5">
-        <Label>Choose a prompt pack for older story files</Label>
-        <p class="text-muted-foreground text-xs">
-          Story files saved before Aventuras recorded prompt packs carry no pack of their own, and
-          import using the built-in one. Turn this on to be asked which of your packs such a file
-          should use. Files that do record a pack bind to a matching installed pack, and ask only
-          when the match is uncertain or a required value is missing, whatever this is set to.
-        </p>
-        <p class="text-muted-foreground pt-1 text-xs italic">
-          No effect if you only have one pack installed — there would be nothing to choose.
-        </p>
-      </div>
-      <Switch
-        checked={settings.experimentalFeatures.legacyImportPackMapping}
-        onCheckedChange={handleLegacyImportPackMappingToggle}
-      />
     </div>
   </div>
 

--- a/src/lib/components/story/LibraryView.svelte
+++ b/src/lib/components/story/LibraryView.svelte
@@ -8,7 +8,6 @@
   import SetupWizard from '../wizard/SetupWizard.svelte'
   import STImportWizard from '../wizard/STImportWizard.svelte'
   import PackMappingDialog from './PackMappingDialog.svelte'
-  import { settings } from '$lib/stores/settings.svelte'
   import type { PresetPack } from '$lib/services/packs'
   import { planPackBinding } from '$lib/services/import'
   import type { PackBindingContext, PackBindingResolution } from '$lib/services/import'
@@ -88,10 +87,7 @@
   async function resolvePackBinding(
     context: PackBindingContext,
   ): Promise<PackBindingResolution | null> {
-    const plan = await planPackBinding(
-      context,
-      settings.experimentalFeatures.legacyImportPackMapping,
-    )
+    const plan = await planPackBinding(context)
     if (!plan.ask) return plan.resolution
 
     return new Promise((resolve) => {

--- a/src/lib/components/sync/SyncModal.svelte
+++ b/src/lib/components/sync/SyncModal.svelte
@@ -18,7 +18,6 @@
   import type { SyncServerInfo, SyncStoryPreview, SyncConnectionData } from '$lib/types/sync'
   import { onDestroy, untrack } from 'svelte'
   import PackMappingDialog from '$lib/components/story/PackMappingDialog.svelte'
-  import { settings } from '$lib/stores/settings.svelte'
   import type { PresetPack } from '$lib/services/packs'
   import { planPackBinding, previewImport } from '$lib/services/import'
   import type { PackBindingContext, PackBindingResolution } from '$lib/services/import'
@@ -56,10 +55,7 @@
     if ('error' in preview) return preview
     const { context } = preview
 
-    const plan = await planPackBinding(
-      context,
-      settings.experimentalFeatures.legacyImportPackMapping,
-    )
+    const plan = await planPackBinding(context)
     if (!plan.ask) return plan.resolution
 
     return new Promise((resolve) => {

--- a/src/lib/services/import/packBinding.test.ts
+++ b/src/lib/services/import/packBinding.test.ts
@@ -263,30 +263,24 @@ describe('decidePackPrompt — what the interactive import asks about', () => {
   ]
 
   const device = (over: Partial<Parameters<typeof decidePackPrompt>[1]> = {}) => ({
-    legacyImportPackMapping: false,
     packCount: 3,
     ...over,
   })
 
   describe('a file that records no pack', () => {
-    it('is not asked about while the opt-in is off', () => {
-      // The compatibility promise: files written before packs were recorded import exactly as
-      // they did, with no new step in a workflow people already rely on.
-      expect(decidePackPrompt(recordsNoPack, device({ packCount: 4 }))).toEqual({ prompt: 'none' })
+    it('is asked about whenever there is more than one pack', () => {
+      expect(decidePackPrompt(recordsNoPack, device({ packCount: 2 }))).toEqual({
+        prompt: 'choose-pack',
+      })
+      expect(decidePackPrompt(recordsNoPack, device({ packCount: 4 }))).toEqual({
+        prompt: 'choose-pack',
+      })
     })
 
-    it('is asked about when the opt-in is on and there is more than one pack', () => {
-      expect(
-        decidePackPrompt(recordsNoPack, device({ legacyImportPackMapping: true, packCount: 2 })),
-      ).toEqual({ prompt: 'choose-pack' })
-    })
-
-    it('is not asked about on a single-pack device, opt-in or not', () => {
+    it('is not asked about on a single-pack device', () => {
       // Nothing was named, so there is no information to convey and no choice to make. Counting
       // packs rather than looking for a custom one also covers a renamed built-in pack.
-      expect(
-        decidePackPrompt(recordsNoPack, device({ legacyImportPackMapping: true, packCount: 1 })),
-      ).toEqual({ prompt: 'none' })
+      expect(decidePackPrompt(recordsNoPack, device({ packCount: 1 }))).toEqual({ prompt: 'none' })
     })
   })
 
@@ -295,14 +289,6 @@ describe('decidePackPrompt — what the interactive import asks about', () => {
       // The point of the whole policy: every file written from 1.9.0 on records a pack, so a
       // confirm-on-match rule would put a modal in front of every import forever.
       expect(decidePackPrompt(file('exact'), device())).toEqual({ prompt: 'none' })
-    })
-
-    it('binds without asking whatever the legacy opt-in says', () => {
-      for (const legacyImportPackMapping of [true, false]) {
-        expect(decidePackPrompt(file('exact'), device({ legacyImportPackMapping }))).toEqual({
-          prompt: 'none',
-        })
-      }
     })
 
     it('asks which pack when the name matches but the author does not', () => {
@@ -395,7 +381,7 @@ describe('planPackBinding — the one policy both callers use', () => {
     db.packs.push(pack({ id: 'local-grimdark' }))
     const ctx = await buildBindingContext(named as never)
 
-    const plan = await planPackBinding(ctx, false)
+    const plan = await planPackBinding(ctx)
 
     expect(plan).toEqual({
       ask: false,
@@ -411,7 +397,7 @@ describe('planPackBinding — the one policy both callers use', () => {
       customVariableValues: { Mood: 'somber' },
     } as never)
 
-    const plan = await planPackBinding(ctx, false)
+    const plan = await planPackBinding(ctx)
 
     expect(plan).toEqual({
       ask: false,
@@ -425,7 +411,7 @@ describe('planPackBinding — the one policy both callers use', () => {
   it('asks which pack, with nothing locked, when the named pack is absent', async () => {
     const ctx = await buildBindingContext(named as never)
 
-    await expect(planPackBinding(ctx, false)).resolves.toEqual({ ask: true, lockedPack: null })
+    await expect(planPackBinding(ctx)).resolves.toEqual({ ask: true, lockedPack: null })
   })
 
   it('locks the pack and names the gap when only a required value is missing', async () => {
@@ -434,17 +420,18 @@ describe('planPackBinding — the one policy both callers use', () => {
     db.packVariables = [{ variableName: 'mood', isRequired: true } as never]
     const ctx = await buildBindingContext({ pack: named.pack } as never)
 
-    const plan = await planPackBinding(ctx, false)
+    const plan = await planPackBinding(ctx)
 
     expect(plan).toEqual({ ask: true, lockedPack: local, onlyVariables: ['mood'] })
   })
 
-  it('passes the legacy opt-in through for a file that records no pack', async () => {
-    db.packs.push(pack({ id: 'local-grimdark' }))
+  it('asks which pack for a file that records no pack, once there is a choice', async () => {
+    // `beforeEach` leaves the built-in pack installed and nothing else: one pack, no choice.
     const ctx = await buildBindingContext(undefined)
+    await expect(planPackBinding(ctx)).resolves.toMatchObject({ ask: false })
 
-    await expect(planPackBinding(ctx, false)).resolves.toMatchObject({ ask: false })
-    await expect(planPackBinding(ctx, true)).resolves.toEqual({ ask: true, lockedPack: null })
+    db.packs.push(pack({ id: 'local-grimdark' }))
+    await expect(planPackBinding(ctx)).resolves.toEqual({ ask: true, lockedPack: null })
   })
 })
 
@@ -632,7 +619,7 @@ describe('sync — the decision is made before anything is written', () => {
     expect(calls.deleted).toEqual([])
   })
 
-  it('binds a legacy file to the built-in pack without consulting the opt-in', async () => {
+  it('binds a legacy file to the built-in pack when the caller supplies no resolver', async () => {
     await syncImport(sampleExport(undefined))
 
     expect(calls.stories[0].packId).toBe('default-pack')

--- a/src/lib/services/import/packBinding.ts
+++ b/src/lib/services/import/packBinding.ts
@@ -202,23 +202,21 @@ export type PackPromptDecision =
  * why the pack-count gate applies there and not here.
  *
  * A pure decision rather than a branch inside `runImport`: the pipeline keeps one rule ("ask the
- * resolver"), and the UI decides what it has to ask. Sync never calls this at all.
+ * resolver"), and the UI decides what it has to ask. Both interactive paths — file import and
+ * sync — go through it.
  */
 export function decidePackPrompt(
   ctx: PackBindingContext,
   device: {
-    legacyImportPackMapping: boolean
     packCount: number
     /** The matched pack's variables. Only consulted on a confident match. */
     matchedPackVariables?: RequiredVariableDef[]
   },
 ): PackPromptDecision {
-  // A file that records no pack: today's silent path, unless the Labs opt-in is on and the
-  // device has a choice worth offering.
+  // A file that records no pack has named nothing to match, so the only question worth asking is
+  // which pack — and only where there is more than one to pick from.
   if (!ctx.binding) {
-    return device.legacyImportPackMapping && device.packCount > 1
-      ? { prompt: 'choose-pack' }
-      : { prompt: 'none' }
+    return device.packCount > 1 ? { prompt: 'choose-pack' } : { prompt: 'none' }
   }
 
   if (ctx.match.confidence !== 'exact' || !ctx.match.pack) return { prompt: 'choose-pack' }
@@ -248,10 +246,7 @@ export type PackPromptPlan =
  * lives in one place and the components keep only their own dialog plumbing. `database` is
  * reached from here rather than from the components for the same reason.
  */
-export async function planPackBinding(
-  ctx: PackBindingContext,
-  legacyImportPackMapping: boolean,
-): Promise<PackPromptPlan> {
+export async function planPackBinding(ctx: PackBindingContext): Promise<PackPromptPlan> {
   const matched = ctx.match.pack
   const [packs, matchedPackVariables] = await Promise.all([
     database.getAllPacks(),
@@ -259,7 +254,6 @@ export async function planPackBinding(
   ])
 
   const decision = decidePackPrompt(ctx, {
-    legacyImportPackMapping,
     packCount: packs.length,
     matchedPackVariables,
   })

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -917,7 +917,6 @@ export function getDefaultExperimentalFeatures(): ExperimentalFeatures {
     backgroundGeneration: false,
     generationNotifications: false,
     notificationPreview: false,
-    legacyImportPackMapping: false,
   }
 }
 
@@ -1205,7 +1204,7 @@ export function getDefaultUISettings(): UISettings {
     highlightDialogue: false,
     dialogueColor: '',
     incognitoKeyboard: false,
-    activityReporting: 'off',
+    activityReporting: 'line',
   }
 }
 

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -868,15 +868,6 @@ export interface ExperimentalFeatures {
   generationNotifications: boolean
   /** Android: Include preview of generated text in the completion notification */
   notificationPreview: boolean
-  /**
-   * Ask which prompt pack to use when importing a story file that records no pack.
-   *
-   * Off by default on purpose: files predating the pack section are every file in existence, and
-   * they already import bound to the built-in pack. Only consulted on the interactive file-import
-   * path, and only when the device has more than one pack — sync never prompts, and a device with
-   * one pack has nothing to choose.
-   */
-  legacyImportPackMapping: boolean
 }
 
 // ===== World State Delta Tracking (Phase 1) =====


### PR DESCRIPTION
## Why

Two settings were parked in a state that no longer matched what they were for.

**Generation Activity** shipped as `Off`, so the feature added in #484 — the one that exists to make a forty-second wait legible — was invisible until someone went looking for it in Interface settings. Recording is already guarded, session-only and never persisted or exported, and `Status line` costs one line of chrome in place of the ellipsis.

**The pack mapping step for story files that record no pack** sat behind a Labs switch that was hedged as "off by default, existing files import as they always did". It has shipped, the path works, and the gate that actually decides whether a prompt is useful — more than one pack installed — is enforced independently. The switch only hid a correct prompt from the people it was written for.

## What this does

- **`activityReporting` defaults to `line`.** New installs, and every existing install that never touched the setting, report the deepest running step and the turn's elapsed time instead of the animated ellipsis. Reset All now lands on `Status line` too, through the `setActivityReporting` call `resetAllSettings` already makes.
- **A user who chose `Off` keeps it.** `activity_reporting` is written only by the setter and the interface reset, and `loadSettings` reads it back before the default applies — so the new default reaches absent keys only. No migration, no settings rewrite.
- **`legacyImportPackMapping` is retired**: gone from `ExperimentalFeatures`, from `getDefaultExperimentalFeatures`, and from the Labs panel. `decidePackPrompt` and `planPackBinding` lose the parameter rather than defaulting it, so the no-binding branch reduces to `packCount > 1`.
- **The pack-count gate stays.** With one pack installed there is nothing to choose, so nothing is asked.

## A divergence this settles

The spec said the opt-in "SHALL NOT apply to sync", and a comment in `packBinding.ts` claimed "Sync never calls this at all". Neither was true of the code: `SyncModal` passed the same Labs flag into `planPackBinding` as `LibraryView` did, so a no-pack sync payload was silent only because the flag was off. Retiring the flag resolves this in favour of the code — both interactive paths now behave identically — and the comment is corrected.

Practically: a synced story recording no pack, arriving on a device with more than one pack, now asks which pack to use. It asks before anything is written or deleted, so cancelling still leaves the device untouched.

## Compatibility

The retired key is left behind in the stored `experimental_features` blob. It is loaded as `{ ...getDefaultExperimentalFeatures(), ...loaded }`, so an unknown key survives the spread harmlessly and is never read again.

## Verification

`npm run check` 0 errors · `npm test` 1456 passed · `npm run lint` 0 errors.

**Not yet exercised in the running app** — worth a manual pass before merge, since a Svelte-level mistake in the two markup edits passes all three:

- [ ] A profile with no `activity_reporting` row shows the status line without touching settings; setting it to `Off` brings the ellipsis back and survives a restart
- [ ] Importing a story file recording no pack asks which pack on a two-pack device, and does not on a single-pack one
- [ ] The Labs tab renders with no gap or stray separator where the Story Import section was
- [ ] A sync payload recording no pack on a multi-pack device asks before writing, and cancelling changes nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Removed the experimental “Story Import” setting from Settings.
  - Story files without a recorded prompt pack now prompt users to choose one when multiple packs are available.
  - Sync and import use consistent prompt-pack selection behavior.
  - Single-pack devices continue using the available pack automatically.
  - Default activity reporting is now set to line-level reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->