### PR TITLE
Clear the scroll-lock close grace when an overlay reopens

### DIFF
--- a/src/lib/utils/scrollLock.test.ts
+++ b/src/lib/utils/scrollLock.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { isBodyLocked, isWithinCloseGrace } from './scrollLock'
+import { isBodyLocked, isWithinCloseGrace, hasEntitledOwner } from './scrollLock'
 import { MODAL_CLOSE_TRANSITION_MS } from '$lib/constants/layout'
 
 /** The half-locked states are the point: they are what the library's deferred apply produces. */
@@ -39,5 +39,61 @@ describe('isWithinCloseGrace', () => {
 
   it('drops entitlement for an overlay stalled at closed', () => {
     expect(isWithinCloseGrace(1000, 1000 + 60_000)).toBe(false)
+  })
+})
+
+describe('hasEntitledOwner', () => {
+  const overlay = () => ({})
+  const GRACE = MODAL_CLOSE_TRANSITION_MS
+
+  it('is entitled while an overlay is open', () => {
+    expect(hasEntitledOwner([overlay()], [], new WeakMap(), 0)).toBe(true)
+  })
+
+  it('is not entitled when nothing is on screen', () => {
+    expect(hasEntitledOwner([], [], new WeakMap(), 0)).toBe(false)
+  })
+
+  it('starts the clock the first time a closing overlay is seen', () => {
+    const el = overlay()
+    const since = new WeakMap<object, number>()
+    expect(hasEntitledOwner([], [el], since, 1000)).toBe(true)
+    expect(since.get(el)).toBe(1000)
+  })
+
+  it('stays entitled through the exit, then stops', () => {
+    const el = overlay()
+    const since = new WeakMap<object, number>()
+    hasEntitledOwner([], [el], since, 1000)
+    expect(hasEntitledOwner([], [el], since, 1000 + GRACE - 1)).toBe(true)
+    expect(hasEntitledOwner([], [el], since, 1000 + GRACE)).toBe(false)
+  })
+
+  /** Reusing the first close's timestamp would drop the lock while the second close is running. */
+  it('restarts the clock when the same overlay reopens and closes again', () => {
+    const el = overlay()
+    const since = new WeakMap<object, number>()
+
+    hasEntitledOwner([], [el], since, 0)
+    expect(hasEntitledOwner([], [el], since, GRACE)).toBe(false)
+
+    // Reopened: the stale timestamp must not survive it
+    expect(hasEntitledOwner([el], [], since, GRACE + 100)).toBe(true)
+    expect(since.get(el)).toBeUndefined()
+
+    // Closing again, long after the first close would have expired
+    expect(hasEntitledOwner([], [el], since, GRACE + 200)).toBe(true)
+    expect(hasEntitledOwner([], [el], since, GRACE + 200 + GRACE - 1)).toBe(true)
+    expect(hasEntitledOwner([], [el], since, GRACE + 200 + GRACE)).toBe(false)
+  })
+
+  it('is entitled when any one of several closing overlays is still in grace', () => {
+    const stalled = overlay()
+    const fresh = overlay()
+    const since = new WeakMap<object, number>()
+
+    hasEntitledOwner([], [stalled], since, 0)
+    expect(hasEntitledOwner([], [stalled], since, GRACE)).toBe(false)
+    expect(hasEntitledOwner([], [stalled, fresh], since, GRACE)).toBe(true)
   })
 })

--- a/src/lib/utils/scrollLock.ts
+++ b/src/lib/utils/scrollLock.ts
@@ -22,12 +22,9 @@ export const NO_SCROLL_LOCK_ATTR = 'data-no-scroll-lock'
  * Everything in this stack that legitimately holds a body lock, as it appears in the DOM.
  *
  * `bits-ui` resolves `preventScroll ?? true`, so dialog, alert-dialog, context-menu and
- * dropdown/menu lock. Popover, select and tooltip opt out upstream; a sub-menu shares
- * `MenuContentState` and so looks identical here, and is excluded by the same marker the
- * app's own dropdowns carry. `vaul` locks its own way.
- *
- * `[data-state]` is what separates a library-owned overlay from a hand-rolled one with the
- * same ARIA role, which holds no lock and must not be able to veto recovery.
+ * dropdown/menu lock; a sub-menu does not, but looks identical, hence the marker.
+ * `[data-state]` separates these from a hand-rolled overlay with the same role, which holds
+ * no lock and must not veto recovery.
  */
 const OVERLAY_CLAUSES = [
   '[role="dialog"]',
@@ -39,7 +36,6 @@ const OVERLAY_CLAUSES = [
 const OPEN_OVERLAY_SELECTOR = OVERLAY_CLAUSES.map((c) => `${c}[data-state="open"]`).join(', ')
 const CLOSING_OVERLAY_SELECTOR = OVERLAY_CLAUSES.map((c) => `${c}[data-state="closed"]`).join(', ')
 
-/** When each closing overlay was first seen, so the grace below is measured from somewhere. */
 const closingSince = new WeakMap<Element, number>()
 
 /** Is a closing overlay still within the window where it may hold its lock? */
@@ -48,26 +44,41 @@ export function isWithinCloseGrace(since: number, now: number): boolean {
 }
 
 /**
- * Is anything on screen entitled to be holding the body lock right now?
+ * Is any of these entitled to hold the body lock?
  *
- * A closing overlay still owns its lock — the owner unmounts with the element, not with the
- * state flip — so it counts, but only until its exit has had time to finish. `bits-ui` drops
- * the element from an animation callback, and a WebView that never delivers one would
- * otherwise leave a node at `data-state="closed"` vetoing recovery for the rest of the session.
+ * A closing overlay still owns its lock, since the owner unmounts with the element rather than
+ * with the state flip — but only until its exit could have finished, or a node stalled at
+ * `closed` would veto recovery for the rest of the session. Reopening clears the clock: the
+ * same element can close, reopen and close again, and the second close starts over.
  */
-function hasOpenOverlay(): boolean {
-  if (document.querySelector(OPEN_OVERLAY_SELECTOR) !== null) return true
+export function hasEntitledOwner<T extends object>(
+  open: readonly T[],
+  closing: readonly T[],
+  since: WeakMap<T, number>,
+  now: number,
+): boolean {
+  for (const el of open) since.delete(el)
+  if (open.length > 0) return true
 
-  const now = Date.now()
-  for (const el of document.querySelectorAll(CLOSING_OVERLAY_SELECTOR)) {
-    const since = closingSince.get(el)
-    if (since === undefined) {
-      closingSince.set(el, now)
+  for (const el of closing) {
+    const seen = since.get(el)
+    if (seen === undefined) {
+      since.set(el, now)
       return true
     }
-    if (isWithinCloseGrace(since, now)) return true
+    if (isWithinCloseGrace(seen, now)) return true
   }
   return false
+}
+
+/** Is anything on screen entitled to be holding the body lock right now? */
+function hasOpenOverlay(): boolean {
+  return hasEntitledOwner(
+    Array.from(document.querySelectorAll(OPEN_OVERLAY_SELECTOR)),
+    Array.from(document.querySelectorAll(CLOSING_OVERLAY_SELECTOR)),
+    closingSince,
+    Date.now(),
+  )
 }
 
 /**


### PR DESCRIPTION
Recovers a commit that was left behind when #489 was squash-merged: it was
authored a few minutes after that merge landed, so it never shipped. Cherry-picked
onto current `master` so the diff is just the one change rather than #489's history
a second time.

## The bug

The close grace gives a closing overlay a window in which it still counts as owning
the body scroll lock — the owner unmounts with the element, not with the `data-state`
flip. But the grace timestamp was never dropped when an element went back to open, so
an overlay that closed, reopened and closed again reused the first close's clock. The
second close inherited an already-expired grace and stopped counting as an owner while
it was still exiting, releasing the lock early — exactly the failure the grace exists
to prevent, and reachable by opening and closing the same menu twice.

## The change

The bookkeeping moves into `hasEntitledOwner`, keyed on anything object-like rather
than on `Element`. Reopening clears the clock, so the second close starts over.

Because the function no longer touches the DOM, the close/reopen/close sequence is a
unit test instead of something only a device can exercise — which matters in this repo,
where the test environment has no DOM.

## Checks

`npm run check`, `npm test` and `npm run lint` all pass (0 errors; the lint warnings
are pre-existing and repo-wide, none in the touched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved overlay handling during closing transitions to keep scroll locking active when another eligible overlay remains open or within its grace period.
  - Correctly resets closing-state timing when overlays reopen, preventing stale state from affecting subsequent interactions.
- **Tests**
  - Added coverage for open overlays, empty states, grace-period expiry, reopening behavior, and multiple simultaneously closing overlays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->